### PR TITLE
format: fix longstanding formatting bug

### DIFF
--- a/sys/src/libc/fmt/dofmt.c
+++ b/sys/src/libc/fmt/dofmt.c
@@ -379,24 +379,24 @@ _ifmt(Fmt *f)
 		break;
 	case 'u':
 		base = 10;
-		f->flags |= FmtUnsigned;
+		fl |= FmtUnsigned;
 		break;
 	case 'x':
 		base = 16;
-		f->flags |= FmtUnsigned;
+		fl |= FmtUnsigned;
 		break;
 	case 'X':
 		base = 16;
-		f->flags |= FmtUnsigned;
+		fl |= FmtUnsigned;
 		conv = "0123456789ABCDEF";
 		break;
 	case 'b':
 		base = 2;
-		f->flags |= FmtUnsigned;
+		fl |= FmtUnsigned;
 		break;
 	case 'o':
 		base = 8;
-		f->flags |= FmtUnsigned;
+		fl |= FmtUnsigned;
 		break;
 	default:
 		return -1;

--- a/sys/src/regress/build.json
+++ b/sys/src/regress/build.json
@@ -12,6 +12,7 @@
 			"execl.c",
 			"fdmux.c",
 			"float.c",
+			"fmt.c",
 			"fork.c",
 			"frexp.c",
 			"iphash.c",

--- a/sys/src/regress/fmt.c
+++ b/sys/src/regress/fmt.c
@@ -1,0 +1,25 @@
+
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+void
+main(void)
+{
+	static char buf[1024];
+	unsigned long x = 0xfeefd000deadbeef;
+	seprint(buf, buf+sizeof(buf), "%.2X", x);
+	if (strcmp("DEADBEEF", buf)) {
+		print("FAIL");
+		exits("FAIL");
+	}
+	print("PASS\n");
+	exits("PASS");
+}


### PR DESCRIPTION
For a long time, this code sequence:
	unsigned long x = 0xfeefd000deadbeef;
	seprint(buf, buf+sizeof(buf), "%.2X", x);
	print("%s\n", buf);

would result in this
-21524111

which is not at all what we want.

With this fix, they now result in this:
DEADBEEF

This change includes a simple test for testing formatting, which
we should grow over time: fmt.c

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>