### PR TITLE
QUIET: quiet things down

### DIFF
--- a/sys/src/9/amd64/asm.c
+++ b/sys/src/9/amd64/asm.c
@@ -55,9 +55,9 @@ asmdump(void)
 {
 	Asm* assem;
 
-	print("asm: index %d:\n", asmindex);
+	DBG("asm: index %d:\n", asmindex);
 	for(assem = asmlist; assem != nil; assem = assem->next){
-		print(" %#P %#P %d (%P)\n",
+		DBG(" %#P %#P %d (%P)\n",
 			assem->addr, assem->addr+assem->size,
 			assem->type, assem->size);
 	}
@@ -351,15 +351,15 @@ asmmeminit(void)
 	cx = 0;
 #endif /* ConfCrap */
 	for(assem = asmlist; assem != nil; assem = assem->next){
-		print("asm: addr %#P end %#P type %d size %P\n",
+		DBG("asm: addr %#P end %#P type %d size %P\n",
 			assem->addr, assem->addr+assem->size,
 			assem->type, assem->size);
 		if((assem->type != AsmMEMORY)&&(assem->type != AsmRESERVED)) {
-			print("Skipping, it's not AsmMEMORY or AsmRESERVED\n");
+			DBG("Skipping, it's not AsmMEMORY or AsmRESERVED\n");
 			continue;
 		}
 		va = KSEG2+assem->addr;
-		print("asm: addr %#P end %#P type %d size %P\n",
+		DBG("asm: addr %#P end %#P type %d size %P\n",
 			assem->addr, assem->addr+assem->size,
 			assem->type, assem->size);
 
@@ -411,12 +411,12 @@ asmmeminit(void)
 //  hi = 600*MiB;
 		conf.mem[cx].npage = (hi - lo)/PGSZ;
 		conf.npage += conf.mem[cx].npage;
-		print("cm %d: addr %#llx npage %lu\n",
+		DBG("cm %d: addr %#llx npage %lu\n",
 			cx, conf.mem[cx].base, conf.mem[cx].npage);
 		cx++;
 #endif /* ConfCrap */
 	}
-	print("%d %d %d\n", npg[0], npg[1], npg[2]);
+	DBG("%d %d %d\n", npg[0], npg[1], npg[2]);
 
 #ifdef ConfCrap
 	/*
@@ -426,7 +426,7 @@ asmmeminit(void)
 	conf.upages = conf.npage;
 	i = (sys->vmend - sys->vmstart)/PGSZ;		/* close enough */
 	conf.ialloc = (i/2)*PGSZ;
-	print("npage %llu upage %lu kpage %d\n",
+	DBG("npage %llu upage %lu kpage %d\n",
 		conf.npage, conf.upages, i);
 
 #endif /* ConfCrap */

--- a/sys/src/9/amd64/devacpi.c
+++ b/sys/src/9/amd64/devacpi.c
@@ -464,10 +464,10 @@ static uint8_t sdtchecksum(void *addr, int len)
 	uint8_t *p, sum;
 
 	sum = 0;
-print("check %p %d\n", addr, len);
+	//print("check %p %d\n", addr, len);
 	for (p = addr; len-- > 0; p++)
 		sum += *p;
-print("sum is 0x%x\n", sum);
+	//print("sum is 0x%x\n", sum);
 	return sum;
 }
 
@@ -475,7 +475,7 @@ static void *sdtmap(uintptr_t pa, size_t *n, int cksum)
 {
 	Sdthdr *sdt;
 	Acpilist *p;
-print("sdtmap %p\n", (void *)pa);
+	//print("sdtmap %p\n", (void *)pa);
 	if (!pa) {
 		print("sdtmap: nil pa\n");
 		return nil;
@@ -485,10 +485,10 @@ print("sdtmap %p\n", (void *)pa);
 		print("acpi: vmap: nil\n");
 		return nil;
 	}
-print("sdt %p\n", sdt);
-print("get it\n");
+	//print("sdt %p\n", sdt);
+	//print("get it\n");
 	*n = l32get(sdt->length);
-print("*n is %d\n", *n);
+	//print("*n is %d\n", *n);
 	if (!*n) {
 		print("sdt has zero length: pa = %p, sig = %.4s\n", pa, sdt->sig);
 		return nil;
@@ -498,22 +498,22 @@ print("*n is %d\n", *n);
 		print("acpi: vmap: nil\n");
 		return nil;
 	}
-print("check it\n");
+	//print("check it\n");
 	if (cksum != 0 && sdtchecksum(sdt, *n) != 0) {
 		print("acpi: SDT: bad checksum. pa = %p, len = %lu\n", pa, *n);
 		return nil;
 	}
-print("now mallocz\n");
+	//print("now mallocz\n");
 	p = mallocz(sizeof(Acpilist) + *n, 1);
-print("malloc'ed %p\n", p);
+	//print("malloc'ed %p\n", p);
 	if (p == nil)
 		panic("sdtmap: memory allocation failed for %lu bytes", *n);
-print("move (%p, %p, %d)\n", p->raw, (void *)sdt, *n);
+	//print("move (%p, %p, %d)\n", p->raw, (void *)sdt, *n);
 	memmove(p->raw, (void *)sdt, *n);
 	p->size = *n;
 	p->next = acpilists;
 	acpilists = p;
-	print("sdtmap: size %d\n", *n);
+	//print("sdtmap: size %d\n", *n);
 	return p->raw;
 }
 
@@ -530,13 +530,15 @@ static int loadfacs(uintptr_t pa)
 	}
 
 	/* no unmap */
-	print("acpi: facs: hwsig: %#p\n", facs->hwsig);
-	print("acpi: facs: wakingv: %#p\n", facs->wakingv);
-	print("acpi: facs: flags: %#p\n", facs->flags);
-	print("acpi: facs: glock: %#p\n", facs->glock);
-	print("acpi: facs: xwakingv: %#p\n", facs->xwakingv);
-	print("acpi: facs: vers: %#p\n", facs->vers);
-	print("acpi: facs: ospmflags: %#p\n", facs->ospmflags);
+	if (0) {
+		print("acpi: facs: hwsig: %#p\n", facs->hwsig);
+		print("acpi: facs: wakingv: %#p\n", facs->wakingv);
+		print("acpi: facs: flags: %#p\n", facs->flags);
+		print("acpi: facs: glock: %#p\n", facs->glock);
+		print("acpi: facs: xwakingv: %#p\n", facs->xwakingv);
+		print("acpi: facs: vers: %#p\n", facs->vers);
+		print("acpi: facs: ospmflags: %#p\n", facs->ospmflags);
+	}
 
 	return 0;
 }
@@ -547,7 +549,7 @@ static void loaddsdt(uintptr_t pa)
 	uint8_t *dsdtp;
 
 	dsdtp = sdtmap(pa, &n, 1);
-print("Loaded it\n");
+	//print("Loaded it\n");
 	if (dsdtp == nil) {
 		print("acpi: Failed to map dsdtp.\n");
 		return;
@@ -708,13 +710,13 @@ static Atable *parsefadt(Atable *parent,
 	else
 		loadfacs(fp->facs);
 
-print("x %p %p %p \n", fp, (void *)fp->xdsdt, (void *)(uint64_t)fp->dsdt);
+	//print("x %p %p %p \n", fp, (void *)fp->xdsdt, (void *)(uint64_t)fp->dsdt);
 
 	if (fp->xdsdt == (uint64_t)fp->dsdt)	/* acpica */
 		loaddsdt(fp->xdsdt);
 	else
 		loaddsdt(fp->dsdt);
-print("y\n");
+	//print("y\n");
 
 	return finatable_nochildren(t);
 }
@@ -1484,22 +1486,22 @@ static void parsexsdt(Atable *root)
 	uintptr_t dhpa;
 	//Atable *n;
 	uint8_t *tbl;
-print("1\n");
+	//print("1\n");
 	psliceinit(&slice);
-print("2\n");
-print("xsdt %p\n", xsdt);
+	//print("2\n");
+	//print("xsdt %p\n", xsdt);
 	tbl = xsdt->p + sizeof(Sdthdr);
 	end = xsdt->len - sizeof(Sdthdr);
 	print("%s: tbl %p, end %d\n", __func__, tbl, end);
 	for (int i = 0; i < end; i += xsdt->asize) {
 		dhpa = (xsdt->asize == 8) ? l64get(tbl + i) : l32get(tbl + i);
 		sdt = sdtmap(dhpa, &l, 1);
-		print("sdt for map of %p, %d, 1 is %p\n", (void *)dhpa, l, sdt);
+		kmprint("sdt for map of %p, %d, 1 is %p\n", (void *)dhpa, l, sdt);
 		if (sdt == nil)
 			continue;
-		print("acpi: %s: addr %#p\n", __func__, sdt);
+		kmprint("acpi: %s: addr %#p\n", __func__, sdt);
 		for (int j = 0; j < nelem(ptable); j++) {
-			print("tb sig %s\n", ptable[j].sig);
+			kmprint("tb sig %s\n", ptable[j].sig);
 			if (memcmp(sdt->sig, ptable[j].sig, sizeof(sdt->sig)) == 0) {
 				table = ptable[j].parse(root, ptable[j].sig, (void *)sdt, l);
 				if (table != nil)
@@ -1508,7 +1510,7 @@ print("xsdt %p\n", xsdt);
 			}
 		}
 	}
-	print("FINATABLE\n\n\n\n"); delay(1000);
+	kmprint("FINATABLE\n\n\n\n"); delay(1000);
 	finatable(root, &slice);
 }
 
@@ -1546,12 +1548,12 @@ static void parsersdptr(void)
 	root = mkatable(nil, XSDT, devname(), nil, 0, sizeof(Xsdt));
 	root->parent = root;
 
-	print("/* RSDP */ Rsdp = {%08c, %x, %06c, %x, %p, %d, %p, %x}\n",
+	kmprint("/* RSDP */ Rsdp = {%08c, %x, %06c, %x, %p, %d, %p, %x}\n",
 		   rsd->signature, rsd->rchecksum, rsd->oemid, rsd->revision,
 		   *(uint32_t *)rsd->raddr, *(uint32_t *)rsd->length,
 		   *(uint32_t *)rsd->xaddr, rsd->xchecksum);
 
-	print("acpi: RSD PTR@ %#p, physaddr $%p length %ud %#llx rev %d\n",
+	kmprint("acpi: RSD PTR@ %#p, physaddr $%p length %ud %#llx rev %d\n",
 		   rsd, l32get(rsd->raddr), l32get(rsd->length),
 		   l64get(rsd->xaddr), rsd->revision);
 
@@ -1584,15 +1586,15 @@ static void parsersdptr(void)
 	}
 	if ((xsdt->p[0] != 'R' && xsdt->p[0] != 'X')
 		|| memcmp(xsdt->p + 1, "SDT", 3) != 0) {
-		print("acpi: xsdt sig: %c%c%c%c\n",
+		kmprint("acpi: xsdt sig: %c%c%c%c\n",
 		       xsdt->p[0], xsdt->p[1], xsdt->p[2], xsdt->p[3]);
 		xsdt = nil;
 		return;
 	}
 	xsdt->asize = asize;
-	print("acpi: XSDT %#p\n", xsdt);
+	kmprint("acpi: XSDT %#p\n", xsdt);
 	parsexsdt(root);
-	print("parsexdt done: lastpath %d\n", lastpath);
+	kmprint("parsexdt done: lastpath %d\n", lastpath);
 	atableindex = reallocarray(nil, lastpath, sizeof(Atable *));
 	assert(atableindex != nil);
 	makeindex(root);
@@ -1634,7 +1636,7 @@ static int acpigen(Chan *c, char *name, Dirtab *tab, int ntab,
  */
 static void dumpxsdt(void)
 {
-	print("xsdt: len = %lu, asize = %lu, p = %p\n",
+	kmprint("xsdt: len = %lu, asize = %lu, p = %p\n",
 	       xsdt->len, xsdt->asize, xsdt->p);
 }
 

--- a/sys/src/9/amd64/ioapic.c
+++ b/sys/src/9/amd64/ioapic.c
@@ -283,7 +283,6 @@ ioapicinit(int id, int ibase, uintptr_t pa)
 	apic = &xioapic[id];
 	if(apic->useable || (apic->Ioapic.addr = vmap(pa, 1024)) == nil)
 		return;
-	print("===================> set %d useable\n", id);
 	apic->useable = 1;
 	apic->Ioapic.paddr = pa;
 

--- a/sys/src/9/amd64/main.c
+++ b/sys/src/9/amd64/main.c
@@ -71,10 +71,10 @@ void
 stacksnippet(void)
 {
 	Stackframe *stkfr;
-	print(" stack:");
+	kmprint(" stack:");
 	for(stkfr = stackframe(); stkfr != nil; stkfr = stkfr->next)
-		print(" %c:%p", ktextaddr(stkfr->pc) ? 'k' : '?', ktextaddr(stkfr->pc) ? (stkfr->pc & 0xfffffff) : stkfr->pc);
-	print("\n");
+		kmprint(" %c:%p", ktextaddr(stkfr->pc) ? 'k' : '?', ktextaddr(stkfr->pc) ? (stkfr->pc & 0xfffffff) : stkfr->pc);
+	kmprint("\n");
 }
 
 void
@@ -96,7 +96,7 @@ machp_bad(void)
 		return;
 	}
 	trace[i] = badpc;
-	print("machp access spllo,");
+	kmprint("machp access spllo,");
 	stacksnippet();
 }
 

--- a/sys/src/9/amd64/mpacpi.c
+++ b/sys/src/9/amd64/mpacpi.c
@@ -38,7 +38,7 @@ int mpacpi(int ncleft)
 	if (mt == nil)
 		return ncleft;
 
-	print("APIC lapic paddr %#.8llux, flags %#.8ux\n",
+	print("APIC lapic paddr %#.8llx, flags %#.8x\n",
 		   mt->lapicpa, mt->pcat);
 	np = 0;
 	//print("apics->st %p\n", apics->st);

--- a/sys/src/9/port/devcons.c
+++ b/sys/src/9/port/devcons.c
@@ -176,6 +176,21 @@ print(char *fmt, ...)
 	return n;
 }
 
+int
+kmprint(char *fmt, ...)
+{
+	int n;
+	va_list arg;
+	char buf[PRINTSIZE];
+
+	va_start(arg, fmt);
+	n = vseprint(buf, buf+sizeof(buf), fmt, arg) - buf;
+	va_end(arg);
+	kmesgputs(buf, n);
+
+	return n;
+}
+
 /*
  * Want to interlock iprints to avoid interlaced output on
  * multiprocessor, but don't want to deadlock if one processor

--- a/sys/src/9/port/devcoreboot.c
+++ b/sys/src/9/port/devcoreboot.c
@@ -44,7 +44,7 @@
 /* === Parsing code === */
 /* This is the generic parsing code. */
 static void cb_parse_memory(void *ptr, struct sysinfo_t *info)
-{ print("%s\n", __func__);
+{ kmprint("%s\n", __func__);
 	struct cb_memory *mem = ptr;
 	int count = MEM_RANGE_COUNT(mem);
 	int i;
@@ -70,12 +70,12 @@ static void cb_parse_memory(void *ptr, struct sysinfo_t *info)
 }
 
 static void cb_parse_serial(void *ptr, struct sysinfo_t *info)
-{ print("%s\n", __func__);
+{ kmprint("%s\n", __func__);
 	info->serial = ((struct cb_serial *)ptr);
 }
 
 static void cb_parse_vboot_handoff(unsigned char *ptr, struct sysinfo_t *info)
-{ print("%s\n", __func__);
+{ kmprint("%s\n", __func__);
 	struct cb_range *vbho = (struct cb_range *)ptr;
 
 	info->vboot_handoff = (void *)(uintptr_t)vbho->range_start;
@@ -83,7 +83,7 @@ static void cb_parse_vboot_handoff(unsigned char *ptr, struct sysinfo_t *info)
 }
 
 static void cb_parse_vbnv(unsigned char *ptr, struct sysinfo_t *info)
-{ print("%s\n", __func__);
+{ kmprint("%s\n", __func__);
 	struct cb_range *vbnv = (struct cb_range *)ptr;
 
 	info->vbnv_start = vbnv->range_start;
@@ -91,7 +91,7 @@ static void cb_parse_vbnv(unsigned char *ptr, struct sysinfo_t *info)
 }
 
 static void cb_parse_gpios(unsigned char *ptr, struct sysinfo_t *info)
-{ print("%s\n", __func__);
+{ kmprint("%s\n", __func__);
 	int i;
 	struct cb_gpios *gpios = (struct cb_gpios *)ptr;
 
@@ -103,7 +103,7 @@ static void cb_parse_gpios(unsigned char *ptr, struct sysinfo_t *info)
 }
 
 static void cb_parse_vdat(unsigned char *ptr, struct sysinfo_t *info)
-{ print("%s\n", __func__);
+{ kmprint("%s\n", __func__);
 	struct cb_range *vdat = (struct cb_range *) ptr;
 
 	info->vdat_addr = KADDR(vdat->range_start);
@@ -111,60 +111,60 @@ static void cb_parse_vdat(unsigned char *ptr, struct sysinfo_t *info)
 }
 
 static void cb_parse_tstamp(unsigned char *ptr, struct sysinfo_t *info)
-{ print("%s\n", __func__);
+{ kmprint("%s\n", __func__);
 	struct cb_cbmem_tab *const cbmem = (struct cb_cbmem_tab *)ptr;
 	info->tstamp_table = KADDR(cbmem->cbmem_tab);
 }
 
 static void cb_parse_cbmem_cons(unsigned char *ptr, struct sysinfo_t *info)
-{ print("%s\n", __func__);
+{ kmprint("%s\n", __func__);
 	struct cb_cbmem_tab *const cbmem = (struct cb_cbmem_tab *)ptr;
 	info->cbmem_cons = KADDR(cbmem->cbmem_tab);
 }
 
 static void cb_parse_mrc_cache(unsigned char *ptr, struct sysinfo_t *info)
-{ print("%s\n", __func__);
+{ kmprint("%s\n", __func__);
 	struct cb_cbmem_tab *const cbmem = (struct cb_cbmem_tab *)ptr;
 	info->mrc_cache = KADDR(cbmem->cbmem_tab);
 }
 
 static void cb_parse_acpi_gnvs(unsigned char *ptr, struct sysinfo_t *info)
-{ print("%s\n", __func__);
+{ kmprint("%s\n", __func__);
 	struct cb_cbmem_tab *const cbmem = (struct cb_cbmem_tab *)ptr;
 	info->acpi_gnvs = KADDR(cbmem->cbmem_tab);
 }
 
 static void cb_parse_optiontable(void *ptr, struct sysinfo_t *info)
-{ print("%s\n", __func__);
+{ kmprint("%s\n", __func__);
 	/* ptr points to a coreboot table entry and is already virtual */
 	info->option_table = ptr;
 }
 
 static void cb_parse_checksum(void *ptr, struct sysinfo_t *info)
-{ print("%s\n", __func__);
+{ kmprint("%s\n", __func__);
 	struct cb_cmos_checksum *cmos_cksum = ptr;
 	info->cmos_range_start = cmos_cksum->range_start;
 	info->cmos_range_end = cmos_cksum->range_end;
 	info->cmos_checksum_location = cmos_cksum->location;
 }
 static void cb_parse_framebuffer(void *ptr, struct sysinfo_t *info)
-{ print("%s\n", __func__);
+{ kmprint("%s\n", __func__);
 	/* ptr points to a coreboot table entry and is already virtual */
 	info->framebuffer = ptr;
 }
 
 static void cb_parse_x86_rom_var_mtrr(void *ptr, struct sysinfo_t *info)
 { 
-	print("%s, ignoring MTRR information.\n", __func__);
+	kmprint("%s, ignoring MTRR information.\n", __func__);
 }
 
 static void cb_parse_string(unsigned char *ptr, char **info)
-{ print("%s\n", __func__);
+{ kmprint("%s\n", __func__);
 	*info = (char *)((struct cb_string *)ptr)->string;
 }
 
 int cb_parse_header(void *addr, int len, struct sysinfo_t *info)
-{ print("%s\n", __func__);
+{ kmprint("%s\n", __func__);
 	struct cb_header *header;
 	unsigned char *ptr = addr;
 	void *forward;
@@ -173,7 +173,7 @@ int cb_parse_header(void *addr, int len, struct sysinfo_t *info)
 	for (i = 0; i < len; i += 16, ptr += 16) {
 		header = (struct cb_header *)ptr;
 		if (0)
-		print("Check header %p sig %p val %02x %02x %02x %02x\n", header, header->signature, 
+		kmprint("Check header %p sig %p val %02x %02x %02x %02x\n", header, header->signature, 
 				header->signature[0], 
 				header->signature[1], 
 				header->signature[2], 
@@ -182,7 +182,7 @@ int cb_parse_header(void *addr, int len, struct sysinfo_t *info)
 			break;
 	}
 
-	print("found ? i %d len %d\n", i, len);
+	kmprint("found ? i %d len %d\n", i, len);
 	/* We walked the entire space and didn't find anything. */
 	if (i >= len)
 		return -1;
@@ -206,12 +206,12 @@ int cb_parse_header(void *addr, int len, struct sysinfo_t *info)
 	for (i = 0; i < header->table_entries; i++) {
 		struct cb_record *rec = (struct cb_record *)ptr;
 	I_AM_HERE;
-	print("rec %p tag %p\n", rec, rec->tag);
+	kmprint("rec %p tag %p\n", rec, rec->tag);
 		/* We only care about a few tags here (maybe more later). */
 		switch (rec->tag) {
 		case CB_TAG_FORWARD:
 			forward = KADDR((unsigned long)((struct cb_forward *)rec)->forward);
-			print("FORWARD: %p %p\n", (unsigned long)((struct cb_forward *)rec)->forward, 
+			kmprint("FORWARD: %p %p\n", (unsigned long)((struct cb_forward *)rec)->forward, 
 					forward);
 			return cb_parse_header(forward, len, info);
 			continue;

--- a/sys/src/9/port/devtab.c
+++ b/sys/src/9/port/devtab.c
@@ -35,9 +35,7 @@ devtabinit(void)
 	int i;
 
 	for(i = 0; devtab[i] != nil; i++) {
-		print("INIT %d %s\n", i, devtab[i]->name);
 		devtab[i]->init();
-		print("DONE\n");
 	}
 }
 

--- a/sys/src/9/port/portfns.h
+++ b/sys/src/9/port/portfns.h
@@ -168,6 +168,7 @@ int		kbdputc(Queue*, int);
 void		kbdputmap(uint16_t, uint16_t, Rune);
 void		kickpager(int, int);
 void		killbig(char*);
+int		kmprint(char*, ...);
 void		kproc(char*, void(*)(void*), void*);
 void		kprocchild(Proc*, void (*)(void*), void*);
 void		(*kproftimer)(uintptr_t);


### PR DESCRIPTION
add kmprint, which is like print but only goes to the
kmesg buffer, i.e. does not pollute the console.

Use kmprint and just reduce the amount of junk printed
so people can see their boot messages.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>