### PR TITLE
Remove acid from the build.

### DIFF
--- a/sys/src/cmd/build.json
+++ b/sys/src/cmd/build.json
@@ -143,7 +143,6 @@
 		],
 		"Projects": [
 			"9660srv/9660srv.json",
-			"acid/acid.json",
 			"astro/astro.json",
 			"auth/auth.json",
 			"aux/aux.json",


### PR DESCRIPTION
Acid was mistakenly added to the build even thought it still requires plan 9
extensions. This broke clang building.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>