### PR TITLE
libz: fix broken shift of negative number

### DIFF
--- a/sys/src/libz/build.json
+++ b/sys/src/libz/build.json
@@ -25,6 +25,7 @@
 			"cp zconf.h harvey/",
 			"cp harvey.c harvey.h harvey/",
 			"echo > harvey/fcntl.h",
+			"cat upstream/inflate.c | sed -f patch/port-inflate.sed > harvey/inflate.c",
 			"cat upstream/gzguts.h | sed -f patch/port-gzguts.sed > harvey/gzguts.h",
 			"cat upstream/zutil.c | sed -f patch/port-zutils.sed > harvey/zutil.c",
 			"cat upstream/gzread.c | sed -f patch/port-gzread.sed  > harvey/gzread.c",

--- a/sys/src/libz/patch/port-inflate.sed
+++ b/sys/src/libz/patch/port-inflate.sed
@@ -1,2 +1,1 @@
-# avoid signed left shift
-s/-1L << 16/-1UL << 16/g
+/1L.*<<.*16/s//1UL << 16/


### PR DESCRIPTION
newer clang compilers noticed this, nothing else did.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>