### PR TITLE
Panic if there is no MP table

### DIFF
--- a/sys/src/9/amd64/mp.c
+++ b/sys/src/9/amd64/mp.c
@@ -419,8 +419,9 @@ mpsinit(int maxcores)
 	_MP_ *mp;
 	PCMP *pcmp;
 
-	if((mp = sigsearch("_MP_")) == nil)
-		return;
+	if((mp = sigsearch("_MP_")) == nil) {
+		panic("NO _MP_ table");
+	}
 	if(DBGFLG){
 		DBG("_MP_ @ %#p, addr %#ux length %ud rev %d",
 			mp, l32get(mp->addr), mp->length, mp->revision);


### PR DESCRIPTION
The code assumes, from the earliest stages, that apicbase
has been set. Right now, it's only set in the mp table parser.

The result is that there are obscure failures if no _MP_ is found.

We need to drag this code base into the third millenium but at least
for now make an error that is useful, instead of just a panic on
referencing address 0x20.

THINK CAREFULLY BEFORE YOU LGTM THIS ONE.

But it at least gives me a comprehensible error on coreboot on the thinkpad.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>