### PR TITLE
Use %.8llx in devpci.c and pci.c: this fixes (on the surface) issue

### DIFF
--- a/sys/src/9/386/pci.c
+++ b/sys/src/9/386/pci.c
@@ -534,10 +534,10 @@ pcishowdev(Pcidev* t)
 	for(i = 0; i < nelem(t->mem); i++) {
 		if(t->mem[i].size == 0)
 			continue;
-		print("%d:%.8lx %d ", i, t->mem[i].bar, t->mem[i].size);
+		print("%d:%.8llx %d ", i, t->mem[i].bar, t->mem[i].size);
 	}
 	if(t->ioa.bar || t->ioa.size)
-		print("ioa:%.8lx %d ", t->ioa.bar, t->ioa.size);
+		print("ioa:%.8llx %d ", t->ioa.bar, t->ioa.size);
 	if(t->mema.bar || t->mema.size)
 
 	if(t->bridge)

--- a/sys/src/9/port/devpci.c
+++ b/sys/src/9/port/devpci.c
@@ -203,7 +203,7 @@ pciread(Chan *c, void *va, int32_t n, int64_t offset)
 		for(i=0; i<nelem(p->mem); i++){
 			if(p->mem[i].size == 0)
 				continue;
-			w = seprint(w, ebuf, " %d:%.8lx %d", i, p->mem[i].bar, p->mem[i].size);
+			w = seprint(w, ebuf, " %d:%.8llx %d", i, p->mem[i].bar, p->mem[i].size);
 		}
 		*w++ = '\n';
 		*w = '\0';


### PR DESCRIPTION
This patch should fix the symptoms described in the issue #231. 

Resulting output from pci:
0.0.0:  brg   06.00.00 8086/29c0   0
0.1.0:  vid   03.00.00 1b36/0100  10 0:f4000000 67108864 1:f8000000 67108864 2:fc090000 8192 3:0000c281 32
0.10.0: virtio-balloon 00.ff.00 1af4/1002  11 0:0000c301 32
0.11.0: virtio-disk    01.00.00 1af4/1001  11 0:0000c201 64 1:fc099000 4096
0.2.0:  net   02.00.00 10ec/8139  11 0:0000c001 256 1:fc092000 256
0.3.0:  virtio-net     02.00.00 1af4/1000  11 0:0000c2a1 32 1:fc093000 4096
0.31.0: brg   06.01.00 8086/2918   0
0.31.2: disk  01.06.01 8086/2922  10 4:0000c321 32 5:fc09a000 4096
0.31.3: smb   0c.05.00 8086/2930  10 4:0000b101 64
0.4.0:  virtio-9p      00.02.00 1af4/1009  10 0:0000c101 64 1:fc094000 4096
0.5.0:  virtio-9p      00.02.00 1af4/1009  10 0:0000c141 64 1:fc095000 4096
0.6.0:  virtio-console 07.80.00 1af4/1003  11 0:0000c2c1 32 1:fc096000 4096
0.7.0:  virtio-scsi    01.00.00 1af4/1004  11 0:0000c181 64 1:fc097000 4096
0.8.0:  virtio-disk    01.00.00 1af4/1001  10 0:0000c1c1 64 1:fc098000 4096
0.9.0:  virtio-rng     00.ff.00 1af4/1005  10 0:0000c2e1 32

Output from the boot log when PCI devices are scanned:

bus dev type vid  did intl memory
0   0/0 06 00 00 8086 29c0 A   0  
0   1/0 03 00 00 1b36 0100 B  10  0:f4000000 67108864 1:f8000000 67108864 2:fc090000 8192 3:0000c281 32 
0   2/0 02 00 00 10ec 8139 B  11  0:0000c001 256 1:fc092000 256 
0   3/0 02 00 00 1af4 1000 B  11  0:0000c2a1 32 1:fc093000 4096 
0   4/0 00 02 00 1af4 1009 B  10  0:0000c101 64 1:fc094000 4096 
0   5/0 00 02 00 1af4 1009 B  10  0:0000c141 64 1:fc095000 4096 
0   6/0 07 80 00 1af4 1003 B  11  0:0000c2c1 32 1:fc096000 4096 
0   7/0 01 00 00 1af4 1004 B  11  0:0000c181 64 1:fc097000 4096 
0   8/0 01 00 00 1af4 1001 B  10  0:0000c1c1 64 1:fc098000 4096 
0   9/0 00 ff 00 1af4 1005 B  10  0:0000c2e1 32 
0  10/0 00 ff 00 1af4 1002 B  11  0:0000c301 32 
0  11/0 01 00 00 1af4 1001 B  11  0:0000c201 64 1:fc099000 4096 
0  31/0 06 01 00 8086 2918 A   0  
0  31/2 01 06 01 8086 2922 B  10  4:0000c321 32 5:fc09a000 4096 
0  31/3 0c 05 00 8086 2930 B  10  4:0000b101 64 

Thanks.