### PR TITLE
Updating code to be able being built by gcc 6

### DIFF
--- a/amd64/include/cflags.json
+++ b/amd64/include/cflags.json
@@ -18,6 +18,9 @@
 			],
 			"/opt/intel/bin/icc": [
 				"-Wno-main"
+			],
+			"/usr/bin/gcc": [
+				"-Wno-frame-address"
 			]
 		},
 		"Cflags": [

--- a/amd64/include/klib.json
+++ b/amd64/include/klib.json
@@ -3,6 +3,9 @@
 		"ToolOpts": {
 			"/usr/bin/clang": [
 				"-mno-implicit-float"
+			],
+			"/usr/bin/gcc": [
+				"-Wno-frame-address"
 			]
 		},
 		"Cflags": [

--- a/sys/src/9/amd64/core.json
+++ b/sys/src/9/amd64/core.json
@@ -15,6 +15,9 @@
 			],
 			"/usr/bin/clang-3.7": [
 				"-mno-implicit-float"
+			],
+			"/usr/bin/gcc": [
+				"-Wno-frame-address"
 			]
 		},
 		"Cflags": [

--- a/sys/src/cmd/fossil/check.c
+++ b/sys/src/cmd/fossil/check.c
@@ -303,8 +303,8 @@ walkEpoch(Fsck *chk, Block *b, uint8_t score[VtScoreSize], int type,
 			}
 			if(!(e.flags & VtEntryActive))
 				continue;
-if(0)			fprint(2, "%x[%d] tag=%x snap=%d score=%V\n",
-				addr, i, e.tag, e.snap, e.score);
+			/* fprint(2, "%x[%d] tag=%x snap=%d score=%V\n",
+				addr, i, e.tag, e.snap, e.score); */
 			ep = epoch;
 			if(e.snap != 0){
 				if(e.snap >= epoch){
@@ -609,8 +609,8 @@ chkDir(Fsck *chk, char *name, Source *source, Source *meta)
 				name, o);
 			continue;
 		}
-if(0)		fprint(2, "source %V:%d block %d addr %d\n", source->score,
-			source->offset, o, b->addr);
+		/* fprint(2, "source %V:%d block %d addr %d\n", source->score,
+			source->offset, o, b->addr); */
 		if(b->addr != NilBlock && getBit(chk->errmap, b->addr))
 			warn(chk, "previously reported error in block %x is in %s",
 				b->addr, name);

--- a/sys/src/lib9p/req.c
+++ b/sys/src/lib9p/req.c
@@ -68,8 +68,8 @@ allocreq(Reqpool *pool, uint32_t tag)
 Req*
 lookupreq(Reqpool *pool, uint32_t tag)
 {
-if(chatty9p > 1)
-	fprint(2, "lookupreq %lu\n", tag);
+	if(chatty9p > 1)
+		fprint(2, "lookupreq %lu\n", tag);
 	return lookupkey(pool->map, tag);
 }
 
@@ -81,8 +81,8 @@ closereq(Req *r)
 	if(r == nil)
 		return;
 
-if(chatty9p > 1)
-	fprint(2, "closereq %p %ld\n", r, r->ref.ref);
+	if(chatty9p > 1)
+		fprint(2, "closereq %p %ld\n", r, r->ref.ref);
 
 	if(decref(&r->ref) == 0){
 		if(r->fid)
@@ -116,7 +116,7 @@ if(chatty9p > 1)
 Req*
 removereq(Reqpool *pool, uint32_t tag)
 {
-if(chatty9p > 1)
-	fprint(2, "removereq %lu\n", tag);
+	if(chatty9p > 1)
+		fprint(2, "removereq %lu\n", tag);
 	return deletekey(pool->map, tag);
 }

--- a/sys/src/lib9p/srv.c
+++ b/sys/src/lib9p/srv.c
@@ -94,8 +94,8 @@ getreq(Srv *s)
 		r->type = 0;
 		r->srv = s;
 		r->pool = nil;
-if(chatty9p)
-	fprint(2, "<-%d- %F: dup tag\n", s->infd, &f);
+		if(chatty9p)
+			fprint(2, "<-%d- %F: dup tag\n", s->infd, &f);
 		return r;
 	}
 
@@ -106,11 +106,12 @@ if(chatty9p)
 	memset(&r->ofcall, 0, sizeof r->ofcall);
 	r->type = r->ifcall.type;
 
-if(chatty9p)
-	if(r->error)
-		fprint(2, "<-%d- %F: %s\n", s->infd, &r->ifcall, r->error);
-	else	
-		fprint(2, "<-%d- %F\n", s->infd, &r->ifcall);
+	if(chatty9p) {
+		if(r->error)
+			fprint(2, "<-%d- %F: %s\n", s->infd, &r->ifcall, r->error);
+		else
+			fprint(2, "<-%d- %F\n", s->infd, &r->ifcall);
+	}
 
 	return r;
 }
