### PR TITLE
Added customisable keymapping to zenith

### DIFF
--- a/sys/src/cmd/zenith/acme.c
+++ b/sys/src/cmd/zenith/acme.c
@@ -68,10 +68,10 @@ threadmain(int argc, char *argv[])
 	int i;
 	char *p, *loadfile;
 	char buf[256];
-	Column *c;
+	char* initscript  = "zenith.init"
+;	Column *c;
 	int ncol;
 	Display *d;
-//
 
 	rfork(RFENVG|RFNAMEG);
 
@@ -106,6 +106,11 @@ threadmain(int argc, char *argv[])
 	case 'l':
 		loadfile = ARGF();
 		if(loadfile == nil)
+			goto Usage;
+		break;
+	case 'i':
+		initscript = ARGF();
+		if(initscript == nil)
 			goto Usage;
 		break;
 	default:
@@ -234,6 +239,8 @@ threadmain(int argc, char *argv[])
 	threadcreate(waitthread, nil, STACK);
 	threadcreate(xfidallocthread, nil, STACK);
 	threadcreate(newwindowthread, nil, STACK);
+	loadinitscript("/bin/zenith.init");
+	loadinitscript(initscript);
 
 	threadnotify(shutdown, 1);
 	recvul(cexit);

--- a/sys/src/cmd/zenith/build.json
+++ b/sys/src/cmd/zenith/build.json
@@ -30,7 +30,8 @@
 			"xfid.c"
 		],
 	        "Post": [
-	                "mkdir -p $HARVEY/mnt/acme"
+	                "mkdir -p $HARVEY/mnt/acme",
+			"cp zenith.init $HARVEY/$ARCH/bin"
 	        ]
 	}
 }

--- a/sys/src/cmd/zenith/cols.c
+++ b/sys/src/cmd/zenith/cols.c
@@ -40,7 +40,7 @@ colinit(Column *c, Rectangle r)
 	r1.min.y = r1.max.y;
 	r1.max.y += Border;
 	draw(screen, r1, display->black, nil, ZP);
-	textinsert(t, 0, L"New Cut Paste Snarf Sort Zerox Delcol ", 38, TRUE);
+	textinsert(t, 0, (Rune*)L"New Cut Paste Snarf Sort Zerox Delcol ", 38, TRUE);
 	textsetselect(t, t->file->Buffer.nc, t->file->Buffer.nc);
 	draw(screen, t->scrollr, colbutton, nil, colbutton->r.min);
 	c->safe = TRUE;

--- a/sys/src/cmd/zenith/dat.h
+++ b/sys/src/cmd/zenith/dat.h
@@ -13,6 +13,7 @@ enum
 	Qacme,
 	Qcons,
 	Qconsctl,
+	Qctl,
 	Qdraw,
 	Qeditout,
 	Qindex,
@@ -200,6 +201,7 @@ struct Text
 	int		ncachealloc;
 	Rune	*cache;
 	int	nofill;
+	int extended;
 };
 
 unsigned int		textbacknl(Text*, unsigned int, unsigned int);

--- a/sys/src/cmd/zenith/ecmd.c
+++ b/sys/src/cmd/zenith/ecmd.c
@@ -362,7 +362,7 @@ f_cmd(Text *t, Cmd *cp)
 
 	if(cp->text == nil){
 		empty.n = 0;
-		empty.r = L"";
+		empty.r = (Rune*)L"";
 		str = &empty;
 	}else
 		str = cp->text;

