### PR TITLE
amd64/sdata.c: Make buf[] in atadrive() static.

### DIFF
--- a/sys/src/9/amd64/build.json
+++ b/sys/src/9/amd64/build.json
@@ -70,6 +70,7 @@
 					"usbehci"
 				],
 				"Sd": [
+					"sdata",
 					"sdiahci"
 				],
 				"Uart": [

--- a/sys/src/9/amd64/sdata.c
+++ b/sys/src/9/amd64/sdata.c
@@ -643,7 +643,8 @@ atadrive(int cmdport, int ctlport, int dev)
 {
 	Drive *drive;
 	int as, i, pkt;
-	uint8_t buf[512], *p;
+	static uint8_t buf[512];
+	uint8_t *p;
 	uint16_t iconfig, *sp;
 
 	atadebug(0, 0, "identify: port 0x%uX dev 0x%2.2uX\n", cmdport, dev);


### PR DESCRIPTION
The atadrive function was declaring a local 512 byte buf, i.e. a
stack variable. Big arrays like this on kernel stack are almost always
a bad idea. In this case we were getting a page fault on NULL while probing.

I'm pretty sure this function is single threaded, i.e. only one invocation
is ever active at a time. So I just made buf[] static. The sdata panics
promptly ceased.

If you ever want to make this function reentrant you'll need to use malloc to
allocate buf[] and be sure to free it on all the (many) exits.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>