@@ -616,8 +617,8 @@ sstat(Srv *srv, Req *r)
 		if(r->d.muid)
 			r->d.muid = estrdup9p(r->d.muid);
 	}
-	if(srv->stat)	
-		srv->stat(r);	
+	if(srv->stat)
+		srv->stat(r);
 	else if(r->fid->file)
 		respond(r, nil);
 	else
@@ -716,7 +717,7 @@ srv(Srv *srv)
 	while(r = getreq(srv)){
 		if(r->error){
 			respond(r, r->error);
-			continue;	
+			continue;
 		}
 		switch(r->ifcall.type){
 		default:
@@ -796,8 +797,8 @@ respond(Req *r, char *error)
 	if(r->error)
 		setfcallerror(&r->ofcall, r->error);
 
-if(chatty9p)
-	fprint(2, "-%d-> %F\n", srv->outfd, &r->ofcall);
+	if(chatty9p)
+		fprint(2, "-%d-> %F\n", srv->outfd, &r->ofcall);
 
 	qlock(&srv->wlock);
 	n = convS2M(&r->ofcall, srv->wbuf, srv->msize);

--- a/sys/src/libauth/auth_getkey.c
+++ b/sys/src/libauth/auth_getkey.c
@@ -30,10 +30,10 @@ auth_getkey(char *params)
 		werrstr("auth_getkey: no /factotum or /boot/factotum: didn't get key %s", params);
 		return -1;
 	}
-if(0)	if(d->type != '/'){
+	/* if(d->type != '/'){
 		werrstr("auth_getkey: /factotum may be bad: didn't get key %s", params);
 		return -1;
-	}
+	} */
 	switch(pid = fork()){
 	case -1:
 		werrstr("can't fork for %s: %r", name);

--- a/sys/src/libmemlayer/draw.c
+++ b/sys/src/libmemlayer/draw.c
@@ -73,8 +73,8 @@ memdraw(Memimage *dst, Rectangle r, Memimage *src, Point p0, Memimage *mask, Poi
 		mask = memopaque;
 
 	if(mask->layer){
-if(drawdebug)	iprint("mask->layer != nil\n");
-		return;	/* too hard, at least for now */
+		if(drawdebug)	iprint("mask->layer != nil\n");
+			return;	/* too hard, at least for now */
 	}
 
     Top:
@@ -84,7 +84,7 @@ if(drawdebug)	iprint("mask->layer != nil\n");
 	}
 
 	if(drawclip(dst, &r, src, &p0, mask, &p1, &srcr, &mr) == 0){
-if(drawdebug)	iprint("drawclip dstcr %R srccr %R maskcr %R\n", dst->clipr, src->clipr, mask->clipr);
+		if(drawdebug)	iprint("drawclip dstcr %R srccr %R maskcr %R\n", dst->clipr, src->clipr, mask->clipr);
 		return;
 	}
 

--- a/sys/src/liboventi/server.c
+++ b/sys/src/liboventi/server.c
@@ -65,7 +65,7 @@ dispatchHello(VtSession *z, Packet **pkt)
 
 	p = *pkt;
 
-	version = nil;	
+	version = nil;
 	uid = nil;
 	crypto = nil;
 	codec = nil;
@@ -190,7 +190,6 @@ vtExport(VtSession *z)
 		return 1;
 	}
 
-	
 	p = nil;
 	clean = 0;
 	vtAttach();
@@ -198,7 +197,7 @@ vtExport(VtSession *z)
 		goto Exit;
 
 	vtDebug(z, "server connected!\n");
-if(0)	vtSetDebug(z, 1);
+	//vtSetDebug(z, 1);
 
 	for(;;) {
 		p = vtRecvPacket(z);


### PR DESCRIPTION
Added -Wno-frame-address to avoid errors about
__builtin_frame_address in:
- libc/port/getcallerpc.c
- libc/port/malloc.c

And related in kernel and cmd.
Unfortunately, clang doesn't recognize this warning supress option,
instead it has -Wno-address. Suggestions for tweaking old build and new
build tools are welcome.

NOTE: if/else statements indentation is now a warning in case
{} would be missing.