### PR TITLE
build: make it emacs friendly by showing directories

### DIFF
--- a/util/src/harvey/cmd/build/build.go
+++ b/util/src/harvey/cmd/build/build.go
@@ -437,16 +437,25 @@ func projects(b *build, r []*regexp.Regexp) {
 	}
 }
 
+func dirPop(s string) {
+	fmt.Printf("Leaving directory `%v'\n", s)
+	failOn(os.Chdir(s))
+}
+
+func dirPush(s string) {
+	fmt.Printf("Entering directory `%v'\n", s)
+	failOn(os.Chdir(s))
+}
 // assumes we are in the wd of the project.
 func project(bf string, which []*regexp.Regexp) {
 	cwd, err := os.Getwd()
 	failOn(err)
 	debug("Start new project cwd is %v", cwd)
-	defer os.Chdir(cwd)
+	defer dirPop(cwd)
 	dir := path.Dir(bf)
 	root := path.Base(bf)
 	debug("CD to %v and build using %v", dir, root)
-	failOn(os.Chdir(dir))
+	dirPush(dir)
 	builds := process(root, which)
 	debug("Processing %v: %d target", root, len(builds))
 	for _, b := range builds {


### PR DESCRIPTION
This was so simple I don't know why I did not do it long ago.

Now if you goto error emacs will find it, as build outputs entering and leaving
directory info.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>