### PR TITLE
Gather PCI capabilities for each device during the PCI bus scan, make them part of the device structure. Visualize PCI capabilities via devpci generated directory as additional file entries.

### DIFF
--- a/rc/bin/pci
+++ b/rc/bin/pci
@@ -107,10 +107,10 @@ builtin cd '#$/pci' && grep . *ctl | {
 	s/:	05/:	mem   05/
 	s/:	06/:	brg   06/
 	s/:	07/:	ser   07/
-	s/:	0c\.03/:	usb  0c.03/
-	s/:	0c\.05/:	smb  0c.05/
-	s/:	0d/:	rad  0d/
-	s/:	10/:	cryp 10/
+	s/:	0c\.03/:	usb   0c.03/
+	s/:	0c\.05/:	smb   0c.05/
+	s/:	0d/:	rad   0d/
+	s/:	10/:	cryp  10/
 	t
 	s/	/	---  /
 ' | $filter

--- a/sys/src/9/386/pci.c
+++ b/sys/src/9/386/pci.c
@@ -176,9 +176,8 @@ pcilscan(int bno, Pcidev** list)
 				maxfno = Maxfn;
 
 			/*
-			 * DMG 06/08/2016 Some virtio-pci devices (e. g. 9p)
-			 * have ccrb = 0x00, their BARs and sizes also shouldbe
-			 * picked up here.
+			 * Some virtio-pci devices (e. g. 9p) have ccrb = 0x00, 
+			 * their BARs and sizes also should be picked up here.
 			 */
 
 			/*
@@ -369,14 +368,14 @@ struct Slot {
 
 typedef struct Router Router;
 struct Router {
-	uint8_t	signature[4];		// Routing table signature
+	uint8_t	signature[4];	// Routing table signature
 	uint8_t	version[2];		// Version number
 	uint8_t	size[2];		// Total table size
 	uint8_t	bus;			// Interrupt router bus number
 	uint8_t	devfn;			// Router's devfunc
 	uint8_t	pciirqs[2];		// Exclusive PCI irqs
 	uint8_t	compat[4];		// Compatible PCI interrupt router
-	uint8_t	miniport[4];		// Miniport data
+	uint8_t	miniport[4];	// Miniport data
 	uint8_t	reserved[11];
 	uint8_t	checksum;
 };
@@ -733,12 +732,10 @@ pciclrmwi(Pcidev* p)
 	pcicfgw16(p, PciPCR, p->pcr);
 }
 
-/*
- * DMG 06/11/2016. Move the capability offset finding in a separate function
- * as this code will be common between the pcicap function below and the new
- * function to build the capability descriptor in the memory while scanning
- * the PCI bus.
- */
+// Find the capability offset in a PCI device configuration space.
+// It depends of whether a device is a bridge, or a regular PCI device.
+// Return a positive number (offset) if capabilities are present, or -1
+// if the device does not have capabilities.
 
 int
 pcicapoff(Pcidev *p)
@@ -760,6 +757,10 @@ pcicapoff(Pcidev *p)
 	}
 	return off;
 }
+
+// Obtain the offset to the needed capability (by its cap_vndr value)
+// in the device configuration space. Return a positive number (offset)
+// if the capability exists, or -1 otherwise.
 
 int
 pcicap(Pcidev *p, int cap)

--- a/sys/src/9/386/pci.c
+++ b/sys/src/9/386/pci.c
@@ -19,7 +19,8 @@
 
 #include "io.h"
 
