### PR TITLE
ACPI: further changes, both to pci, and ACPI

### DIFF
--- a/sys/src/9/386/pci.c
+++ b/sys/src/9/386/pci.c
@@ -168,6 +168,7 @@ pcilscan(int bno, Pcidev** list)
 			p->ltr = pcicfgr8(p, PciLTR);
 
 			p->intl = pcicfgr8(p, PciINTL);
+			p->intp = pcicfgr8(p, PciINTP);
 
 			/*
 			 * If the device is a multi-function device adjust the
@@ -523,9 +524,12 @@ void
 pcishowdev(Pcidev* t)
 {
 	int i;
-	print("%d  %2d/%d %.2x %.2x %.2x %.4x %.4x %3d  ",
+	char intpin = 'x';
+	if (t->intl != 255)
+		intpin = "ABCDEFGH"[t->intp&0x7];
+	print("%d  %2d/%d %.2x %.2x %.2x %.4x %.4x %c %3d  ",
 	      BUSBNO(t->tbdf), BUSDNO(t->tbdf), BUSFNO(t->tbdf),
-	      t->ccrb, t->ccru, t->ccrp, t->vid, t->did, t->intl);
+	      t->ccrb, t->ccru, t->ccrp, t->vid, t->did, intpin, t->intl);
 
 	for(i = 0; i < nelem(t->mem); i++) {
 		if(t->mem[i].size == 0)

--- a/sys/src/9/amd64/devacpi.c
+++ b/sys/src/9/amd64/devacpi.c
@@ -519,14 +519,21 @@ print("ACPICODE: ioapicinit(%d, %p);\n", io->Id, (void*)(uint64_t)io->Address);
 	}
 
 	/* Get the _PRT */
-	as = AcpiEvaluateObject(ACPI_ROOT_OBJECT, "\\_SB.PCI0._PRT", NULL, &out);
-	print("get the PRT: %d\n", as);
-	print("Length is %u ptr is %p\n", out.Length, out.Pointer);
-	hexdump(out.Pointer, out.Length);
-	objwalk(out.Pointer);
+	int i;
+	for(i = 0; i < 255; i++) {
+		static char path[255];
+		snprint(path, sizeof(path), "\\_SB.PCI%d._PRT", i);
+		as = AcpiEvaluateObject(ACPI_ROOT_OBJECT, path, NULL, &out);
+		if (!ACPI_SUCCESS(as))
+			continue;
+		print("------>GOT the PRT: %d\n", i);
+		print("Length is %u ptr is %p\n", out.Length, out.Pointer);
+		hexdump(out.Pointer, out.Length);
+		objwalk(out.Pointer);
 
-	as = AcpiGetDevices (nil, device, nil, nil);
-	print("acpigetdevices %d\n", as);
+		as = AcpiGetDevices (nil, device, nil, nil);
+		print("acpigetdevices %d\n", as);
+	}
 
 /* per device code. Not useful yet.
 

--- a/sys/src/9/amd64/io.h
+++ b/sys/src/9/amd64/io.h
@@ -352,6 +352,7 @@ struct Pcidev
 		int	size;
 	} rom;
 	unsigned char	intl;		/* interrupt line */
+	unsigned char	intp;		/* interrupt pin */
 
 	Pcidev*	list;
 	Pcidev*	link;				/* next device on this bno */


### PR DESCRIPTION
The pci intp pin is far more useful than the intl, which seems
to be tied tightly to 8259 mode.