### PR TITLE
ratrace: add a -o switch

### DIFF
--- a/sys/man/1/ratrace
+++ b/sys/man/1/ratrace
@@ -4,6 +4,8 @@ ratrace \- trace process system calls
 .SH SYNOPSIS
 .B ratrace
 [
+.I -o outputfile
+] | [
 .I pid
 ] | [
 .I -c command


### PR DESCRIPTION
While debugging the gdbserver it became essential to have a -o switch.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>