-int pcicapoff(Pcidev *p);
+int
+pcicapoff(Pcidev *p);
 
 enum
 {
@@ -70,7 +71,8 @@ static char* bustypes[] = {
 	"XPRESS",
 };
 
-static	int	pcicfgrw(int, int, int, int, int);
+static int
+pcicfgrw(int, int, int, int, int);
 
 static int
 tbdffmt(Fmt* fmt)

--- a/sys/src/9/amd64/io.h
+++ b/sys/src/9/amd64/io.h
@@ -97,7 +97,7 @@ typedef struct ACVctl {
 } ACVctl;
 
 enum {
-	BusCBUS		= 0,		/* Corollary CBUS */
+	BusCBUS		= 0,	/* Corollary CBUS */
 	BusCBUSII,			/* Corollary CBUS II */
 	BusEISA,			/* Extended ISA */
 	BusFUTURE,			/* IEEE Futurebus */
@@ -166,12 +166,12 @@ enum {
 	Pcibcmem	= 5,		/* memory */
 	Pcibcbridge	= 6,		/* bridge */
 	Pcibccomm	= 7,		/* simple comms (e.g., serial) */
-	Pcibcbasesys	= 8,		/* base system */
+	Pcibcbasesys	= 8,	/* base system */
 	Pcibcinput	= 9,		/* input */
 	Pcibcdock	= 0xa,		/* docking stations */
 	Pcibcproc	= 0xb,		/* processors */
 	Pcibcserial	= 0xc,		/* serial bus (e.g., USB) */
-	Pcibcwireless	= 0xd,		/* wireless */
+	Pcibcwireless	= 0xd,	/* wireless */
 	Pcibcintell	= 0xe,		/* intelligent i/o */
 	Pcibcsatcom	= 0xf,		/* satellite comms */
 	Pcibccrypto	= 0x10,		/* encryption/decryption */
@@ -194,12 +194,12 @@ enum {
 	Pcisc3d		= 2,		/* 3D */
 
 	/* bridges */
-	Pcischostpci	= 0,		/* host/pci */
-	Pciscpcicpci	= 1,		/* pci/pci */
+	Pcischostpci	= 0,	/* host/pci */
+	Pciscpcicpci	= 1,	/* pci/pci */
 
 	/* simple comms */
 	Pciscserial	= 0,		/* 16450, etc. */
-	Pciscmultiser	= 1,		/* multiport serial */
+	Pciscmultiser	= 1,	/* multiport serial */
 
 	/* serial bus */
 	Pciscusb	= 3,		/* USB */
@@ -279,11 +279,10 @@ struct Pcisiz
 	int	bar;
 };
 
-/*
- * DMG 06/11/2016 Add the definitions for generic PCI capability structure
- * based on the VIRTIO spec 1.0. Below is the layout of a capability in the PCI
- * device config space. The structure visible to the kernel repeats this, but
- * adds fields to build the linked list of capabilities per device.
+/* Definitions for generic PCI capability structure based on the
+ * VIRTIO spec 1.0. Below is the layout of a capability in the PCI
+ * device config space. The structure visible to the kernel repeats this,
+ * but adds fields to build the linked list of capabilities per device.
  *
  * struct virtio_pci_cap {
  *   u8 cap_vndr; // Generic PCI field: PCI_CAP_ID_VNDR 
@@ -295,11 +294,8 @@ struct Pcisiz
  *   le32 offset; // Offset within bar. 
  *   le32 length; // Length of the structure, in bytes. 
  * };
- * 
- * Add the linked list of capabilities to the PCI device descriptor structure.
- * 
  */
-
+ 
 enum {
 	PciCapVndr 	= 0x00,
 	PciCapNext 	= 0x01,
@@ -314,7 +310,7 @@ struct Pcidev;
 
 typedef struct Pcicap Pcicap;
 struct Pcicap {
-	struct Pcidev *dev;				/* link to the device structure */
+	struct Pcidev *dev;			/* link to the device structure */
 	Pcicap *link;				/* next capability or NULL */
 	uint8_t vndr;				/* vendor code */
 	uint8_t caplen;				/* length in the config area */
@@ -324,10 +320,16 @@ struct Pcicap {
 	uint32_t length;			/* length in the memory or IO space */
 };
 
+/* Linked list of capabilities is added to the PCI device descriptor
+ * structure. Also, an index array of pointers to the capabilities
+ * descriptiors is added. The index will be used to simplify generation
+ * of the capabilities directory in devpci.c.
+ */
+
 typedef struct Pcidev Pcidev;
 struct Pcidev
 {
-	int	tbdf;			/* type+bus+device+function */
+	int	tbdf;					/* type+bus+device+function */
 	uint16_t	vid;			/* vendor ID */
 	uint16_t	did;			/* device ID */
 
@@ -349,12 +351,12 @@ struct Pcidev
 		uint32_t	bar;
 		int	size;
 	} rom;
-	unsigned char	intl;			/* interrupt line */
+	unsigned char	intl;		/* interrupt line */
 
 	Pcidev*	list;
-	Pcidev*	link;			/* next device on this bno */
+	Pcidev*	link;				/* next device on this bno */
 
-	Pcidev*	bridge;			/* down a bus */
+	Pcidev*	bridge;				/* down a bus */
 	struct {
 		uint32_t	bar;
 		int	size;

--- a/sys/src/9/amd64/virtio_ring.h
+++ b/sys/src/9/amd64/virtio_ring.h
@@ -42,7 +42,6 @@
  */
 
 /* 
- * DMG 06/08/2016
  * To make the compiler happy about types le16, le32 etc.
  * These typedefs replace inclusion of <stdint.h>
  * as it conflicts with Plan 9 definitions

--- a/sys/src/9/port/devpci.c
+++ b/sys/src/9/port/devpci.c
@@ -28,6 +28,7 @@ enum {
 	Qpcidir,
 	Qpcictl,
 	Qpciraw,
+	Qpcicap,
 };
 
 #define TYPE(q)		((uint32_t)(q).path & 0x0F)
@@ -40,9 +41,14 @@ static Dirtab topdir[] = {
 
 extern Dev pcidevtab;
 
+/*
+ * Display device capabilities as a directory, each cap has an entry as a file.
+ */
+
 static int
 pcidirgen(Chan *c, int t, int tbdf, Dir *dp)
 {
+	Pcidev *p;
 	Proc *up = externup();
 	Qid q;
 
@@ -58,9 +64,31 @@ pcidirgen(Chan *c, int t, int tbdf, Dir *dp)
 			BUSBNO(tbdf), BUSDNO(tbdf), BUSFNO(tbdf));
 		devdir(c, q, up->genbuf, 128, eve, 0664, dp);
 		return 1;
+	case Qpcicap:
+		p = pcimatchtbdf(tbdf);
+		if((p == nil) || (p->capcnt == 0))
+			return 0;
+		snprint(up->genbuf, sizeof up->genbuf, "%d.%d.%dcap",
+			BUSBNO(tbdf), BUSDNO(tbdf), BUSFNO(tbdf));
+		q.type = QTDIR;
+		devdir(c, q, up->genbuf, 0, eve, DMDIR|0555, dp);
+		return 1;
 	}
 	return -1;
 }
+
+/*
+ * DMG 06/13/2016. Generate the contents of the capabilities directory
+ * using the capabilities index built at the time of the PCI bus scan.
+ * Each capability is displayed as a file of length equal to the length
+ * of the capability in the memory, and the file name is formatted as
+ * capN.vV.lL.tT.bB.oO where N is capability index as collected during
+ * the PCI bus scan, V is capability vendor code (cap_vndr), L is
+ * capability length in the PCI config space (cap_len), T is capability
+ * config type (cfg_type), B is BAR number, and O is offset within BAR.
+ * The capabilities files cannot be read or written. They are displayed
+ * for exploratory purposes only.
+ */
 
 static int
 pcigen(Chan *c, char *d, Dirtab* dir, int i, int s, Dir *dp)
@@ -87,20 +115,31 @@ pcigen(Chan *c, char *d, Dirtab* dir, int i, int s, Dir *dp)
 			return 1;
 		}
 		p = pcimatch(nil, 0, 0);
-		while(s >= 2 && p != nil) {
+		while(s >= 3 && p != nil) {
 			p = pcimatch(p, 0, 0);
-			s -= 2;
+			s -= 3;
 		}
 		if(p == nil)
 			return -1;
 		return pcidirgen(c, s+Qpcictl, p->tbdf, dp);
+	case Qpcicap:
 	case Qpcictl:
 	case Qpciraw:
 		tbdf = MKBUS(BusPCI, 0, 0, 0)|BUSBDF((uint32_t)c->qid.path);
 		p = pcimatchtbdf(tbdf);
 		if(p == nil)
 			return -1;
-		return pcidirgen(c, TYPE(c->qid), tbdf, dp);
+		if(TYPE(c->qid) == Qpcicap) {
+			if(s >= p->capcnt)
+				return -1;
+			q = (Qid){BUSBDF(tbdf)|(Qpcicap + s + 1), 0, 0};
+			Pcicap *pcp = p->capidx[s];
+			snprint(up->genbuf, sizeof up->genbuf, "cap%d.v%d.l%d.t%d.b%d.o%d", s, pcp->vndr, pcp->caplen, pcp->type, pcp->bar, pcp->offset);
+			devdir(c, q, up->genbuf, pcp->length, eve, 0444, dp);
+			return 1;
+		} else {
+			return pcidirgen(c, TYPE(c->qid), tbdf, dp);
+		}
 	default:
 		break;
 	}
@@ -153,6 +192,7 @@ pciread(Chan *c, void *va, int32_t n, int64_t offset)
 	switch(TYPE(c->qid)){
 	case Qtopdir:
 	case Qpcidir:
+	case Qpcicap:
 		return devdirread(c, a, n, (Dirtab *)0, 0L, pcigen);
 	case Qpcictl:
 		tbdf = MKBUS(BusPCI, 0, 0, 0)|BUSBDF((uint32_t)c->qid.path);


### PR DESCRIPTION
This patch adds collection of PCI capabilities for each device and visualization of them via devpci generated device directory.

Example output from `pci && echo && ls -l /dev/pci/*cap`

0.0.0:	brg   06.00.00 8086/29c0   0
0.1.0:	vid   03.00.00 1b36/0100  10 0:f4000000 67108864 1:f8000000 67108864 2:fc090000 8192 3:0000c241 32
0.10.0:	virtio-disk    01.00.00 1af4/1001  11 0:0000c1c1 64 1:fc098000 4096
0.2.0:	net   02.00.00 10ec/8139  11 0:0000c001 256 1:fc092000 256
0.3.0:	virtio-net     02.00.00 1af4/1000  11 0:0000c261 32 1:fc093000 4096
0.31.0:	brg   06.01.00 8086/2918   0
0.31.2:	disk  01.06.01 8086/2922  10 4:0000c2e1 32 5:fc099000 4096
0.31.3:	smb   0c.05.00 8086/2930  10 4:0000b101 64
0.4.0:	virtio-9p      00.02.00 1af4/1009  10 0:0000c101 64 1:fc094000 4096
0.5.0:	virtio-console 07.80.00 1af4/1003  10 0:0000c281 32 1:fc095000 4096
0.6.0:	virtio-scsi    01.00.00 1af4/1004  11 0:0000c141 64 1:fc096000 4096
0.7.0:	virtio-disk    01.00.00 1af4/1001  11 0:0000c181 64 1:fc097000 4096
0.8.0:	virtio-rng     00.ff.00 1af4/1005  10 0:0000c2a1 32
0.9.0:	virtio-balloon 00.ff.00 1af4/1002  10 0:0000c2c1 32

--r--r--r-- $ 0 harvey harvey 0 Feb  7  2006 /dev/pci/0.10.0cap/cap0.v17.l1.t0.b1.o2049
--r--r--r-- $ 0 harvey harvey 0 Feb  7  2006 /dev/pci/0.3.0cap/cap0.v17.l2.t0.b1.o2049
--r--r--r-- $ 0 harvey harvey 0 Feb  7  2006 /dev/pci/0.31.2cap/cap0.v5.l128.t0.b0.o0
--r--r--r-- $ 0 harvey harvey 0 Feb  7  2006 /dev/pci/0.31.2cap/cap1.v18.l16.t0.b72.o0
--r--r--r-- $ 0 harvey harvey 0 Feb  7  2006 /dev/pci/0.4.0cap/cap0.v17.l1.t0.b1.o2049
--r--r--r-- $ 0 harvey harvey 0 Feb  7  2006 /dev/pci/0.5.0cap/cap0.v17.l1.t0.b1.o2049
--r--r--r-- $ 0 harvey harvey 0 Feb  7  2006 /dev/pci/0.6.0cap/cap0.v17.l3.t0.b1.o2049
--r--r--r-- $ 0 harvey harvey 0 Feb  7  2006 /dev/pci/0.7.0cap/cap0.v17.l1.t0.b1.o2049

Capability name is formatted as  capN.vV.lL.tT.bB.oO where N is capability index as collected during the PCI bus scan, V is capability vendor code (cap_vndr), L is capability length in the PCI config space (cap_len), T is capability config type (cfg_type), B is BAR number, and O is offset within BAR.

This has some exploratory value. For most devices, only capability 17 (MSI-X) is present. The disk device (0.31.2) has 2 capabilities: 18 (storage related, with strange BAR number 72) and 5 (common device configuration).

Looking for possible plan9 virtio drivers, I have found that 9front has virtio-ethernet, and virtio-SD (disk) drivers. Both use the legacy (per the VIRTIO spec v1) interface which is port-based (not memory-mapped) IO, and the port range is exposed via BAR0. No capabilities are involved.

Anyway I would suggest to add this patch to the Harvey sources. It does not introduce any incompatibility while opens some way to write newer PCI-virtio device drivers based on capabilities rather than legacy interface.

Thanks.