### PR TITLE
clang-format: always break after function return type.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,6 +13,7 @@ AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: All
 AlwaysBreakAfterDefinitionReturnType: true
+AlwaysBreakAfterDefinitionReturnType: true
 AlwaysBreakTemplateDeclarations: false
 AlwaysBreakBeforeMultilineStrings: false
 BreakBeforeBinaryOperators: None


### PR DESCRIPTION
How's this look? Good? Bad?

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>