--- a/sys/src/cmd/zenith/exec.c
+++ b/sys/src/cmd/zenith/exec.c
@@ -71,34 +71,34 @@ struct Exectab
 };
 
 Exectab exectab[] = {
-	{ L"Cut",		cut,		TRUE,	TRUE,	TRUE	},
-	{ L"Del",		del,		FALSE,	FALSE,	XXX		},
-	{ L"Delcol",	delcol,	FALSE,	XXX,		XXX		},
-	{ L"Delete",	del,		FALSE,	TRUE,	XXX		},
-	{ L"Dump",	dump,	FALSE,	TRUE,	XXX		},
-	{ L"Edit",		edit,		FALSE,	XXX,		XXX		},
-	{ L"Exit",		exit,		FALSE,	XXX,		XXX		},
-	{ L"Font",		fontx,	FALSE,	XXX,		XXX		},
-	{ L"Get",		get,		FALSE,	TRUE,	XXX		},
-	{ L"ID",		id,		FALSE,	XXX,		XXX		},
-	{ L"Incl",		incl,		FALSE,	XXX,		XXX		},
-	{ L"Indent",	indent,	FALSE,	XXX,		XXX		},
-	{ L"Kill",		kill,		FALSE,	XXX,		XXX		},
-	{ L"Load",		dump,	FALSE,	FALSE,	XXX		},
-	{ L"Local",		local,	FALSE,	XXX,		XXX		},
-	{ L"Look",		look,		FALSE,	XXX,		XXX		},
-	{ L"New",		new,		FALSE,	XXX,		XXX		},
-	{ L"Newcol",	newcol,	FALSE,	XXX,		XXX		},
-	{ L"Paste",		paste,	TRUE,	TRUE,	XXX		},
-	{ L"Put",		put,		FALSE,	XXX,		XXX		},
-	{ L"Putall",		putall,	FALSE,	XXX,		XXX		},
-	{ L"Redo",		undo,	FALSE,	FALSE,	XXX		},
-	{ L"Send",		sendx,	TRUE,	XXX,		XXX		},
-	{ L"Snarf",		cut,		FALSE,	TRUE,	FALSE	},
-	{ L"Sort",		sort,		FALSE,	XXX,		XXX		},
-	{ L"Tab",		tab,		FALSE,	XXX,		XXX		},
-	{ L"Undo",		undo,	FALSE,	TRUE,	XXX		},
-	{ L"Zerox",	zeroxx,	FALSE,	XXX,		XXX		},
+	{ (Rune *)L"Cut",		cut,		TRUE,	TRUE,	TRUE	},
+	{ (Rune *)L"Del",		del,		FALSE,	FALSE,	XXX		},
+	{ (Rune *)L"Delcol",	delcol,	FALSE,	XXX,		XXX		},
+	{ (Rune *)L"Delete",	del,		FALSE,	TRUE,	XXX		},
+	{ (Rune *)L"Dump",	dump,	FALSE,	TRUE,	XXX		},
+	{ (Rune *)L"Edit",		edit,		FALSE,	XXX,		XXX		},
+	{ (Rune *)L"Exit",		exit,		FALSE,	XXX,		XXX		},
+	{ (Rune *)L"Font",		fontx,	FALSE,	XXX,		XXX		},
+	{ (Rune *)L"Get",		get,		FALSE,	TRUE,	XXX		},
+	{ (Rune *)L"ID",		id,		FALSE,	XXX,		XXX		},
+	{ (Rune *)L"Incl",		incl,		FALSE,	XXX,		XXX		},
+	{ (Rune *)L"Indent",	indent,	FALSE,	XXX,		XXX		},
+	{ (Rune *)L"Kill",		kill,		FALSE,	XXX,		XXX		},
+	{ (Rune *)L"Load",		dump,	FALSE,	FALSE,	XXX		},
+	{ (Rune *)L"Local",		local,	FALSE,	XXX,		XXX		},
+	{ (Rune *)L"Look",		look,		FALSE,	XXX,		XXX		},
+	{ (Rune *)L"New",		new,		FALSE,	XXX,		XXX		},
+	{ (Rune *)L"Newcol",	newcol,	FALSE,	XXX,		XXX		},
+	{ (Rune *)L"Paste",		paste,	TRUE,	TRUE,	XXX		},
+	{ (Rune *)L"Put",		put,		FALSE,	XXX,		XXX		},
+	{ (Rune *)L"Putall",		putall,	FALSE,	XXX,		XXX		},
+	{ (Rune *)L"Redo",		undo,	FALSE,	FALSE,	XXX		},
+	{ (Rune *)L"Send",		sendx,	TRUE,	XXX,		XXX		},
+	{ (Rune *)L"Snarf",		cut,		FALSE,	TRUE,	FALSE	},
+	{ (Rune *)L"Sort",		sort,		FALSE,	XXX,		XXX		},
+	{ (Rune *)L"Tab",		tab,		FALSE,	XXX,		XXX		},
+	{ (Rune *)L"Undo",		undo,	FALSE,	TRUE,	XXX		},
+	{ (Rune *)L"Zerox",	zeroxx,	FALSE,	XXX,		XXX		},
 	{ nil, 			nil,		0,		0,		0		},
 };
 
@@ -873,7 +873,7 @@ sendx(Text *et, Text *t, Text*a, int b, int c, Rune*d, int f)
 	textsetselect(t, t->file->Buffer.nc, t->file->Buffer.nc);
 	paste(t, t, nil, TRUE, TRUE, nil, 0);
 	if(textreadc(t, t->file->Buffer.nc-1) != '\n'){
-		textinsert(t, t->file->Buffer.nc, L"\n", 1, TRUE);
+		textinsert(t, t->file->Buffer.nc, (Rune *)L"\n", 1, TRUE);
 		textsetselect(t, t->file->Buffer.nc, t->file->Buffer.nc);
 	}
 }
