### PR TITLE
Fix reallocarray and use 'rm -f' when cleaning.

### DIFF
--- a/sys/src/lib.json
+++ b/sys/src/lib.json
@@ -7,7 +7,7 @@
 			"-static"
 		],
 		"Post": [
-			"rm *.o"
+			"rm -f *.o"
 		],
 		"Pre": [
 			"rm -f *.o *.tag.*"

--- a/sys/src/libc/port/reallocarray.c
+++ b/sys/src/libc/port/reallocarray.c
@@ -15,15 +15,14 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/types.h>
-#include <errno.h>
-#include <stdint.h>
-#include <stdlib.h>
+#include <u.h>
+#include <libc.h>
 
 /*
  * This is sqrt(SIZE_MAX+1), as s1*s2 <= SIZE_MAX
  * if both s1 < MUL_NO_OVERFLOW and s2 < MUL_NO_OVERFLOW
  */
+#define SIZE_MAX ~(size_t)0
 #define MUL_NO_OVERFLOW	((size_t)1 << (sizeof(size_t) * 4))
 
 void *
@@ -31,8 +30,7 @@ reallocarray(void *optr, size_t nmemb, size_t size)
 {
 	if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
 	    nmemb > 0 && SIZE_MAX / nmemb < size) {
-		errno = ENOMEM;
-		return NULL;
+		return nil;
 	}
 	return realloc(optr, size * nmemb);
 }


### PR DESCRIPTION
In sys/src/lib.json: use 'rm -f' when removing object files.
In sys/src/libc/port/reallocarray.c: Actually make this build
under Harvey. :-)

Signed-off-by: Dan Cross <cross@gajendra.net>