### PR TITLE
fixfmt: Last cleaning of %u modifier in libs

### DIFF
--- a/sys/src/9/amd64/core.json
+++ b/sys/src/9/amd64/core.json
@@ -15,6 +15,7 @@
 			"-DKERNDATE=1433623937",
 			"-g",
 			"-Wall",
+			"-Werror",
 			"-W",
 			"-Wno-sign-compare",
 			"-Wno-missing-field-initializers",

--- a/sys/src/9/port/devramfs.c
+++ b/sys/src/9/port/devramfs.c
@@ -203,7 +203,7 @@ ramread(Chan *c, void *buf, int32_t n, int64_t off)
 	if (off + n > filelen){
 		n = filelen - off;
 	}
-	memcpy(buf, file->data, n);
+	memmove(buf, file->data, n);
 	qunlock(&ramlock);
 	return n;
 }
@@ -221,7 +221,7 @@ ramwrite(Chan* c, void* v, int32_t n, int64_t off)
 		file->data = newfile;
 		file->length = n+off;
 	}
-	memcpy(file->data + off, v, n);
+	memmove(file->data + off, v, n);
 	qunlock(&ramlock);
 	return n;
 }

--- a/sys/src/libc/port/pool.c
+++ b/sys/src/libc/port/pool.c
@@ -716,11 +716,11 @@ dumpblock(Pool *p, Bhdr *b)
 	uint8_t *cp;
 
 	dp = (uint32_t*)b;
-	p->print(p, "pool %s block %p\nhdr %.8lux %.8lux %.8lux %.8lux %.8lux %.8lux\n",
+	p->print(p, "pool %s block %p\nhdr %.8lx %.8lx %.8lx %.8lx %.8lx %.8lx\n",
 		p->name, b, dp[0], dp[1], dp[2], dp[3], dp[4], dp[5], dp[6]);
 
 	dp = (uint32_t*)B2T(b);
-	p->print(p, "tail %.8lux %.8lux %.8lux %.8lux %.8lux %.8lux | %.8lux %.8lux\n",
+	p->print(p, "tail %.8lx %.8lx %.8lx %.8lx %.8lx %.8lx | %.8lx %.8lx\n",
 		dp[-6], dp[-5], dp[-4], dp[-3], dp[-2], dp[-1], dp[0], dp[1]);
 
 	if(b->magic == ALLOC_MAGIC){
@@ -1438,7 +1438,7 @@ pooldumparena(Pool *p, Arena *a)
 	Bhdr *b;
 
 	for(b=&a->Bhdr; b->magic != ARENATAIL_MAGIC; b=B2NB(b))
-		p->print(p, "(%p %.8lux %lu)", b, b->magic, b->size);
+		p->print(p, "(%p %.8lx %lu)", b, b->magic, b->size);
 	p->print(p, "\n");
 }
 

--- a/sys/src/libmach/8db.c
+++ b/sys/src/libmach/8db.c
@@ -1861,7 +1861,7 @@ immediate(Instr *ip, int64_t val)
 	if((ip->rex & REXW) == 0)
 		bprint(ip, "%lx", (int32_t)val);
 	else
-		bprint(ip, "%llux", val);
+		bprint(ip, "%llx", val);
 }
 
 static void

--- a/sys/src/libmach/machdata.c
+++ b/sys/src/libmach/machdata.c
@@ -90,9 +90,9 @@ symoff(char *buf, int n, uint64_t v, int space)
 			delta = -delta;
 	}
 	if (v == 0 || r == 0)
-		return snprint(buf, n, "%llux", v);
+		return snprint(buf, n, "%llx", v);
 	if (s.type != 't' && s.type != 'T' && delta >= 4096)
-		return snprint(buf, n, "%llux", v);
+		return snprint(buf, n, "%llx", v);
 	else if (delta)
 		return snprint(buf, n, "%s+%lx", s.name, delta);
 	else
@@ -200,12 +200,12 @@ ieeedftos(char *buf, int n, uint32_t h, uint32_t l)
 		return snprint(buf, n, "0.");
 	exp = (h>>20) & ((1L<<11)-1L);
 	if(exp == 0)
