### PR TITLE
clang: add more compiler names that need -mno-implicit-float

### DIFF
--- a/amd64/include/cflags.json
+++ b/amd64/include/cflags.json
@@ -4,6 +4,18 @@
 			"/usr/bin/clang": [
 				"-mno-implicit-float"
 			],
+			"/usr/bin/clang-3.4": [
+				"-mno-implicit-float"
+			],
+			"/usr/bin/clang-3.5": [
+				"-mno-implicit-float"
+			],
+			"/usr/bin/clang-3.6": [
+				"-mno-implicit-float"
+			],
+			"/usr/bin/clang-3.7": [
+				"-mno-implicit-float"
+			],
 			"/opt/intel/bin/icc": [
 				"-Wno-main"
 			]

--- a/sys/src/9/amd64/apic.c
+++ b/sys/src/9/amd64/apic.c
@@ -88,13 +88,13 @@ Mach	*xlapicmachptr[Napic];		/* maintained, but unused */
 static uint32_t
 apicrget(int r)
 {
-	return *((uint32_t*)(apicbase+r));
+	return *((volatile uint32_t*)(apicbase+r));
 }
 
 static void
 apicrput(int r, uint32_t data)
 {
-	*((uint32_t*)(apicbase+r)) = data;
+	*((volatile uint32_t*)(apicbase+r)) = data;
 }
 
 int

--- a/sys/src/9/amd64/core.json
+++ b/sys/src/9/amd64/core.json
@@ -3,6 +3,18 @@
 		"ToolOpts": {
 			"/usr/bin/clang": [
 				"-mno-implicit-float"
+			],
+			"/usr/bin/clang-3.4": [
+				"-mno-implicit-float"
+			],
+			"/usr/bin/clang-3.5": [
+				"-mno-implicit-float"
+			],
+			"/usr/bin/clang-3.6": [
+				"-mno-implicit-float"
+			],
+			"/usr/bin/clang-3.7": [
+				"-mno-implicit-float"
 			]
 		},
 		"Cflags": [

--- a/sys/src/9/amd64/mp.c
+++ b/sys/src/9/amd64/mp.c
@@ -15,6 +15,7 @@
 
 #include "apic.h"
 
+#define ISABUSNO 0xff
 /*
  * MultiProcessor Specification Version 1.[14].
  */
@@ -225,7 +226,7 @@ print("MP: add an apic, # %d\n", p[1]);
 	case 1:					/* bus */
 		print("CODE: /* case 1, bus */\n");
 		if (p[1] == hackisabusno)
-				p[1] = 0xff;
+				p[1] = ISABUSNO;
 		DBG("mpparse: bus: %d type %6.6s\n", p[1], (char*)p+2);
 print("MP: adda  bus %d\n", p[1]);
 		if(mpbus[p[1]] != nil){
@@ -243,7 +244,7 @@ print("MP: adda  bus %d\n", p[1]);
 					continue;
 				}
 				hackisabusno = p[1];
-				p[1] = 0xff;
+				p[1] = ISABUSNO;
 				mpisabusno = p[1];
 print("CODE: mpisabusno = %d\n", p[1]);
 			}


### PR DESCRIPTION
This correctly invoked the version compilers (e.g. clang-3.7) with
the option, but it only seemed to for no-implicit-float with
CC=clang

I have no idea but I hope mkx will allow selection of these
flags for different compilers.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>