### PR TITLE
Fix compiler errors found by clang 3.8.0-1

### DIFF
--- a/sys/src/9/amd64/sdata.c
+++ b/sys/src/9/amd64/sdata.c
@@ -945,8 +945,6 @@ ataclear(SDev *sdev)
 		free(ctlr->drive[0]);
 	if (ctlr->drive[1])
 		free(ctlr->drive[1]);
-	if (sdev->name)
-		free(sdev->name);
 	if (sdev->unitflg)
 		free(sdev->unitflg);
 	if (sdev->unit)

--- a/sys/src/9/port/devdraw.c
+++ b/sys/src/9/port/devdraw.c
@@ -1383,10 +1383,10 @@ drawcoord(unsigned char *p, unsigned char *maxp, int oldx, int *newx)
 		x |= *p++ << 7;
 		x |= *p++ << 15;
 		if(x & (1<<22))
-			x |= ~0<<23;
+			x |= ~0UL<<23;
 	}else{
 		if(b & 0x40)
-			x |= ~0<<7;
+			x |= ~0UL<<7;
 		x += oldx;
 	}
 	*newx = x;

--- a/sys/src/9/port/devsd.c
+++ b/sys/src/9/port/devsd.c
@@ -490,7 +490,7 @@ static int
 sdgen(Chan* c, char* d, Dirtab* dir, int j, int s, Dir* dp)
 {
 	Proc *up = externup();
-	Qid q;
+	Qid q = {};
 	int64_t l;
 	int i, r;
 	SDpart *pp;


### PR DESCRIPTION
The errors found in sdata.c were potentially responsible for kernel panics.

Signed-off-by: Aaron <aaron@ahud.me>