### PR TITLE
Fixing order of elements for ld

### DIFF
--- a/util/src/harvey/cmd/build/build.go
+++ b/util/src/harvey/cmd/build/build.go
@@ -344,12 +344,12 @@ func link(b *build) {
 			f := path.Base(n)
 			o := f[:len(f)] + ".o"
 			args := []string{"-o", n, o}
+			args = append(args, "-L", fromRoot("/$ARCH/lib"))
+			args = append(args, b.Libs...)
 			args = append(args, b.Oflags...)
 			if toolOpts, ok := b.ToolOpts[tools["ld"]]; ok {
 				args = append(args, toolOpts...)
 			}
-			args = append(args, "-L", fromRoot("/$ARCH/lib"))
-			args = append(args, b.Libs...)
 			run(b, *shellhack, exec.Command(tools["ld"], args...))
 		}
 		return
@@ -359,9 +359,9 @@ func link(b *build) {
 		args = append(args, toolOpts...)
 	}
 	args = append(args, b.ObjectFiles...)
-	args = append(args, b.Oflags...)
 	args = append(args, "-L", fromRoot("/$ARCH/lib"))
 	args = append(args, b.Libs...)
+	args = append(args, b.Oflags...)
 	run(b, *shellhack, exec.Command(tools["ld"], args...))
 }
 


### PR DESCRIPTION
This should fix BSD issues, and it's the right way
to do an static compilation.