### PR TITLE
Bring in the virtqueue definitions from the virtio spec 1.0. Make sure BAR address and size are picked up for virtio-pci devices with ID=0x00 (e. g. virtio-9p).

### DIFF
--- a/sys/src/9/386/pci.c
+++ b/sys/src/9/386/pci.c
@@ -171,6 +171,12 @@ pcilscan(int bno, Pcidev** list)
 				maxfno = Maxfn;
 
 			/*
+			 * DMG 06/08/2016 Some virtio-pci devices (e. g. 9p)
+			 * have ccrb = 0x00, their BARs and sizes also shouldbe
+			 * picked up here.
+			 */
+
+			/*
 			 * If appropriate, read the base address registers
 			 * and work out the sizes.
 			 */
@@ -184,7 +190,6 @@ pcilscan(int bno, Pcidev** list)
 				}
 				break;
 
-			case 0x00:
 			case 0x05:		/* memory controller */
 			case 0x06:		/* bridge device */
 				break;

--- a/sys/src/9/amd64/virtio_ring.h
+++ b/sys/src/9/amd64/virtio_ring.h
@@ -1,0 +1,141 @@
+#ifndef VIRTQUEUE_H
+#define VIRTQUEUE_H
+/*
+*    Virtual I/O Device (VIRTIO) Version 1.0
+*    Committee Specification Draft 02 / Public Review Draft 02
+*    11 March 2014
+*    Copyright (c) OASIS Open 2014. All Rights Reserved.
+*    Source: http://docs.oasis-open.org/virtio/virtio/v1.0/csprd02/listings/
+*/
+/* An interface for efficient virtio implementation.
+ *
+ * This header is BSD licensed so anyone can use the definitions
+ * to implement compatible drivers/servers.
+ *
+ * Portions of this material may also be copyright: 
+ * Copyright 2007, 2009, IBM Corporation
+ * Copyright 2011, Red Hat, Inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of IBM nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL IBM OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/* 
+ * DMG 06/08/2016
+ * To make the compiler happy about types le16, le32 etc.
+ * These typedefs replace inclusion of <stdint.h>
+ * as it conflicts with Plan 9 definitions
+ */
+
+typedef unsigned short le16;
+typedef unsigned int le32;
+typedef unsigned long long le64;
+
+
+/* This marks a buffer as continuing via the next field. */
+#define VIRTQ_DESC_F_NEXT       1
+/* This marks a buffer as write-only (otherwise read-only). */
+#define VIRTQ_DESC_F_WRITE      2
+/* This means the buffer contains a list of buffer descriptors. */
+#define VIRTQ_DESC_F_INDIRECT   4
+
+/* The device uses this in used->flags to advise the driver: don't kick me
+ * when you add a buffer.  It's unreliable, so it's simply an
+ * optimization. */
+#define VIRTQ_USED_F_NO_NOTIFY  1
+/* The driver uses this in avail->flags to advise the device: don't
+ * interrupt me when you consume a buffer.  It's unreliable, so it's
+ * simply an optimization.  */
+#define VIRTQ_AVAIL_F_NO_INTERRUPT      1
+
+/* Support for indirect descriptors */
+#define VIRTIO_F_INDIRECT_DESC    28
+
+/* Support for avail_idx and used_idx fields */
+#define VIRTIO_F_EVENT_IDX        29
+
+/* Arbitrary descriptor layouts. */
+#define VIRTIO_F_ANY_LAYOUT       27
+
+/* Virtqueue descriptors: 16 bytes.
+ * These can chain together via "next". */
+struct virtq_desc {
+        /* Address (guest-physical). */
+        le64 addr;
+        /* Length. */
+        le32 len;
+        /* The flags as indicated above. */
+        le16 flags;
+        /* We chain unused descriptors via this, too */
+        le16 next;
+};
+
+struct virtq_avail {
+        le16 flags;
+        le16 idx;
+        le16 ring[];
+        /* Only if VIRTIO_F_EVENT_IDX: le16 used_event; */
+};
+
+/* le32 is used here for ids for padding reasons. */
+struct virtq_used_elem {
+        /* Index of start of used descriptor chain. */
+        le32 id;
+        /* Total length of the descriptor chain which was written to. */
+        le32 len;
+};
+
+struct virtq_used {
+        le16 flags;
+        le16 idx;
+        struct virtq_used_elem ring[];
+        /* Only if VIRTIO_F_EVENT_IDX: le16 avail_event; */
+};
+
+struct virtq {
+        unsigned int num;
+
+        struct virtq_desc *desc;
+        struct virtq_avail *avail;
+        struct virtq_used *used;
+};
+
+static inline int virtq_need_event(uint16_t event_idx, uint16_t new_idx, uint16_t old_idx)
+{
+         return (uint16_t)(new_idx - event_idx - 1) < (uint16_t)(new_idx - old_idx);
+}
+
+/* Get location of event indices (only with VIRTIO_F_EVENT_IDX) */
+static inline le16 *virtq_used_event(struct virtq *vq)
+{
+        /* For backwards compat, used event index is at *end* of avail ring. */
+        return &vq->avail->ring[vq->num];
+}
+
+static inline le16 *virtq_avail_event(struct virtq *vq)
+{
+        /* For backwards compat, avail event index is at *end* of used ring. */
+        return (le16 *)&vq->used->ring[vq->num];
+}
+#endif /* VIRTQUEUE_H */

