### PR TITLE
Remove envsetup and change instructions in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -18,10 +18,11 @@ mkdir -p tmp
 
 cat <<EOF
 
-Now just set your environment variables and build:
+For now, we have on architecture:
+export ARCH=amd64
 
-	source envsetup
-	build
+And build:
+./util/build
 
 See \`build -h' for more information on the build tool.
 EOF

--- a/envsetup
+++ b/envsetup
@@ -1,6 +1,0 @@
-echo Starting $SHELL with environment set up as follows:
-echo HARVEY=$(pwd)
-echo ARCH=amd64
-echo PATH=$(pwd)/util:$PATH
-echo CC=gcc
-CC=gcc HARVEY=$(pwd) ARCH=amd64 PATH=$(pwd)/util:$PATH $SHELL


### PR DESCRIPTION
It's a huge problem causer and I think it's why people keep not catching problems
with the build. We're going to move to a world with the new build in which environment
variables get set correctly. For now, let's stop causing trouble for ourselves.

I had a day of false positives with harvey builds because of this damned script. envsetup makes it way too easy
to move to a new tree, forget you have the wrong variables set, and be building in your old tree. It's horrible.

Change-Id: I644d6772f0923006798a51f007283f2eda0b286a
Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>