### PR TITLE
clang: add sys/src/9/amd64/clang.json

### DIFF
--- a/sys/src/9/amd64/clang.json
+++ b/sys/src/9/amd64/clang.json
@@ -1,0 +1,133 @@
+{
+	"cpu": {
+		"CFlags": [
+			"-mno-implicit-float"
+		],
+		"Env": [
+			"CONF=cpu"
+		],
+		"Include": [
+			"core.json",
+			"../386/386.json",
+			"../ip/ip.json",
+			"../port/port.json"
+		],
+		"Kernel": {
+			"Config": {
+				"Code": [
+					"int cpuserver = 1;",
+					"uint32_t kerndate = 1;"
+				],
+				"Dev": [
+					"acpi",
+					"arch",
+					"cap",
+					"cons",
+					"coreboot",
+					"draw",
+					"dup",
+					"env",
+					"fdmux",
+					"ether",
+					"ip",
+					"kbin",
+					"kprof",
+					"mnt",
+					"mntn",
+					"mouse",
+					"pci",
+					"pipe",
+					"proc",
+					"regress",
+					"root",
+					"rtc",
+					"sd",
+					"segment",
+					"srv",
+					"ssl",
+					"tls",
+					"uart",
+					"ws",
+					"usb",
+					"vga"
+				],
+				"Ip": [
+					"tcp",
+					"udp",
+					"ipifc",
+					"icmp",
+					"icmp6",
+					"gre"
+				],
+				"Link": [
+					"ether8169",
+					"ether82557",
+					"ether82563",
+					"etherigbe",
+					"ether8139",
+					"ethermedium",
+					"loopbackmedium",
+					"netdevmedium",
+					"usbuhci",
+					"usbohci",
+					"usbehci"
+				],
+				"Sd": [
+					"sdiahci"
+				],
+				"Uart": [
+					"i8250",
+					"pci"
+				],
+				"VGA": [
+					"vgavesa"
+				]
+			},
+			"Ramfiles": {
+				"bind": "/$ARCH/bin/bind",
+				"boot": "/sys/src/9/boot/bootcpu.elf.out",
+				"cat": "/$ARCH/bin/cat",
+				"date": "/$ARCH/bin/date",
+				"echo": "/$ARCH/bin/echo",
+				"factotum": "/$ARCH/bin/auth/factotum",
+				"fdisk": "/$ARCH/bin/disk/fdisk",
+				"fossil": "/$ARCH/bin/fossil/fossil",
+				"ipconfig": "/$ARCH/bin/ip/ipconfig",
+				"ls": "/$ARCH/bin/ls",
+				"mount": "/$ARCH/bin/mount",
+				"nvram": "/util/nvram",
+				"prep": "/$ARCH/bin/disk/prep",
+				"rc": "/$ARCH/bin/rc",
+				"ps": "/$ARCH/bin/ps",
+				"ed": "/$ARCH/bin/ed",
+				"rcmain": "/rc/lib/rcmain",
+				"screenconsole": "/$ARCH/bin/aux/screenconsole",
+				"realemu": "/$ARCH/bin/aux/realemu",
+				"vga": "/$ARCH/bin/aux/vga",
+				"srv": "/$ARCH/bin/srv",
+				"startdisk": "startdisk",
+				"usbd": "/$ARCH/bin/usb/usbd",
+				"venti": "/$ARCH/bin/venti/venti"
+			},
+			"Systab": "/sys/src/libc/9syscall/sys.h"
+		},
+		"Program": "harvey",
+		"SourceFiles": [
+			"cga.c",
+			"devacpi.c",
+			"devusb.c",
+			"devvga.c",
+			"ether8139.c",
+			"ether82563.c",
+			"cpu.c",
+			"mouse.c",
+			"screen.c",
+			"sdata.c",
+			"usbehcipc.c",
+			"usbohci.c",
+			"usbuhci.c",
+			"vga.c",
+			"vgax.c"
+		]
+	}
+}


### PR DESCRIPTION
Until we figure out how to special-case flags for compilers (or we get that in the new build tool)
just use this file for building the kernel. We don't want xmm usage in the kernel for now.

To use
CC=clang build sys/src/9/amd64/clang.json

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>