### PR TITLE
sdata: remove sdata.c from the build.

### DIFF
--- a/sys/src/9/amd64/BUILD
+++ b/sys/src/9/amd64/BUILD
@@ -150,7 +150,6 @@ AMD64_SRCS = [
 	"ether82563.c",
 	"mouse.c",
 	"screen.c",
-	"sdata.c",
 	"usbehcipc.c",
 	"usbohci.c",
 	"usbuhci.c",

--- a/sys/src/9/amd64/amd64coreboot.json
+++ b/sys/src/9/amd64/amd64coreboot.json
@@ -114,7 +114,6 @@
 			"amd64cpu.c",
 			"mouse.c",
 			"cbscreen.c",
-			"sdata.c",
 			"usbehcipc.c",
 			"usbohci.c",
 			"usbuhci.c",

--- a/sys/src/9/amd64/build.json
+++ b/sys/src/9/amd64/build.json
@@ -122,7 +122,6 @@
 			"cpu.c",
 			"mouse.c",
 			"screen.c",
-			"sdata.c",
 			"usbehcipc.c",
 			"usbohci.c",
 			"usbuhci.c",


### PR DESCRIPTION
Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>