### PR TITLE
Fix the clean rule

### DIFF
--- a/clean.json
+++ b/clean.json
@@ -2,7 +2,8 @@
 	"amd64cpu": {
 		"Projects": ["/sys/src/9/amd64/clean.json"],
 	"Pre": [
-		"rm -f $ARCH/lib/*.a"
+		"rm -rf $ARCH/lib/*.a $ARCH/bin/*",
+		"git checkout $ARCH/bin"
 	]
 	}
 	


### PR DESCRIPTION
It now blows away $ARCH/bin without thinking hard (because, stupidly, amd64/bin includes
some rc scripts, i.e. not binaries -- wtf?) and all the .a's in lib. Then, to undo
any possible damage, it does a checkout of $ARCH/bin

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>