-		return snprint(buf, n, "DeN(%.8lux%.8lux)", h, l);
+		return snprint(buf, n, "DeN(%.8lx%.8lx)", h, l);
 	if(exp == ((1L<<11)-1L)){
 		if(l==0 && (h&((1L<<20)-1L)) == 0)
 			return snprint(buf, n, "Inf");
 		else
-			return snprint(buf, n, "NaN(%.8lux%.8lux)", h&((1L<<20)-1L), l);
+			return snprint(buf, n, "NaN(%.8lx%.8lx)", h&((1L<<20)-1L), l);
 	}
 	exp -= (1L<<10) - 2L;
 	fr = l & ((1L<<16)-1L);
@@ -237,12 +237,12 @@ ieeesftos(char *buf, int n, uint32_t h)
 		return snprint(buf, n, "0.");
 	exp = (h>>23) & ((1L<<8)-1L);
 	if(exp == 0)
-		return snprint(buf, n, "DeN(%.8lux)", h);
+		return snprint(buf, n, "DeN(%.8lx)", h);
 	if(exp == ((1L<<8)-1L)){
 		if((h&((1L<<23)-1L)) == 0)
 			return snprint(buf, n, "Inf");
 		else
-			return snprint(buf, n, "NaN(%.8lux)", h&((1L<<23)-1L));
+			return snprint(buf, n, "NaN(%.8lx)", h&((1L<<23)-1L));
 	}
 	exp -= (1L<<7) - 2L;
 	fr = (h & ((1L<<23)-1L)) | (1L<<23);

--- a/sys/src/libmach/sym.c
+++ b/sys/src/libmach/sym.c
@@ -417,7 +417,7 @@ buildtbls(void)
 		case 'B':
 		case 'b':
 			if(debug)
-				print("Global: %s %llux\n", p->name, p->value);
+				print("Global: %s %llx\n", p->name, p->value);
 			globals[ng++] = p;
 			break;
 		case 'z':
@@ -456,7 +456,7 @@ buildtbls(void)
 			tp->sym = p;
 			tp->locals = ap;
 			if(debug)
