### PR TITLE
Fix GO9PRUN

### DIFF
--- a/util/GO9PRUN
+++ b/util/GO9PRUN
@@ -1,3 +1,5 @@
+#!/bin/bash
+set -e
 
 trap : 2
 
@@ -23,9 +25,10 @@ $kvmdo qemu-system-x86_64 -s -cpu Opteron_G1 -smp 1 -m 2048 $kvmflag \
 -net dump,file=/tmp/vm0.pcap \
 -redir tcp:9999::9 \
 -redir tcp:17010::17010 \
+-redir tcp:5356::5356 \
 -redir tcp:17013::17013 \
 -append "service=cpu nobootprompt=tcp maxcores=1024 fs=10.0.2.2 auth=10.0.2.2 nvram=/boot/nvram nvrlen=512 nvroff=0" \
--kernel harvey.32bit $*
+-kernel $HARVEY/sys/src/9/amd64/harvey.32bit $*
 EOF
 
 echo $cmd


### PR DESCRIPTION
Use the HARVEY variable so that we don't have to be any
particular place to run it correctly.

Add a shebang (#!/bin/bash) and set -e so some errors
get caught.

Add a port forward for 5356 so we don't get ridiculous delays on
start. CPU servers don't run auth servers anyway, but this cpu
server would hang on the auth server.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>