### PR TITLE
Pcivirtio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ cfg/pxe/tftpboot
 usr/harvey/tmp
 
 build_out
+
+cron/lock

--- a/rc/bin/pci
+++ b/rc/bin/pci
@@ -88,7 +88,7 @@ builtin cd '#$/pci' && grep . *ctl | {
 		sed /:06/d
 	if not
 		cat
-	} | tee /tmp/aaa |
+	} |
 	sed '
 	s/ctl:/:	/
 	t noop

--- a/rc/bin/pci
+++ b/rc/bin/pci
@@ -69,23 +69,44 @@ while (~ $done 0 && ! ~ $#* 0 && ~ $1 -*) {
 if (! ~ $#* 0)
 	usage $0
 
+# DMG 06/02/2016 Make pci(8) recognize virtio devices
+# source: http://git.qemu.org/?p=qemu.git;a=blob;f=include/hw/pci/pci.h
+# devices with vendor code 0x1af4 are QEMU own virtio devices.
+# useful device codes below:
+# 0x1000: virtio network card
+# 0x1001: virtio block device
+# 0x1002: virtio balloon
+# 0x1003: virtio console
+# 0x1004: virtio SCSI
+# 0x1005: virtio RNG (random numbers generator)
+# 0x1009: virtio 9P transport
+# based on this information, the translation table below is amended
+# to show these devices in the pci (8) output.
+
 builtin cd '#$/pci' && grep . *ctl | {
 	if (~ $bridges no)
 		sed /:06/d
 	if not
 		cat
-	} |
+	} | tee /tmp/aaa |
 	sed '
 	s/ctl:/:	/
 	t noop
 : noop
-	s/:	01/:	disk 01/
-	s/:	02/:	net  02/
-	s/:	03/:	vid  03/
-	s/:	04/:	aud  04/
-	s/:	05/:	mem  05/
-	s/:	06/:	brg  06/
-	s/:	07/:	ser  07/
+	s/:	(02\..*\ 1af4\/1000)/:	virtio-net     \1/
+	s/:	(01\..*\ 1af4\/1001)/:	virtio-disk    \1/
+	s/:	(00\..*\ 1af4\/1002)/:	virtio-balloon \1/
+	s/:	(07\..*\ 1af4\/1003)/:	virtio-console \1/
+	s/:	(01\..*\ 1af4\/1004)/:	virtio-scsi    \1/
+	s/:	(00\..*\ 1af4\/1005)/:	virtio-rng     \1/
+	s/:	(00\..*\ 1af4\/1009)/:	virtio-9p      \1/
+	s/:	01/:	disk  01/
+	s/:	02/:	net   02/
+	s/:	03/:	vid   03/
+	s/:	04/:	aud   04/
+	s/:	05/:	mem   05/
+	s/:	06/:	brg   06/
+	s/:	07/:	ser   07/
 	s/:	0c\.03/:	usb  0c.03/
 	s/:	0c\.05/:	smb  0c.05/
 	s/:	0d/:	rad  0d/


### PR DESCRIPTION
This patch hardcodes into the rc/bin/pci script the vendor/device IDs defined in the proper header file of the QEMU source tree for the virtio devices.

Testing:

For the following QEMU command line options (not aiming to define functional devices, just to create something that pci can see; hash-numbers identify command line options to be referred from pci output):

-fsdev local,path=/tmp,id=fstmp,security_model=none \ # 1
-device virtio-9p-pci,fsdev=fstmp,mount_tag=hosttmp \ # 2
-drive file=...,if=virtio \ # 3
-device virtio-serial-pci \ # 4
-device virtio-scsi-pci \ # 5
-drive file=...,id=xyz,if=none \ # 6
-device virtio-blk-pci,drive=xyz \ # 6
-device virtio-rng-pci \ # 7
-net nic,model=virtio \ # 8
-balloon virtio \ # 9

pci outputs (numbers in brackets mine, to reference the QEMU option lines):

0.0.0:  brg   06.00.00 8086/1237   0
0.1.0:  brg   06.01.00 8086/7000   0
0.1.1:  disk  01.01.80 8086/7010   0 4:0000c2a1 16
0.1.3:  brg   06.80.00 8086/7113   9
0.10.0: virtio-balloon 00.ff.00 1af4/1002  10     [9]
0.11.0: virtio-disk    01.00.00 1af4/1001  11 0:0000c1c1 64 1:fc098000 4096     [3 or 6]
0.2.0:  vid   03.00.00 1b36/0100  10 0:f4000000 67108864 1:f8000000 67108864 2:fc090000 81
0.3.0:  net   02.00.00 10ec/8139  11 0:0000c001 256 1:fc092000 256
0.4.0:  virtio-net     02.00.00 1af4/1000  11 0:0000c221 32 1:fc093000 4096       [8]
0.5.0:  virtio-9p      00.02.00 1af4/1009  10      [1]
0.6.0:  virtio-console 07.80.00 1af4/1003  10 0:0000c241 32 1:fc095000 4096      [4]
0.7.0:  virtio-scsi    01.00.00 1af4/1004  11 0:0000c141 64 1:fc096000 4096      [5]
0.8.0:  virtio-disk    01.00.00 1af4/1001  11 0:0000c181 64 1:fc097000 4096   [6 or 3]
0.9.0:  virtio-rng     00.ff.00 1af4/1005  10     [7]

Additionally, added cron/lock to .gitignore to get rid of git annoying message about an untracked file.

Thanks.