-				print("TEXT: %s at %llux\n", p->name, p->value);
+				print("TEXT: %s at %llx\n", p->name, p->value);
 			if(f && !f->sym) {			/* first  */
 				f->sym = p;
 				f->addr = p->value;
@@ -470,7 +470,7 @@ buildtbls(void)
 					p->name);
 			else {
 				if(debug)
-					print("Local: %s %llux\n", p->name, p->value);
+					print("Local: %s %llx\n", p->name, p->value);
 				tp->locals[tp->n] = p;
 				tp->n++;
 				ap++;
@@ -494,7 +494,7 @@ buildtbls(void)
 		for(j = 0; j < ntxt; j++) {
 			if(f->sym == tp->sym) {
 				if(debug) {
-					print("LINK: %s to at %llux", f->sym->name, f->addr);
+					print("LINK: %s to at %llx", f->sym->name, f->addr);
 					printhist("... ", f->hist, 1);
 				}
 				f->txt = tp++;
@@ -873,7 +873,7 @@ file2pc(char *file, int32_t line)
 	 * run the state machine to locate the pc closest to that value.
 	 */
 	if(debug)
-		print("find pc for %ld - between: %llux and %llux\n", line, start, end);
+		print("find pc for %ld - between: %llx and %llx\n", line, start, end);
 	pc = line2addr(line, start, end);
 	if(pc == ~0) {
 		werrstr("line %ld not in file %s", line, file);

--- a/sys/src/libmemdraw/draw.c
+++ b/sys/src/libmemdraw/draw.c
@@ -1592,12 +1592,12 @@ writebyte(Param *p, uint8_t *w, Buffer src)
 
 	for(i=0; i<dx; i++){
 		u = w[0] | (w[1]<<8) | (w[2]<<16) | (w[3]<<24);
-		DBG print("u %.8lux...", u);
+		DBG print("u %.8lx...", u);
 		u &= mask;
-		DBG print("&mask %.8lux...", u);
+		DBG print("&mask %.8lx...", u);
 		if(isgrey){
 			u |= ((*grey >> (8-img->nbits[CGrey])) & img->mask[CGrey]) << img->shift[CGrey];
-			DBG print("|grey %.8lux...", u);
+			DBG print("|grey %.8lx...", u);
 			grey += delta;
 		}else{
 			u |= ((*red >> (8-img->nbits[CRed])) & img->mask[CRed]) << img->shift[CRed];
@@ -1606,13 +1606,13 @@ writebyte(Param *p, uint8_t *w, Buffer src)
 			red += delta;
 			grn += delta;
 			blu += delta;
-			DBG print("|rgb %.8lux...", u);
+			DBG print("|rgb %.8lx...", u);
 		}
 
 		if(isalpha){
 			u |= ((*alpha >> (8-img->nbits[CAlpha])) & img->mask[CAlpha]) << img->shift[CAlpha];
 			alpha += adelta;
-			DBG print("|alpha %.8lux...", u);
+			DBG print("|alpha %.8lx...", u);
 		}
 
 		w[0] = u;
@@ -2026,7 +2026,7 @@ rgbatoimg(Memimage *img, uint32_t rgba)
 		}
 		d += nb;
 	}
-//	print("rgba2img %.8lux = %.*lux\n", rgba, 2*d/8, v);
+//	print("rgba2img %.8lx = %.*lx\n", rgba, 2*d/8, v);
 	return v;
 }
 

--- a/sys/src/libmemdraw/drawtest.c
+++ b/sys/src/libmemdraw/drawtest.c
@@ -226,11 +226,11 @@ dumpimage(char *name, Memimage *img, void *vdata, Point labelpt)
 		break;
 	case 24:
 		fmt = (void(*)(Biobuf*,char*,uint32_t))Bprint;
-		arg = "%.6lux";
+		arg = "%.6lx";
 		break;
 	case 32:
 		fmt = (void(*)(Biobuf*,char*,uint32_t))Bprint;
-		arg = "%.8lux";
+		arg = "%.8lx";
 		break;
 	}
 	if(fmt == nil){
@@ -272,7 +272,7 @@ dumpimage(char *name, Memimage *img, void *vdata, Point labelpt)
 				nb += 8;
 			}
 			nb -= bpp;
-//			print("bpp %d v %.8lux mask %.8lux nb %d\n", bpp, v, mask, nb);
+//			print("bpp %d v %.8lx mask %.8lx nb %d\n", bpp, v, mask, nb);
 			fmt(&b, arg, (v>>nb)&mask);
 		}
 		Bprint(&b, "\n");
@@ -912,7 +912,7 @@ putpixel(Memimage *img, Point pt, uint32_t nv)
 	p = byteaddr(img, pt);
 	v = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24);
 	bpp = img->depth;
