### PR TITLE
Name changes for aarch64.

### DIFF
--- a/sys/src/9/aarch64/BUILDME
+++ b/sys/src/9/aarch64/BUILDME
@@ -1,5 +1,5 @@
 ARCH=aarch64  \
-STRIP=aarch64-linux-gnu-strip \
-CC=aarch64-linux-gnu-gcc \
-LD=aarch64-linux-gnu-ld \
+STRIP=aarch64-none-eabi-strip \
+CC=aarch64-none-eabi-gcc \
+LD=aarch64-none-eabi-ld \
 ../../../../util/build cpu.json

--- a/sys/src/9/port/elf64.c
+++ b/sys/src/9/port/elf64.c
@@ -267,7 +267,7 @@ static struct {
 	int e_machine;
 } elfmachs[] = {
 	{"amd64", EM_X86_64},
-	{"arm64", EM_AARCH64},
+	{"aarch64", EM_AARCH64},
 	{"power64", EM_PPC64},
 };
 


### PR DESCRIPTION
arm64 -> aarch64 in elf64.c, and the toolchain prefix in
BUILDING should be 'aarch64-none-eabi-'.

Signed-off-by: Dan Cross <cross@gajendra.net>