### PR TITLE
Remove the probe for ISA cards.

### DIFF
--- a/sys/src/9/386/devether.c
+++ b/sys/src/9/386/devether.c
@@ -449,12 +449,6 @@ etherreset(void)
 	Ether *ether;
 	int cardno, ctlrno;
 
-	for(ctlrno = 0; ctlrno < MaxEther; ctlrno++){
-		if((ether = etherprobe(-1, ctlrno)) == nil)
-			continue;
-		etherxx[ctlrno] = ether;
-	}
-
 	cardno = ctlrno = 0;
 	while(cards[cardno].type != nil && ctlrno < MaxEther){
 		if(etherxx[ctlrno] != nil){


### PR DESCRIPTION
The index -1 was supposed to key a search or ISA cards. ISA is dead. I removed the
code but missed the probe of -1. Nothing broke.

This panic was not found until we started building with clang and the kernel
panic'ed. We ran for a year with this bug.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>