-DBG print("v %.8lux...", v);
+DBG print("v %.8lx...", v);
 	if(bpp < 8){
 		/*
 		 * Sub-byte greyscale pixels.  We need to skip the leftmost pt.x%npack pixels,
@@ -976,7 +976,7 @@ DBG print("bits %lx mask %lx sh %d...", bits, mask, sh);
 			sh += nbits;
 		}
 	}
-DBG print("v %.8lux\n", v);
+DBG print("v %.8lx\n", v);
 	p[0] = v;
 	p[1] = v>>8;
 	p[2] = v>>16;

--- a/sys/src/libsec/port/md5pickle.c
+++ b/sys/src/libsec/port/md5pickle.c
@@ -20,7 +20,7 @@ md5pickle(MD5state *s)
 	p = malloc(m);
 	if(p == nil)
 		return p;
-	n = sprint(p, "%16.16llux %8.8x %8.8x %8.8x %8.8x ",
+	n = sprint(p, "%16.16llx %8.8x %8.8x %8.8x %8.8x ",
 		s->len,
 		s->state[0], s->state[1], s->state[2],
 		s->state[3]);

--- a/sys/src/libusb/audio/audio.c
+++ b/sys/src/libusb/audio/audio.c
@@ -48,7 +48,7 @@ audio_endpoint(Dev *_1, Desc *dd)
 	switch(b[2]){
 	case 0x01:
 		if(usbdebug){
-			fprint(2, "CS_ENDPOINT for attributes 0x%x, lockdelayunits %d, lockdelay %#ux, ",
+			fprint(2, "CS_ENDPOINT for attributes 0x%x, lockdelayunits %d, lockdelay %#x, ",
 				b[3], b[4], b[5] | (b[6]<<8));
 			if(b[3] & has_setspeed)
 				fprint(2, "has sampling-frequency control");

--- a/sys/src/libusb/audio/audiosub.c
+++ b/sys/src/libusb/audio/audiosub.c
@@ -244,7 +244,7 @@ audio_interface(Dev *_1, Desc *dd)
 	case 2: // stream
 		switch (b[2]){
 		case 0x01:
-			dprint(2, "Audio stream for TerminalID %d, delay %d, format_tag %#ux\n",
+			dprint(2, "Audio stream for TerminalID %d, delay %d, format_tag %#x\n",
 				b[3], b[4], b[5] | (b[6]<<8));
 			break;
 		case 0x02:

--- a/sys/src/libusb/ether/asix.c
+++ b/sys/src/libusb/ether/asix.c
@@ -146,7 +146,7 @@ getphy(Dev *d)
 
 	if(asixget(d, Crphy, buf, sizeof(buf)) < 0)
 		return -1;
-	deprint(2, "%s: phy addr %#ux\n", argv0, buf[1]);
+	deprint(2, "%s: phy addr %#x\n", argv0, buf[1]);
 	return buf[1];
 }
 

--- a/sys/src/libusb/ether/ether.c
+++ b/sys/src/libusb/ether/ether.c
@@ -251,7 +251,7 @@ dumpframe(char *tag, void *p, int n)
 	s = seprintaddr(s, se, ep->s);
 	s = seprint(s, se, " -> ");
 	s = seprintaddr(s, se, ep->d);
-	s = seprint(s, se, " type 0x%02ux%02ux ", ep->type[0], ep->type[1]);
+	s = seprint(s, se, " type 0x%02x%02x ", ep->type[0], ep->type[1]);
 	n -= Eaddrlen * 2 + 2;
 	for(i = 0; i < n && i < 16; i++)
 		s = seprint(s, se, "%02x", ep->data[i]);

--- a/sys/src/libusb/kb/hid.c
+++ b/sys/src/libusb/kb/hid.c
@@ -96,7 +96,7 @@ parsereportdesc(HidRepTempl *temp, uint8_t *repdesc, int repsz)
 				temp->id = repdesc[i+1];
 				break;
 			default:
-				fprint(2, "report type %#ux bad\n",
+				fprint(2, "report type %#x bad\n",
 					repdesc[i+1]);
 				return -1;
 			}
@@ -213,12 +213,12 @@ dumpreport(HidRepTempl *templ)
 	ifssz = templ->nifcs;
 	ifs = templ->ifcs;
 	for(i = 0; i < ifssz; i++){
-		fprint(2, "\tcount %#ux", ifs[i].count);
+		fprint(2, "\tcount %#x", ifs[i].count);
 		fprint(2, " nbits %d ", ifs[i].nbits);
 		fprint(2, "\n");
 		for(j = 0; j < ifs[i].count; j++){
-			fprint(2, "\t\tkind %#ux ", ifs[i].kind[j]);
-			fprint(2, "v %#lux\n", ifs[i].v[j]);
+			fprint(2, "\t\tkind %#x ", ifs[i].kind[j]);
+			fprint(2, "v %#lx\n", ifs[i].v[j]);
 		}
 		fprint(2, "\n");
 	}

--- a/sys/src/libusb/kb/kb.c
+++ b/sys/src/libusb/kb/kb.c
@@ -177,7 +177,7 @@ setfirstconfig(KDev* f, int eid, uint8_t *desc, int descsz)
 		for(i = 0; i < nr; i++){
 			if(i%8 == 0)
 				fprint(2, "\n\t");
-			fprint(2, "%#2.2ux ", desc[i]);
+			fprint(2, "%#2.2x ", desc[i]);
 		}
 		fprint(2, "\n");
 	}

--- a/sys/src/libusb/lib/devs.c
+++ b/sys/src/libusb/lib/devs.c
@@ -68,7 +68,7 @@ matchdevcsp(char *info, void *a)
 
 	csps = a;
 	for(; *csps != 0; csps++){
-		snprint(sbuf, sizeof(sbuf), "csp %#08ux", *csps);
+		snprint(sbuf, sizeof(sbuf), "csp %#08x", *csps);
 		if(strstr(info, sbuf) != nil)
 			return 0;
 	}

--- a/sys/src/libusb/lib/dump.c
+++ b/sys/src/libusb/lib/dump.c
@@ -146,7 +146,7 @@ Ufmt(Fmt *f)
 		return fmtprint(f, "%s %ld refs\n", buf, d->Ref.ref);
 	s = seprint(s, e, " csp %s.%lu.%lu",
 		classname(Class(ud->csp)), Subclass(ud->csp), Proto(ud->csp));
-	s = seprint(s, e, " vid %#ux did %#ux", ud->vid, ud->did);
+	s = seprint(s, e, " vid %#x did %#x", ud->vid, ud->did);
 	s = seprint(s, e, " refs %ld\n", d->Ref.ref);
 	s = seprint(s, e, "\t%s %s %s\n", ud->vendor, ud->product, ud->serial);
 	for(i = 0; i < Nconf; i++){

--- a/sys/src/libusb/lib/fs.c
+++ b/sys/src/libusb/lib/fs.c
@@ -141,7 +141,7 @@ dump(void)
 	for(rpc = rpcs; rpc != nil; rpc = rpc->next)
 		fprint(2, "rpc %#p %F next %#p\n", rpc, &rpc->t, rpc->next);
 	for(fid = fids; fid != nil; fid = fid->next)
-		fprint(2, "fid %d qid %#llux omode %d aux %#p\n",
+		fprint(2, "fid %d qid %#llx omode %d aux %#p\n",
 			fid->fid, fid->qid.path, fid->omode, fid->aux);
 	fprint(2, "\n");
 	qunlock(&rpclck);
@@ -428,7 +428,7 @@ usbdirread(Usbfs*f, Qid q, char *data, int32_t cnt, int64_t off,
 	d.length = 0;
 	for(i = n = 0; gen(f, q, i, &d, arg) >= 0; i++){
 		if(usbfsdebug > 1)
-			fprint(2, "%s: dir %d q %#llux: %D\n", argv0, i, q.path, &d);
+			fprint(2, "%s: dir %d q %#llx: %D\n", argv0, i, q.path, &d);
 		nd = convD2M(&d, (uint8_t*)data+n, cnt-n);
 		if(nd <= BIT16SZ)
 			break;

--- a/sys/src/libusb/serial/ftdi.c
+++ b/sys/src/libusb/serial/ftdi.c
@@ -722,7 +722,7 @@ epreader(void *u)
 Eagain:
 		rcount = read(dfd, pk->b, sizeof pk->b);
 		if(serialdebug > 5)
-			dsprint(2, "%d %#ux%#ux ", rcount, p->data[0],
+			dsprint(2, "%d %#x%#x ", rcount, p->data[0],
 				p->data[1]);
 
 		if(rcount < 0){

--- a/sys/src/libusb/serial/prolific.c
+++ b/sys/src/libusb/serial/prolific.c
@@ -85,7 +85,7 @@ dumpbuf(uint8_t *buf, int bufsz)
 	int i;
 
 	for(i=0; i<bufsz; i++)
-		print("buf[%d]=%#ux ", i, buf[i]);
+		print("buf[%d]=%#x ", i, buf[i]);
 	print("\n");
 }
 


### PR DESCRIPTION
Restoring -Werror for kernel build

(secondary: replacing memcpy in port/devramfs for memmmove
 to avoid warning in kernel build)