@@ -1004,7 +1004,7 @@ fontx(Text *et, Text *t, Text *argt, int ia, int b, Rune *arg, int narg)
 			break;
 		r = runemalloc(narg-na+1);
 		runemove(r, arg, narg-na);
-		if(runeeq(r, narg-na, L"fix", 3) || runeeq(r, narg-na, L"var", 3)){
+		if(runeeq(r, narg-na, (Rune *)L"fix", 3) || runeeq(r, narg-na, (Rune *)L"var", 3)){
 			free(flag);
 			flag = r;
 		}else{
@@ -1016,7 +1016,7 @@ fontx(Text *et, Text *t, Text *argt, int ia, int b, Rune *arg, int narg)
 	}
 	getarg(argt, FALSE, TRUE, &r, &na);
 	if(r)
-		if(runeeq(r, na, L"fix", 3) || runeeq(r, na, L"var", 3)){
+		if(runeeq(r, na, (Rune *)L"fix", 3) || runeeq(r, na, (Rune *)L"var", 3)){
 			free(flag);
 			flag = r;
 		}else{
@@ -1026,7 +1026,7 @@ fontx(Text *et, Text *t, Text *argt, int ia, int b, Rune *arg, int narg)
 		}
 	fix = 1;
 	if(flag)
-		fix = runeeq(flag, runestrlen(flag), L"fix", 3);
+		fix = runeeq(flag, runestrlen(flag), (Rune *)L"fix", 3);
 	else if(file == nil){
 		newfont = rfget(FALSE, FALSE, FALSE, nil);
 		if(newfont)
@@ -1106,17 +1106,17 @@ indentval(Rune *s, int n)
 {
 	if(n < 2)
 		return IError;
-	if(runestrncmp(s, L"ON", n) == 0){
+	if(runestrncmp(s, (Rune *)L"ON", n) == 0){
 		globalautoindent = TRUE;
 		warning(nil, "Indent ON\n");
 		return IGlobal;
 	}
-	if(runestrncmp(s, L"OFF", n) == 0){
+	if(runestrncmp(s, (Rune *)L"OFF", n) == 0){
 		globalautoindent = FALSE;
 		warning(nil, "Indent OFF\n");
 		return IGlobal;
 	}
-	return runestrncmp(s, L"on", n) == 0;
+	return runestrncmp(s, (Rune *)L"on", n) == 0;
 }
 
 static void
@@ -1190,16 +1190,16 @@ void
 runproc(void *argvp)
 {
 	/* args: */
-		Window *win;
-		char *s;
-		Rune *rdir;
-		int ndir;
-		int newns;
-		char *argaddr;
-		char *arg;
-		Command *c;
-		Channel *cpid;
-		int iseditcmd;
+	Window *win;
+	char *s;
+	Rune *rdir;
+	int ndir;
+	int newns;
+	char *argaddr;
+	char *arg;
+	Command *c;
+	Channel *cpid;
+	int iseditcmd;
 	/* end of args */
 	char *e, *t, *name, *filename, *dir, **av, *news;
 	Rune r, **incl;

--- a/sys/src/cmd/zenith/fns.h
+++ b/sys/src/cmd/zenith/fns.h
@@ -74,7 +74,7 @@ Window*	lookfile(Rune*, int);
 Window*	lookid(int, int);
 char*	runetobyte(Rune*, int);
 Rune*	bytetorune(char*, int*);
-void	fsysinit(void);
+void	fsysinit();
 Mntdir*	fsysmount(Rune*, int, Rune**, int);
 void		fsysincid(Mntdir*);
 void		fsysdelid(Mntdir*);
@@ -96,6 +96,9 @@ Rune*	skipbl(Rune*, int, int*);
 Rune*	findbl(Rune*, int, int*);
 char*	edittext(Window*, int, Rune*, int);
 void		flushwarnings(void);
+void	loadinitscript(const char* initscript);
+int	keymap(char* key, char* mapping);
+int	extendedkeymap(char* key, char* mapping);
 
 #define	runemalloc(a)		(Rune*)emalloc((a)*sizeof(Rune))
 #define	runerealloc(a, b)	(Rune*)erealloc((a), (b)*sizeof(Rune))

--- a/sys/src/cmd/zenith/fsys.c
+++ b/sys/src/cmd/zenith/fsys.c
@@ -73,9 +73,10 @@ Dirtab dirtab[]=
 	{ ".",			QTDIR,	Qdir,		0500|DMDIR },
 	{ "acme",		QTDIR,	Qacme,	0500|DMDIR },
 	{ "cons",		QTFILE,	Qcons,	0600 },
-	{ "consctl",	QTFILE,	Qconsctl,	0000 },
+	{ "consctl",		QTFILE,	Qconsctl,	0000 },
+	{ "ctl",		QTFILE,	Qctl,	0600 },
 	{ "draw",		QTDIR,	Qdraw,	0000|DMDIR },	/* to suppress graphics progs started in acme */
-	{ "editout",	QTFILE,	Qeditout,	0200 },
+	{ "editout",		QTFILE,	Qeditout,	0200 },
 	{ "index",		QTFILE,	Qindex,	0400 },
 	{ "label",		QTFILE,	Qlabel,	0600 },
 	{ "new",		QTDIR,	Qnew,	0500|DMDIR },
@@ -89,7 +90,7 @@ Dirtab dirtabw[]=
 	{ "body",		QTAPPEND,	QWbody,		0600|DMAPPEND },
 	{ "ctl",		QTFILE,		QWctl,		0600 },
 	{ "data",		QTFILE,		QWdata,		0600 },
-	{ "editout",	QTFILE,		QWeditout,	0200 },
+	{ "editout",		QTFILE,		QWeditout,	0200 },
 	{ "errors",		QTFILE,		QWerrors,		0200 },
 	{ "event",		QTFILE,		QWevent,		0600 },
 	{ "rdsel",		QTFILE,		QWrdsel,		0400 },
@@ -121,7 +122,7 @@ int	messagesize = Maxblock+IOHDRSZ;	/* good start */
 void	fsysproc(void *);
 
 void
-fsysinit(void)
+fsysinit()
 {
 	int p[2];
 	int n, fd;

--- a/sys/src/cmd/zenith/look.c
+++ b/sys/src/cmd/zenith/look.c
@@ -323,7 +323,7 @@ isfilec(Rune r)
 {
 	if(isalnum(r))
 		return TRUE;
-	if(runestrchr(L".-+/:", r))
+	if(runestrchr((Rune *)L".-+/:", r))
 		return TRUE;
 	return FALSE;
 }
@@ -392,7 +392,7 @@ includename(Text *t, Rune *r, int n)
 		file = includefile(w->incl[i], r, n);
 
 	if(file.r == nil)
-		file = includefile(L"/sys/include", r, n);
+		file = includefile((Rune *)L"/sys/include", r, n);
 	if(file.r==nil && objdir!=nil)
 		file = includefile(objdir, r, n);
 	if(file.r == nil)

--- a/sys/src/cmd/zenith/rows.c
+++ b/sys/src/cmd/zenith/rows.c
@@ -42,7 +42,7 @@ rowinit(Row *row, Rectangle r)
 	r1.min.y = r1.max.y;
 	r1.max.y += Border;
 	draw(screen, r1, display->black, nil, ZP);
-	textinsert(t, 0, L"Newcol Kill Putall Dump Exit ", 29, TRUE);
+	textinsert(t, 0, (Rune *)L"Newcol Kill Putall Dump Exit ", 29, TRUE);
 	textsetselect(t, t->file->Buffer.nc, t->file->Buffer.nc);
 }
 

--- a/sys/src/cmd/zenith/util.c
+++ b/sys/src/cmd/zenith/util.c
@@ -59,7 +59,7 @@ cvttorunes(char *p, int n, Rune *r, int *nb, int *nr, int *nulls)
 void
 error(char *s)
 {
-	fprint(2, "acme: %s: %r\n", s);
+	fprint(2, "acme: %s(%x <- %x): %r\n", s,  __builtin_return_address(1),  __builtin_return_address(2));
 	remove(acmeerrorfile);
 	abort();
 }

--- a/sys/src/cmd/zenith/wind.c
+++ b/sys/src/cmd/zenith/wind.c
@@ -297,9 +297,9 @@ winsetname(Window *w, Rune *name, int n)
 	if(runeeq(t->file->name, t->file->nname, name, n) == TRUE)
 		return;
 	w->isscratch = FALSE;
-	if(n>=6 && runeeq(L"/guide", 6, name+(n-6), 6))
+	if(n>=6 && runeeq((Rune *)L"/guide", 6, name+(n-6), 6))
 		w->isscratch = TRUE;
-	else if(n>=7 && runeeq(L"+Errors", 7, name+(n-7), 7))
+	else if(n>=7 && runeeq((Rune *)L"+Errors", 7, name+(n-7), 7))
 		w->isscratch = TRUE;
 	filesetname(t->file, name, n);
 	for(i=0; i<t->file->ntext; i++){

--- a/sys/src/cmd/zenith/zenith.init
+++ b/sys/src/cmd/zenith/zenith.init
@@ -1,0 +1,35 @@
+#!/bin/rc
+# Default zenith key mappings (with ctrl key)
+#
+echo keymap a start_of_line >/mnt/acme/ctl
+echo keymap w delete_word_before_cursor >/mnt/acme/ctl
+echo keymap u delete_to_start_of_line >/mnt/acme/ctl
+echo keymap h backspace >/mnt/acme/ctl
+echo keymap e end_of_line >/mnt/acme/ctl
+echo keymap left left >/mnt/acme/ctl
+echo keymap right right >/mnt/acme/ctl
+echo keymap down down >/mnt/acme/ctl
+echo keymap up up >/mnt/acme/ctl
+echo keymap pgup pgup >/mnt/acme/ctl
+echo keymap pgdown pgdown >/mnt/acme/ctl
+echo keymap home home >/mnt/acme/ctl
+echo keymap end end >/mnt/acme/ctl
+echo keymap ins ins >/mnt/acme/ctl
+echo keymap esc select >/mnt/acme/ctl
+echo keymap nl nl >/mnt/acme/ctl
+echo keymap wheelup wheelup >/mnt/acme/ctl
+echo keymap wheeldown wheeldown >/mnt/acme/ctl
+
+# Define extended key as ^s
+echo keymap s extend >/mnt/acme/ctl
+
+#
+# Extended key mappings (press ^s first)
+#
+echo extendedkeymap x execute_line >/mnt/acme/ctl
+echo extendedkeymap f /bin/fortune >/mnt/acme/ctl
+echo extendedkeymap l ls -l >/mnt/acme/ctl
+
+# Can cancel extended mode by pressing ^s
+echo extendedkeymap s extend >/mnt/acme/ctl
+

--- a/sys/src/libc/port/malloc.c
+++ b/sys/src/libc/port/malloc.c
@@ -170,7 +170,14 @@ ppanic(Pool *p, char *fmt, ...)
 		write(pv->printfd, "\n", 1);
 	}
 	va_end(v);
-//	unlock(&pv->lk);
+	n = seprint(msg, msg+sizeof(panicbuf), "stack: %x, %x, %x %x, %x, %x\n",
+	    __builtin_return_address(1), __builtin_return_address(2), __builtin_return_address(3),
+	    __builtin_return_address(4), __builtin_return_address(5), __builtin_return_address(6)
+	    ) - msg;
+	write(2, msg, n);
+	if(pv->printfd != 2){
+	    write(pv->printfd, msg, n);
+	}
 	abort();
 }
 

--- a/usr/harvey/lib/zenith.init
+++ b/usr/harvey/lib/zenith.init
@@ -1,0 +1,30 @@
+#!/bin/rc
+# Zenith key mappings (with ctrl key)
+echo keymap a start_of_line >/mnt/acme/ctl
+echo keymap w delete_word_before_cursor >/mnt/acme/ctl
+echo keymap u delete_to_start_of_line >/mnt/acme/ctl
+echo keymap h backspace >/mnt/acme/ctl
+echo keymap e end_of_line >/mnt/acme/ctl
+echo keymap left left >/mnt/acme/ctl
+echo keymap right right >/mnt/acme/ctl
+echo keymap down down >/mnt/acme/ctl
+echo keymap up up >/mnt/acme/ctl
+echo keymap pgup pgup >/mnt/acme/ctl
+echo keymap pgdown pgdown >/mnt/acme/ctl
+echo keymap home home >/mnt/acme/ctl
+echo keymap end end >/mnt/acme/ctl
+echo keymap ins ins >/mnt/acme/ctl
+echo keymap esc select >/mnt/acme/ctl
+echo keymap nl nl >/mnt/acme/ctl
+echo keymap s extend >/mnt/acme/ctl
+
+#
+# Extended key mappings (press ^s first)
+#
+echo extendedkeymap x execute_line >/mnt/acme/ctl
+echo extendedkeymap f /bin/fortune >/mnt/acme/ctl
+echo extendedkeymap l ls -l >/mnt/acme/ctl
+
+# Can cancel extended mode by pressing ^s
+echo extendedkeymap s extend >/mnt/acme/ctl
+


### PR DESCRIPTION
See zenith.init for details - apart from the existing keyboard shortcuts, I've added:

^s^x to execute the current line
^s^f to display a fortune (just to test the external command keymapping)
^s^l to run ls -l in the current directory.

There's a minor bug with up/down keys going over a blank line, but I wanted to get this change in before I looked at it.