--- a/sys/src/9/port/devpci.c
+++ b/sys/src/9/port/devpci.c
@@ -15,6 +15,13 @@
 #include	"io.h"
 #include	"../port/error.h"
 
+/*
+ * DMG 06/08/2016 Include the definitions from virtio spec v1.0
+ * http://docs.oasis-open.org/virtio/virtio/v1.0/csprd02/listings/virtio_ring.h
+ */
+
+#include	"virtio_ring.h"
+
 enum {
 	Qtopdir = 0,
 


### PR DESCRIPTION
Next small step in the virtio adoption. The virtqueue definitions brought in from the virtio spec 1.0 site. The virtio_ring.h file has been #include'd into devpci.h just to make sure it compiles for now. It has been noticed that the when the PCI devices are scanned, devices with ID=0x00 are skipped, so pci(8) does not display BARs and sizes for them. Devices like virtio-9p belong to this category, so now their information is displayed more accurately.

Before this change (pci(8) output from the previous pull request):

0.0.0:  brg   06.00.00 8086/1237   0
0.1.0:  brg   06.01.00 8086/7000   0
0.1.1:  disk  01.01.80 8086/7010   0 4:0000c2a1 16
0.1.3:  brg   06.80.00 8086/7113   9
**0.10.0: virtio-balloon 00.ff.00 1af4/1002  10**
0.11.0: virtio-disk    01.00.00 1af4/1001  11 0:0000c1c1 64 1:fc098000 4096
0.2.0:  vid   03.00.00 1b36/0100  10 0:f4000000 67108864 1:f8000000 67108864 2:fc090000 8192 3:0000c201 32
0.3.0:  net   02.00.00 10ec/8139  11 0:0000c001 256 1:fc092000 256
0.4.0:  virtio-net     02.00.00 1af4/1000  11 0:0000c221 32 1:fc093000 4096
**0.5.0:  virtio-9p      00.02.00 1af4/1009  10**
0.6.0:  virtio-console 07.80.00 1af4/1003  10 0:0000c241 32 1:fc095000 4096
0.7.0:  virtio-scsi    01.00.00 1af4/1004  11 0:0000c141 64 1:fc096000 4096
0.8.0:  virtio-disk    01.00.00 1af4/1001  11 0:0000c181 64 1:fc097000 4096
**0.9.0:  virtio-rng     00.ff.00 1af4/1005  10**

After the change:

0.0.0:  brg   06.00.00 8086/1237   0
0.1.0:  brg   06.01.00 8086/7000   0
0.1.1:  disk  01.01.80 8086/7010   0 4:0000c2a1 16
0.1.3:  brg   06.80.00 8086/7113   9
**0.10.0: virtio-balloon 00.ff.00 1af4/1002  10 0:0000c281 32**
0.11.0: virtio-disk    01.00.00 1af4/1001  11 0:0000c1c1 64 1:fc098000 4096
0.2.0:  vid   03.00.00 1b36/0100  10 0:f4000000 67108864 1:f8000000 67108864 2:fc090000 8192 3:0000c201 32
0.3.0:  net   02.00.00 10ec/8139  11 0:0000c001 256 1:fc092000 256
0.4.0:  virtio-net     02.00.00 1af4/1000  11 0:0000c221 32 1:fc093000 4096
**0.5.0:  virtio-9p      00.02.00 1af4/1009  10 0:0000c101 64 1:fc094000 4096**
0.6.0:  virtio-console 07.80.00 1af4/1003  10 0:0000c241 32 1:fc095000 4096
0.7.0:  virtio-scsi    01.00.00 1af4/1004  11 0:0000c141 64 1:fc096000 4096
0.8.0:  virtio-disk    01.00.00 1af4/1001  11 0:0000c181 64 1:fc097000 4096
**0.9.0:  virtio-rng     00.ff.00 1af4/1005  10 0:0000c261 32**

Next steps in this direction probably should be picking up the capability and virtqueue structures when scanning the PCI bus, and make devpci display them as subdirectories and files. But this involves massive coding and will take time. This patch is simple and may be applied now.

Thanks.