### PR TITLE
Fix an error resulting from the deanon work.

### DIFF
--- a/sys/src/9/port/page.c
+++ b/sys/src/9/port/page.c
@@ -354,7 +354,7 @@ putpage(Page *p)
 		else
 			pagechainhead(p);
 	}
-	if(&pga.rend.l != nil)
+	if(pga.rend.l.p != nil)
 		wakeup(&pga.rend);
 	unlock(&p->l);
 	if(rlse)


### PR DESCRIPTION
The expression could never be nil. The original was testing against
the value of p in the lock, i.e. whether another process wanted to use
the pool and we got there first.

This is pretty amazing stuff, in that it works at all, but the use of anon
struct members made it even more confusing. Overall, I think they're a bad deal.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>