### PR TITLE
Start of aarch64 port: Add u.h, ureg.h.

### DIFF
--- a/aarch64/include/u.h
+++ b/aarch64/include/u.h
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the Harvey operating system.  It is subject to the
+ * license terms of the GNU GPL v2 in LICENSE.gpl found in the top-level
+ * directory of this distribution and at http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * No part of Harvey operating system, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.gpl file.
+ */
+
+#define nil ((void *)0)
+
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef signed short int16_t;
+typedef unsigned short uint16_t;
+typedef signed int int32_t;
+typedef unsigned int uint32_t;
+typedef unsigned int uint;
+typedef signed long long int64_t;
+typedef unsigned long long uint64_t;
+typedef uint64_t uintptr;
+typedef uint64_t uintptr_t;
+typedef uint64_t usize;
+typedef uint64_t size_t;
+typedef uint32_t Rune;
+
+typedef union FPdbleword FPdbleword;
+union FPdbleword
+{
+	double x;
+	struct {	// little endian
+		uint32_t lo;
+                uint32_t hi;
+	};
+};
+
+typedef uint64_t jmp_buf[32];
+
+#define JMPBUFDPC       0
+#define JMPBUFSP        30
+#define JMPBUFPC        31
+#define JMPBUFARG1      0
+#define JMPBUFARG2      1
+
+typedef uint32_t	mpdigit;	// for /sys/include/mp.h
+
+typedef __builtin_va_list va_list;
+
+#define va_start(v,l)   __builtin_va_start(v,l)
+#define va_end(v)       __builtin_va_end(v)
+#define va_arg(v,l)     __builtin_va_arg(v,l)
+#define va_copy(v,l)    __builtin_va_copy(v,l)

--- a/aarch64/include/ureg.h
+++ b/aarch64/include/ureg.h
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the Harvey operating system.  It is subject to the
+ * license terms of the GNU GPL v2 in LICENSE.gpl found in the top-level
+ * directory of this distribution and at http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * No part of Harvey operating system, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.gpl file.
+ */
+
+typedef struct Ureg {
+	uint64_t x0;
+	uint64_t x1;
+	uint64_t x2;
+	uint64_t x3;
+	uint64_t x4;
+	uint64_t x5;
+	uint64_t x6;
+	uint64_t x7;
+	uint64_t x8;
+	uint64_t x9;
+	uint64_t x10;
+	uint64_t x11;
+	uint64_t x12;
+	uint64_t x13;
+	uint64_t x14;
+	uint64_t x15;
+	union {
+		uint64_t x16;
+		uint64_t ip0;
+	};
+	union {
+		uint64_t x17;
+		uint64_t ip1;
+	};
+	uint64_t x18;
+	uint64_t x19;
+	uint64_t x20;
+	uint64_t x21;
+	uint64_t x22;
+	uint64_t x23;
+	uint64_t x24;
+	uint64_t x25;
+	uint64_t x26;
+	uint64_t x27;
+	uint64_t x28;
+	union {
+		uint64_t x29;
+		uint64_t fp;
+	};
+	union {
+		uint64_t x30;
+		uint64_t lr;
+	};
+	uint64_t sp;
+	uint64_t type;	// of exception
+	uint64_t psr;
+	uint64_t pc;	// interrupted addr
+} Ureg;


### PR DESCRIPTION
Start of the aarch64 port: add basic types, register
definitions.

Signed-off-by: Dan Cross <cross@gajendra.net>