### PR TITLE
clang: force no implicit float in user mode for now

### DIFF
--- a/amd64/include/cflags.json
+++ b/amd64/include/cflags.json
@@ -1,5 +1,10 @@
 {
 	"buildflags": {
+		"ToolOpts": {
+			"/usr/bin/clang": [
+				"-mno-implicit-float"
+			]
+		},
 		"Cflags": [
 			"-ffreestanding",
 			"-fno-builtin",


### PR DESCRIPTION
Until we move the Harvey's Plan 9-based floating point save/restore code from 1991 to 2016,
we have to disallow implicit floating point, because otherwise clang generates
code that uses xmm registers, some of it in note handlers, and the kernel will
kill the process. This was causing bad trouble for usbd among other things.

The fix is to do what we did in Akaros:
- disable any use of the x87
- move to xsaveopt and eager save/restore

But for now, this fixes the problem, at a cost in performance.
usbd no longer explodes in the timeout handler (which is a note handler).

Some amount of study of what we did in Akaros will show the way.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>