### PR TITLE
ACPI: user mode tool to manage IRQs

### DIFF
--- a/amd64/include/mach_acpi.h
+++ b/amd64/include/mach_acpi.h
@@ -45,4 +45,5 @@ typedef int8_t INT8;
 typedef int ACPI_THREAD_ID;
 
 #define ACPI_MACHINE_WIDTH 64
+#pragma clang diagnostic ignored "-Wunused-variable"
 

--- a/amd64/include/mach_acpi.h
+++ b/amd64/include/mach_acpi.h
@@ -29,10 +29,19 @@ struct QLock
 } QLock;
 
 #endif
+#define ACPI_USE_SYSTEM_INTTYPES
+typedef uint8_t BOOLEAN;
 typedef QLock ACPI_MUTEX;
+typedef uint64_t COMPILER_DEPENDENT_UINT64;
+typedef uint64_t UINT64;
 typedef uint32_t UINT32;
 typedef uint16_t UINT16;
 typedef uint8_t UINT8;
+typedef int64_t COMPILER_DEPENDENT_INT64;
+typedef int64_t INT64;
+typedef int32_t INT32;
+typedef int16_t INT16;
+typedef int8_t INT8;
 typedef int ACPI_THREAD_ID;
 
 #define ACPI_MACHINE_WIDTH 64

--- a/sys/include/acpi/acpica/platform/acharvey.h
+++ b/sys/include/acpi/acpica/platform/acharvey.h
@@ -48,29 +48,4 @@
 #define ACPI_USE_SYSTEM_CLIBRARY
 #undef ACPI_USE_STANDARD_HEADERS
 
-#ifdef __KERNEL__
-/* TODO: multithreaded ACPI. But single thread is fine for now. */
-#else
-#endif				/* __KERNEL__ */
-
-#define ACPI_FLUSH_CPU_CACHE()
-#define ACPI_CAST_PTHREAD_T(pthread) ((acpi_thread_id) (pthread))
-
-#if defined(__ia64__)    || defined(__x86_64__) ||\
-	defined(__aarch64__) || defined(__PPC64__)
-#define ACPI_MACHINE_WIDTH          64
-#define COMPILER_DEPENDENT_INT64    long
-#define COMPILER_DEPENDENT_UINT64   unsigned long
-#else
-#define ACPI_MACHINE_WIDTH          32
-#define COMPILER_DEPENDENT_INT64    long long
-#define COMPILER_DEPENDENT_UINT64   unsigned long long
-#define ACPI_USE_NATIVE_DIVIDE
-#endif
-
-#ifndef __cdecl
-#define __cdecl
-#endif
-
-
 #endif				/* __ACHARVEY_H__ */

--- a/sys/src/cmd/acpi/alltables.c
+++ b/sys/src/cmd/acpi/alltables.c
@@ -1,0 +1,196 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <acpi.h>
+#include <accommon.h>
+#include <actables.h>
+#include <acutils.h>
+
+extern void *ACPIRootPointer;
+extern int ACPITableSize;
+extern UINT32 AcpiDbgLevel;
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    ApGetTableLength
+ *
+ * PARAMETERS:  Table               - Pointer to the table
+ *
+ * RETURN:      Table length
+ *
+ * DESCRIPTION: Obtain table length according to table signature.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ *
+ * FUNCTION:    ApIsValidHeader
+ *
+ * PARAMETERS:  Table               - Pointer to table to be validated
+ *
+ * RETURN:      TRUE if the header appears to be valid. FALSE otherwise
+ *
+ * DESCRIPTION: Check for a valid ACPI table header
+ *
+ ******************************************************************************/
+
+BOOLEAN
+ApIsValidHeader (
+    ACPI_TABLE_HEADER       *Table)
+{
+
+    if (!ACPI_VALIDATE_RSDP_SIG (Table->Signature))
+    {
+        /* Make sure signature is all ASCII and a valid ACPI name */
+
+        if (!AcpiUtValidNameseg (Table->Signature))
+        {
+            AcpiLogError ("Table signature (0x%8.8X) is invalid\n",
+                *(UINT32 *) Table->Signature);
+            return (FALSE);
+        }
+
+        /* Check for minimum table length */
+
+        if (Table->Length < sizeof (ACPI_TABLE_HEADER))
+        {
+            AcpiLogError ("Table length (0x%8.8X) is invalid\n",
+                Table->Length);
+            return (FALSE);
+        }
+    }
+
+    return (TRUE);
+}
+
+
+UINT32
+ApGetTableLength (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_TABLE_RSDP         *Rsdp;
+
+
+    /* Check if table is valid */
+
+    if (!ApIsValidHeader (Table))
+    {
+        return (0);
+    }
+
+    if (ACPI_VALIDATE_RSDP_SIG (Table->Signature))
+    {
+        Rsdp = ACPI_CAST_PTR (ACPI_TABLE_RSDP, Table);
+        return (AcpiTbGetRsdpLength (Rsdp));
+    }
+
+    /* Normal ACPI table */
+
+    return (Table->Length);
+}
+
+
+
+void
+main(int argc, char *argv[])
+{
+	ACPI_STATUS status;
+	AcpiDbgLevel = ACPI_LV_VERBOSITY1;
+	print("hi\n");
+	status = AcpiInitializeSubsystem();
+	if (ACPI_FAILURE(status)) {
+		sysfatal("Error %d\n", status);
+	}
+        status = AcpiInitializeTables(NULL, 2048, FALSE);
+        if (ACPI_FAILURE(status))
+		sysfatal("can't set up acpi tables: %d", status);
+
+    ACPI_TABLE_HEADER       *Table;
+    UINT32                  Instance = 0;
+    ACPI_PHYSICAL_ADDRESS   Address;
+    ACPI_STATUS             Status;
+    int                     TableStatus;
+    UINT32                  i;
+
+
+    /* Get and dump all available ACPI tables */
+
+    for (i = 0; i < 255; i++)
+    {
+	    Status = AcpiOsGetTableByIndex (i, &Table, &Instance, &Address);
+	    if (ACPI_FAILURE (Status))
+	    {
+		    /* AE_LIMIT means that no more tables are available */
+		    
+		    if (Status == AE_LIMIT)
+		    {
+			    break;
+		    }
+		    else if (i == 0)
+		    {
+			    AcpiLogError ("Could not get ACPI tables, %s\n",
+					  AcpiFormatException (Status));
+			    break;
+		    }
+		    else
+		    {
+			    AcpiLogError ("Could not get ACPI table at index %u, %s\n",
+					  i, AcpiFormatException (Status));
+			    continue;
+		    }
+	    }
+    UINT32                  TableLength;
+
+    TableLength = ApGetTableLength (Table);
+	    
+        AcpiTbPrintTableHeader (Address, Table);
+
+
+    AcpiUtFilePrintf (1, "%4.4s @ 0x%8.8X%8.8X\n",
+        Table->Signature, ACPI_FORMAT_UINT64 (Address));
+
+    AcpiUtDumpBufferToFile (1,
+        ACPI_CAST_PTR (UINT8, Table), TableLength,
+        DB_BYTE_DISPLAY, 0);
+    AcpiUtFilePrintf (1, "\n");
+
+	    ACPI_FREE (Table);	    
+	    if (TableStatus)
+	    {
+		    break;
+	    }
+    }
+    
+#if 0
+    print("initit dables\n"); 
+        status = AcpiLoadTables();
+        if (ACPI_FAILURE(status))
+		sysfatal("Can't load ACPI tables: %d", status);
+
+	sysfatal("LOADED TABLES. Hi the any key to continue\n"); getchar();
+        status = AcpiEnableSubsystem(0);
+        if (ACPI_FAILURE(status))
+		sysfatal("Can't enable ACPI subsystem");
+
+        status = AcpiInitializeObjects(0);
+        if (ACPI_FAILURE(status))
+		sysfatal("Can't Initialize ACPI objects");
+
+	status = AcpiInitializeDebugger();
+	if (ACPI_FAILURE(status)) {
+		sysfatal("Error %d\n", status);
+	}
+	print("OK on init.\n");
+#endif
+	exits(0);
+}
+

--- a/sys/src/cmd/acpi/build.json
+++ b/sys/src/cmd/acpi/build.json
@@ -1,0 +1,22 @@
+{
+	"irq": {
+		"Cflags": [
+			"-I", "/sys/include/acpi/acpica",
+		    "-U", "_LINUX_",
+		    "-U", "__linux__",
+		    "-D", "__HARVEY__",
+		    "-Wno-unused-function"
+		],
+		"Oflags": [
+			"-lacpi"
+		],
+		"Include": [
+			"/sys/src/cmd/cmd.json"
+		],
+		"Install": "/$ARCH/bin/acpi",
+		"Program": "irq",
+		"SourceFiles": [
+			"irq.c"
+		]
+	}
+}

--- a/sys/src/cmd/acpi/build.json
+++ b/sys/src/cmd/acpi/build.json
@@ -1,17 +1,11 @@
 {
 	"irq": {
-		"Cflags": [
-			"-I", "/sys/include/acpi/acpica",
-		    "-U", "_LINUX_",
-		    "-U", "__linux__",
-		    "-D", "__HARVEY__",
-		    "-Wno-unused-function"
+	    "Include": [
+		"/sys/src/libacpi/acpica/acpiflags.json",
+			"/sys/src/cmd/cmd.json"
 		],
 		"Oflags": [
 			"-lacpi"
-		],
-		"Include": [
-			"/sys/src/cmd/cmd.json"
 		],
 		"Install": "/$ARCH/bin/acpi",
 		"Program": "irq",

--- a/sys/src/cmd/acpi/build.json
+++ b/sys/src/cmd/acpi/build.json
@@ -15,7 +15,10 @@
 		],
 		"Install": "/$ARCH/bin/acpi",
 		"Program": "irq",
-		"SourceFiles": [
+		"NSourceFiles": [
+		    "alltables.c"
+		],
+		"SourceFilesCmd": [
 			"irq.c"
 		]
 	}

--- a/sys/src/cmd/acpi/irq.c
+++ b/sys/src/cmd/acpi/irq.c
@@ -7,18 +7,11 @@
  * in the LICENSE file.
  */
 
-#include <u.h>
-#include <libc.h>
 #include <acpi.h>
 
 extern void *ACPIRootPointer;
 extern int ACPITableSize;
 extern UINT32 AcpiDbgLevel;
-
-static int isprint(int c)
-{
-	return (c >= 32 && c <= 126);
-}
 
 void hexdump(void *v, int length)
 {
@@ -52,13 +45,6 @@ void hexdump(void *v, int length)
 	}
 }
 
-static int getchar(void)
-{
-	char c[1];
-	read(0, c, 1);
-	return c[1];
-}
-
 void
 main(int argc, char *argv[])
 {
@@ -78,15 +64,17 @@ main(int argc, char *argv[])
         if (ACPI_FAILURE(status))
 		sysfatal("Can't load ACPI tables: %d", status);
 
-	sysfatal("LOADED TABLES. Hi the any key to continue\n"); getchar();
+	print("LOADED TABLES. Hi the any key to continue\n"); getchar();
         status = AcpiEnableSubsystem(0);
         if (ACPI_FAILURE(status))
 		sysfatal("Can't enable ACPI subsystem");
 
+	print("enabled subsystem. Hi the any key to continue\n"); getchar();
         status = AcpiInitializeObjects(0);
         if (ACPI_FAILURE(status))
 		sysfatal("Can't Initialize ACPI objects");
 
+	print("inited objects. Hi the any key to continue\n"); getchar();
 	status = AcpiInitializeDebugger();
 	if (ACPI_FAILURE(status)) {
 		sysfatal("Error %d\n", status);

--- a/sys/src/cmd/acpi/irq.c
+++ b/sys/src/cmd/acpi/irq.c
@@ -1,0 +1,97 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <acpi.h>
+
+extern void *ACPIRootPointer;
+extern int ACPITableSize;
+extern UINT32 AcpiDbgLevel;
+
+static int isprint(int c)
+{
+	return (c >= 32 && c <= 126);
+}
+
+void hexdump(void *v, int length)
+{
+	int i;
+	uint8_t *m = v;
+	uintptr_t memory = (uintptr_t) v;
+	int all_zero = 0;
+	print("hexdump: %p, %u\n", v, length);
+	for (i = 0; i < length; i += 16) {
+		int j;
+
+		all_zero++;
+		for (j = 0; (j < 16) && (i + j < length); j++) {
+			if (m[i + j] != 0) {
+				all_zero = 0;
+				break;
+			}
+		}
+
+		if (all_zero < 2) {
+			print("%p:", (void *)(memory + i));
+			for (j = 0; j < 16; j++)
+				print(" %02x", m[i + j]);
+			print("  ");
+			for (j = 0; j < 16; j++)
+				print("%c", isprint(m[i + j]) ? m[i + j] : '.');
+			print("\n");
+		} else if (all_zero == 2) {
+			print("...\n");
+		}
+	}
+}
+
+static int getchar(void)
+{
+	char c[1];
+	read(0, c, 1);
+	return c[1];
+}
+
+void
+main(int argc, char *argv[])
+{
+	ACPI_STATUS status;
+	AcpiDbgLevel = ACPI_LV_VERBOSITY1;
+	print("hi\n");
+	status = AcpiInitializeSubsystem();
+	if (ACPI_FAILURE(status)) {
+		sysfatal("Error %d\n", status);
+	}
+        status = AcpiInitializeTables(NULL, 2048, FALSE);
+        if (ACPI_FAILURE(status))
+		sysfatal("can't set up acpi tables: %d", status);
+
+	print("initit dables\n"); 
+        status = AcpiLoadTables();
+        if (ACPI_FAILURE(status))
+		sysfatal("Can't load ACPI tables: %d", status);
+
+	sysfatal("LOADED TABLES. Hi the any key to continue\n"); getchar();
+        status = AcpiEnableSubsystem(0);
+        if (ACPI_FAILURE(status))
+		sysfatal("Can't enable ACPI subsystem");
+
+        status = AcpiInitializeObjects(0);
+        if (ACPI_FAILURE(status))
+		sysfatal("Can't Initialize ACPI objects");
+
+	status = AcpiInitializeDebugger();
+	if (ACPI_FAILURE(status)) {
+		sysfatal("Error %d\n", status);
+	}
+	print("OK on init.\n");
+	exits(0);
+}
+

--- a/sys/src/cmd/acpi/irq.c
+++ b/sys/src/cmd/acpi/irq.c
@@ -49,7 +49,7 @@ void
 main(int argc, char *argv[])
 {
 	ACPI_STATUS status;
-	AcpiDbgLevel = ACPI_LV_VERBOSITY1;
+	AcpiDbgLevel = 0; //ACPI_LV_VERBOSITY1;
 	print("hi\n");
 	status = AcpiInitializeSubsystem();
 	if (ACPI_FAILURE(status)) {
@@ -64,6 +64,9 @@ main(int argc, char *argv[])
         if (ACPI_FAILURE(status))
 		sysfatal("Can't load ACPI tables: %d", status);
 
+	/* from acpi: */
+    	/* If the Hardware Reduced flag is set, machine is always in acpi mode */
+	AcpiGbl_ReducedHardware = 1;
 	print("LOADED TABLES. Hi the any key to continue\n"); getchar();
         status = AcpiEnableSubsystem(0);
         if (ACPI_FAILURE(status))

--- a/sys/src/cmd/build.json
+++ b/sys/src/cmd/build.json
@@ -143,6 +143,7 @@
 		],
 		"Projects": [
 			"9660srv/9660srv.json",
+			"acpi/build.json",
 			"acme/build.json",
 			"astro/astro.json",
 			"auth/auth.json",

--- a/sys/src/libacpi/acpica/acpiflags.json
+++ b/sys/src/libacpi/acpica/acpiflags.json
@@ -3,7 +3,7 @@
 		"Cflags": [
 		        "-DACPI_DEBUGGER",
 		        "-DACPI_DISASSEMBLER",
-		        "-DACPI_DEBUG_OUTPUT",
+		        "-DACPI_EXEC_APP",
 		        "-D__HARVEY__",
 		        "-U_LINUX",
 		        "-U__linux__",

--- a/sys/src/libacpi/acpica/acpiflags.json
+++ b/sys/src/libacpi/acpica/acpiflags.json
@@ -1,6 +1,7 @@
 {
 	"acpiflags": {
 		"NoCflags": [
+			"-Werror not used because ACPICA sucks",
 			"-Wconversion"
 		],
 		"Cflags": [
@@ -11,9 +12,11 @@
 		        "-U_LINUX",
 		        "-U__linux__",
 			"-Wno-unused-function",
+			"-Wno-unused-variable",
+			"-Wno-unused-const-variable",
 			"-Wno-unknown-pragmas",
 			"-Wno-unused-variable",
-			"-Wall", "-Werror",
+			"-Wall", 
 			"-nostdlib",
 		    "-fno-builtin",
 			"-include", "u.h",

--- a/sys/src/libacpi/acpica/acpiflags.json
+++ b/sys/src/libacpi/acpica/acpiflags.json
@@ -1,5 +1,8 @@
 {
 	"acpiflags": {
+		"NoCflags": [
+			"-Wconversion"
+		],
 		"Cflags": [
 		        "-DACPI_DEBUGGER",
 		        "-DACPI_DISASSEMBLER",
@@ -8,7 +11,9 @@
 		        "-U_LINUX",
 		        "-U__linux__",
 			"-Wno-unused-function",
+			"-Wno-unknown-pragmas",
 			"-Wno-unused-variable",
+			"-Wall", "-Werror",
 			"-nostdlib",
 		    "-fno-builtin",
 			"-include", "u.h",

--- a/sys/src/libacpi/acpica/common/acfileio.c
+++ b/sys/src/libacpi/acpica/common/acfileio.c
@@ -1,0 +1,610 @@
+/******************************************************************************
+ *
+ * Module Name: acfileio - Get ACPI tables from file
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+#include "acapps.h"
+#include "actables.h"
+#include "acutils.h"
+#include <errno.h>
+
+#define _COMPONENT          ACPI_UTILITIES
+        ACPI_MODULE_NAME    ("acfileio")
+
+
+/* Local prototypes */
+
+static ACPI_STATUS
+AcGetOneTableFromFile (
+    char                    *Filename,
+    FILE                    *File,
+    UINT8                   GetOnlyAmlTables,
+    ACPI_TABLE_HEADER       **Table);
+
+static ACPI_STATUS
+AcCheckTextModeCorruption (
+    ACPI_TABLE_HEADER       *Table);
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcGetAllTablesFromFile
+ *
+ * PARAMETERS:  Filename            - Table filename
+ *              GetOnlyAmlTables    - TRUE if the tables must be AML tables
+ *              ReturnListHead      - Where table list is returned
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Get all ACPI tables from within a single file.
+ *
+ ******************************************************************************/
+
+ACPI_STATUS
+AcGetAllTablesFromFile (
+    char                    *Filename,
+    UINT8                   GetOnlyAmlTables,
+    ACPI_NEW_TABLE_DESC     **ReturnListHead)
+{
+    ACPI_NEW_TABLE_DESC     *ListHead = NULL;
+    ACPI_NEW_TABLE_DESC     *ListTail = NULL;
+    ACPI_NEW_TABLE_DESC     *TableDesc;
+    FILE                    *File;
+    ACPI_TABLE_HEADER       *Table = NULL;
+    UINT32                  FileSize;
+    ACPI_STATUS             Status = AE_OK;
+
+
+    File = fopen (Filename, "rb");
+    if (!File)
+    {
+        perror ("Could not open input file");
+        if (errno == ENOENT)
+        {
+            return (AE_NOT_EXIST);
+        }
+
+        return (AE_ERROR);
+    }
+
+    /* Get the file size */
+
+    FileSize = CmGetFileSize (File);
+    if (FileSize == ACPI_UINT32_MAX)
+    {
+        Status = AE_ERROR;
+        goto ErrorExit;
+    }
+
+    fprintf (stderr,
+        "Input file %s, Length 0x%X (%u) bytes\n",
+        Filename, FileSize, FileSize);
+
+    /* We must have at least one ACPI table header */
+
+    if (FileSize < sizeof (ACPI_TABLE_HEADER))
+    {
+        Status = AE_BAD_HEADER;
+        goto ErrorExit;
+    }
+
+    /* Check for an non-binary file */
+
+    if (!AcIsFileBinary (File))
+    {
+        fprintf (stderr,
+            "    %s: File does not appear to contain a valid AML table\n",
+            Filename);
+        return (AE_TYPE);
+    }
+
+    /* Read all tables within the file */
+
+    while (ACPI_SUCCESS (Status))
+    {
+        /* Get one entire ACPI table */
+
+        Status = AcGetOneTableFromFile (
+            Filename, File, GetOnlyAmlTables, &Table);
+
+        if (Status == AE_CTRL_TERMINATE)
+        {
+            Status = AE_OK;
+            break;
+        }
+        else if (Status == AE_TYPE)
+        {
+            return (AE_OK);
+        }
+        else if (ACPI_FAILURE (Status))
+        {
+            goto ErrorExit;
+        }
+
+        /* Print table header for iASL/disassembler only */
+
+#ifdef ACPI_ASL_COMPILER
+
+            AcpiTbPrintTableHeader (0, Table);
+#endif
+
+        /* Allocate and link a table descriptor */
+
+        TableDesc = AcpiOsAllocate (sizeof (ACPI_NEW_TABLE_DESC));
+        TableDesc->Table = Table;
+        TableDesc->Next = NULL;
+
+        /* Link at the end of the local table list */
+
+        if (!ListHead)
+        {
+            ListHead = TableDesc;
+            ListTail = TableDesc;
+        }
+        else
+        {
+            ListTail->Next = TableDesc;
+            ListTail = TableDesc;
+        }
+    }
+
+    /* Add the local table list to the end of the global list */
+
+    if (*ReturnListHead)
+    {
+        ListTail = *ReturnListHead;
+        while (ListTail->Next)
+        {
+            ListTail = ListTail->Next;
+        }
+
+        ListTail->Next = ListHead;
+    }
+    else
+    {
+        *ReturnListHead = ListHead;
+    }
+
+ErrorExit:
+    fclose(File);
+    return (Status);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcGetOneTableFromFile
+ *
+ * PARAMETERS:  Filename            - File where table is located
+ *              File                - Open FILE pointer to Filename
+ *              GetOnlyAmlTables    - TRUE if the tables must be AML tables.
+ *              ReturnTable         - Where a pointer to the table is returned
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Read the next ACPI table from a file. Implements support
+ *              for multiple tables within a single file. File must already
+ *              be open.
+ *
+ * Note: Loading an RSDP is not supported.
+ *
+ ******************************************************************************/
+
+static ACPI_STATUS
+AcGetOneTableFromFile (
+    char                    *Filename,
+    FILE                    *File,
+    UINT8                   GetOnlyAmlTables,
+    ACPI_TABLE_HEADER       **ReturnTable)
+{
+    ACPI_STATUS             Status = AE_OK;
+    ACPI_TABLE_HEADER       TableHeader;
+    ACPI_TABLE_HEADER       *Table;
+    INT32                   Count;
+    long                    TableOffset;
+
+
+    *ReturnTable = NULL;
+
+    /* Get the table header to examine signature and length */
+
+    TableOffset = ftell (File);
+    Count = fread (&TableHeader, 1, sizeof (ACPI_TABLE_HEADER), File);
+    if (Count != sizeof (ACPI_TABLE_HEADER))
+    {
+        return (AE_CTRL_TERMINATE);
+    }
+
+    /* Validate the table signature/header (limited ASCII chars) */
+
+    Status = AcValidateTableHeader (File, TableOffset);
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    if (GetOnlyAmlTables)
+    {
+        /* Table must be an AML table (DSDT/SSDT) or FADT */
+
+        if (!ACPI_COMPARE_NAME (TableHeader.Signature, ACPI_SIG_FADT) &&
+            !AcpiUtIsAmlTable (&TableHeader))
+        {
+            fprintf (stderr,
+                "    %s: Table [%4.4s] is not an AML table - ignoring\n",
+                Filename, TableHeader.Signature);
+
+            return (AE_TYPE);
+        }
+    }
+
+    /* Allocate a buffer for the entire table */
+
+    Table = AcpiOsAllocate ((size_t) TableHeader.Length);
+    if (!Table)
+    {
+        return (AE_NO_MEMORY);
+    }
+
+    /* Read the entire ACPI table, including header */
+
+    fseek (File, TableOffset, SEEK_SET);
+
+    Count = fread (Table, 1, TableHeader.Length, File);
+    if (Count != (INT32) TableHeader.Length)
+    {
+        Status = AE_ERROR;
+        goto ErrorExit;
+    }
+
+    /* Validate the checksum (just issue a warning) */
+
+    Status = AcpiTbVerifyChecksum (Table, TableHeader.Length);
+    if (ACPI_FAILURE (Status))
+    {
+        Status = AcCheckTextModeCorruption (Table);
+        if (ACPI_FAILURE (Status))
+        {
+            goto ErrorExit;
+        }
+    }
+
+    *ReturnTable = Table;
+    return (AE_OK);
+
+
+ErrorExit:
+    AcpiOsFree (Table);
+    return (Status);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcIsFileBinary
+ *
+ * PARAMETERS:  File                - Open input file
+ *
+ * RETURN:      TRUE if file appears to be binary
+ *
+ * DESCRIPTION: Scan a file for any non-ASCII bytes.
+ *
+ * Note: Maintains current file position.
+ *
+ ******************************************************************************/
+
+BOOLEAN
+AcIsFileBinary (
+    FILE                    *File)
+{
+    UINT8                   Byte;
+    BOOLEAN                 IsBinary = FALSE;
+    long                    FileOffset;
+
+
+    /* Scan entire file for any non-ASCII bytes */
+
+    FileOffset = ftell (File);
+    while (fread (&Byte, 1, 1, File) == 1)
+    {
+        if (!isprint (Byte) && !isspace (Byte))
+        {
+            IsBinary = TRUE;
+            goto Exit;
+        }
+    }
+
+Exit:
+    fseek (File, FileOffset, SEEK_SET);
+    return (IsBinary);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcValidateTableHeader
+ *
+ * PARAMETERS:  File                - Open input file
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Determine if a file seems to contain one or more binary ACPI
+ *              tables, via the
+ *              following checks on what would be the table header:
+ *              1) File must be at least as long as an ACPI_TABLE_HEADER
+ *              2) There must be enough room in the file to hold entire table
+ *              3) Signature, OemId, OemTableId, AslCompilerId must be ASCII
+ *
+ * Note: There can be multiple definition blocks per file, so we cannot
+ * expect/compare the file size to be equal to the table length. 12/2015.
+ *
+ * Note: Maintains current file position.
+ *
+ ******************************************************************************/
+
+ACPI_STATUS
+AcValidateTableHeader (
+    FILE                    *File,
+    long                    TableOffset)
+{
+    ACPI_TABLE_HEADER       TableHeader;
+    size_t                  Actual;
+    long                    OriginalOffset;
+    UINT32                  FileSize;
+    UINT32                  i;
+
+
+    ACPI_FUNCTION_TRACE ("AcValidateTableHeader");
+
+
+    /* Read a potential table header */
+
+    OriginalOffset = ftell (File);
+    fseek (File, TableOffset, SEEK_SET);
+
+    Actual = fread (&TableHeader, 1, sizeof (ACPI_TABLE_HEADER), File);
+    fseek (File, OriginalOffset, SEEK_SET);
+
+    if (Actual < sizeof (ACPI_TABLE_HEADER))
+    {
+        return (AE_ERROR);
+    }
+
+    /* Validate the signature (limited ASCII chars) */
+
+    if (!AcpiUtValidNameseg (TableHeader.Signature))
+    {
+        fprintf (stderr, "Invalid table signature: 0x%8.8X\n",
+            *ACPI_CAST_PTR (UINT32, TableHeader.Signature));
+        return (AE_BAD_SIGNATURE);
+    }
+
+    /* Validate table length against bytes remaining in the file */
+
+    FileSize = CmGetFileSize (File);
+    if (TableHeader.Length > (UINT32) (FileSize - TableOffset))
+    {
+        fprintf (stderr, "Table [%4.4s] is too long for file - "
+            "needs: 0x%.2X, remaining in file: 0x%.2X\n",
+            TableHeader.Signature, TableHeader.Length,
+            (UINT32) (FileSize - TableOffset));
+        return (AE_BAD_HEADER);
+    }
+
+    /*
+     * These fields must be ASCII: OemId, OemTableId, AslCompilerId.
+     * We allow a NULL terminator in OemId and OemTableId.
+     */
+    for (i = 0; i < ACPI_NAME_SIZE; i++)
+    {
+        if (!ACPI_IS_ASCII ((UINT8) TableHeader.AslCompilerId[i]))
+        {
+            goto BadCharacters;
+        }
+    }
+
+    for (i = 0; (i < ACPI_OEM_ID_SIZE) && (TableHeader.OemId[i]); i++)
+    {
+        if (!ACPI_IS_ASCII ((UINT8) TableHeader.OemId[i]))
+        {
+            goto BadCharacters;
+        }
+    }
+
+    for (i = 0; (i < ACPI_OEM_TABLE_ID_SIZE) && (TableHeader.OemTableId[i]); i++)
+    {
+        if (!ACPI_IS_ASCII ((UINT8) TableHeader.OemTableId[i]))
+        {
+            goto BadCharacters;
+        }
+    }
+
+    return (AE_OK);
+
+
+BadCharacters:
+
+    ACPI_WARNING ((AE_INFO,
+        "Table header for [%4.4s] has invalid ASCII character(s)",
+        TableHeader.Signature));
+    return (AE_OK);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcCheckTextModeCorruption
+ *
+ * PARAMETERS:  Table           - Table buffer starting with table header
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Check table for text mode file corruption where all linefeed
+ *              characters (LF) have been replaced by carriage return linefeed
+ *              pairs (CR/LF).
+ *
+ ******************************************************************************/
+
+static ACPI_STATUS
+AcCheckTextModeCorruption (
+    ACPI_TABLE_HEADER       *Table)
+{
+    UINT32                  i;
+    UINT32                  Pairs = 0;
+    UINT8                   *Buffer = ACPI_CAST_PTR (UINT8, Table);
+
+
+    /* Scan entire table to determine if each LF has been prefixed with a CR */
+
+    for (i = 1; i < Table->Length; i++)
+    {
+        if (Buffer[i] == 0x0A)
+        {
+            if (Buffer[i - 1] != 0x0D)
+            {
+                /* The LF does not have a preceding CR, table not corrupted */
+
+                return (AE_OK);
+            }
+            else
+            {
+                /* Found a CR/LF pair */
+
+                Pairs++;
+            }
+
+            i++;
+        }
+    }
+
+    if (!Pairs)
+    {
+        return (AE_OK);
+    }
+
+    /*
+     * Entire table scanned, each CR is part of a CR/LF pair --
+     * meaning that the table was treated as a text file somewhere.
+     *
+     * NOTE: We can't "fix" the table, because any existing CR/LF pairs in the
+     * original table are left untouched by the text conversion process --
+     * meaning that we cannot simply replace CR/LF pairs with LFs.
+     */
+    AcpiOsPrintf ("Table has been corrupted by text mode conversion\n");
+    AcpiOsPrintf ("All LFs (%u) were changed to CR/LF pairs\n", Pairs);
+    AcpiOsPrintf ("Table cannot be repaired!\n");
+
+    return (AE_BAD_VALUE);
+}

--- a/sys/src/libacpi/acpica/common/acgetline.c
+++ b/sys/src/libacpi/acpica/common/acgetline.c
@@ -1,0 +1,513 @@
+/******************************************************************************
+ *
+ * Module Name: acgetline - local line editing
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+#include "amlcode.h"
+#include "acparser.h"
+#include "acdebug.h"
+
+#include <stdio.h>
+
+/*
+ * This is an os-independent implementation of line-editing services needed
+ * by the AcpiExec utility. It uses getchar() and putchar() and the existing
+ * history support provided by the AML debugger. It assumes that the terminal
+ * is in the correct line-editing mode such as raw and noecho. The OSL
+ * interface AcpiOsInitialize should do this. AcpiOsTerminate should put the
+ * terminal back into the original mode.
+ */
+#define _COMPONENT          ACPI_OS_SERVICES
+        ACPI_MODULE_NAME    ("acgetline")
+
+
+/* Local prototypes */
+
+static void
+AcpiAcClearLine (
+    UINT32                  EndOfLine,
+    UINT32                  CursorPosition);
+
+/* Various ASCII constants */
+
+#define _ASCII_NUL                  0
+#define _ASCII_BACKSPACE            0x08
+#define _ASCII_TAB                  0x09
+#define _ASCII_ESCAPE               0x1B
+#define _ASCII_SPACE                0x20
+#define _ASCII_LEFT_BRACKET         0x5B
+#define _ASCII_DEL                  0x7F
+#define _ASCII_UP_ARROW             'A'
+#define _ASCII_DOWN_ARROW           'B'
+#define _ASCII_RIGHT_ARROW          'C'
+#define _ASCII_LEFT_ARROW           'D'
+#define _ASCII_NEWLINE              '\n'
+
+extern UINT32               AcpiGbl_NextCmdNum;
+
+/* Erase a single character on the input command line */
+
+#define ACPI_CLEAR_CHAR() \
+    putchar (_ASCII_BACKSPACE); \
+    putchar (_ASCII_SPACE); \
+    putchar (_ASCII_BACKSPACE);
+
+/* Backup cursor by Count positions */
+
+#define ACPI_BACKUP_CURSOR(i, Count) \
+    for (i = 0; i < (Count); i++) \
+        {putchar (_ASCII_BACKSPACE);}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiAcClearLine
+ *
+ * PARAMETERS:  EndOfLine           - Current end-of-line index
+ *              CursorPosition      - Current cursor position within line
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Clear the entire command line the hard way, but probably the
+ *              most portable.
+ *
+ *****************************************************************************/
+
+static void
+AcpiAcClearLine (
+    UINT32                  EndOfLine,
+    UINT32                  CursorPosition)
+{
+    UINT32                  i;
+
+
+    if (CursorPosition < EndOfLine)
+    {
+        /* Clear line from current position to end of line */
+
+        for (i = 0; i < (EndOfLine - CursorPosition); i++)
+        {
+            putchar (' ');
+        }
+    }
+
+    /* Clear the entire line */
+
+    for (; EndOfLine > 0; EndOfLine--)
+    {
+        ACPI_CLEAR_CHAR ();
+    }
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsGetLine
+ *
+ * PARAMETERS:  Buffer              - Where to return the command line
+ *              BufferLength        - Maximum length of Buffer
+ *              BytesRead           - Where the actual byte count is returned
+ *
+ * RETURN:      Status and actual bytes read
+ *
+ * DESCRIPTION: Get the next input line from the terminal. NOTE: terminal
+ *              is expected to be in a mode that supports line-editing (raw,
+ *              noecho). This function is intended to be very portable. Also,
+ *              it uses the history support implemented in the AML debugger.
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AcpiOsGetLine (
+    char                    *Buffer,
+    UINT32                  BufferLength,
+    UINT32                  *BytesRead)
+{
+    char                    *NextCommand;
+    UINT32                  MaxCommandIndex = AcpiGbl_NextCmdNum - 1;
+    UINT32                  CurrentCommandIndex = MaxCommandIndex;
+    UINT32                  PreviousCommandIndex = MaxCommandIndex;
+    int                     InputChar;
+    UINT32                  CursorPosition = 0;
+    UINT32                  EndOfLine = 0;
+    UINT32                  i;
+
+
+    /* Always clear the line buffer before we read a new line */
+
+    memset (Buffer, 0, BufferLength);
+
+    /*
+     * This loop gets one character at a time (except for esc sequences)
+     * until a newline or error is detected.
+     *
+     * Note: Don't attempt to write terminal control ESC sequences, even
+     * though it makes certain things more difficult.
+     */
+    while (1)
+    {
+        if (EndOfLine >= (BufferLength - 1))
+        {
+            return (AE_BUFFER_OVERFLOW);
+        }
+
+        InputChar = getchar ();
+        switch (InputChar)
+        {
+        default: /* This is the normal character case */
+
+            /* Echo the character (at EOL) and copy it to the line buffer */
+
+            if (EndOfLine == CursorPosition)
+            {
+                putchar (InputChar);
+                Buffer[EndOfLine] = (char) InputChar;
+
+                EndOfLine++;
+                CursorPosition++;
+                Buffer[EndOfLine] = 0;
+                continue;
+            }
+
+            /* Insert character into the middle of the buffer */
+
+            memmove (&Buffer[CursorPosition + 1], &Buffer[CursorPosition],
+                (EndOfLine - CursorPosition + 1));
+
+            Buffer [CursorPosition] = (char) InputChar;
+            Buffer [EndOfLine + 1] = 0;
+
+            /* Display the new part of line starting at the new character */
+
+            fprintf (stdout, "%s", &Buffer[CursorPosition]);
+
+            /* Restore cursor */
+
+            ACPI_BACKUP_CURSOR (i, EndOfLine - CursorPosition);
+            CursorPosition++;
+            EndOfLine++;
+            continue;
+
+        case _ASCII_DEL: /* Backspace key */
+
+            if (!EndOfLine) /* Any characters on the command line? */
+            {
+                continue;
+            }
+
+            if (EndOfLine == CursorPosition) /* Erase the final character */
+            {
+                ACPI_CLEAR_CHAR ();
+                EndOfLine--;
+                CursorPosition--;
+                continue;
+            }
+
+            if (!CursorPosition) /* Do not backup beyond start of line */
+            {
+                continue;
+            }
+
+            /* Remove the character from the line */
+
+            memmove (&Buffer[CursorPosition - 1], &Buffer[CursorPosition],
+                (EndOfLine - CursorPosition + 1));
+
+            /* Display the new part of line starting at the new character */
+
+            putchar (_ASCII_BACKSPACE);
+            fprintf (stdout, "%s ", &Buffer[CursorPosition - 1]);
+
+            /* Restore cursor */
+
+            ACPI_BACKUP_CURSOR (i, EndOfLine - CursorPosition + 1);
+            EndOfLine--;
+
+            if (CursorPosition > 0)
+            {
+                CursorPosition--;
+            }
+            continue;
+
+        case _ASCII_NEWLINE: /* Normal exit case at end of command line */
+        case _ASCII_NUL:
+
+            /* Return the number of bytes in the command line string */
+
+            if (BytesRead)
+            {
+                *BytesRead = EndOfLine;
+            }
+
+            /* Echo, terminate string buffer, and exit */
+
+            putchar (InputChar);
+            Buffer[EndOfLine] = 0;
+            return (AE_OK);
+
+        case _ASCII_TAB:
+
+            /* Ignore */
+
+            continue;
+
+        case EOF:
+
+            return (AE_ERROR);
+
+        case _ASCII_ESCAPE:
+
+            /* Check for escape sequences of the form "ESC[x" */
+
+            InputChar = getchar ();
+            if (InputChar != _ASCII_LEFT_BRACKET)
+            {
+                continue; /* Ignore this ESC, does not have the '[' */
+            }
+
+            /* Get the code following the ESC [ */
+
+            InputChar = getchar (); /* Backup one character */
+            switch (InputChar)
+            {
+            case _ASCII_LEFT_ARROW:
+
+                if (CursorPosition > 0)
+                {
+                    putchar (_ASCII_BACKSPACE);
+                    CursorPosition--;
+                }
+                continue;
+
+            case _ASCII_RIGHT_ARROW:
+                /*
+                 * Move one character forward. Do this without sending
+                 * ESC sequence to the terminal for max portability.
+                 */
+                if (CursorPosition < EndOfLine)
+                {
+                    /* Backup to start of line and print the entire line */
+
+                    ACPI_BACKUP_CURSOR (i, CursorPosition);
+                    fprintf (stdout, "%s", Buffer);
+
+                    /* Backup to where the cursor should be */
+
+                    CursorPosition++;
+                    ACPI_BACKUP_CURSOR (i, EndOfLine - CursorPosition);
+                }
+                continue;
+
+            case _ASCII_UP_ARROW:
+
+                /* If no commands available or at start of history list, ignore */
+
+                if (!CurrentCommandIndex)
+                {
+                    continue;
+                }
+
+                /* Manage our up/down progress */
+
+                if (CurrentCommandIndex > PreviousCommandIndex)
+                {
+                    CurrentCommandIndex = PreviousCommandIndex;
+                }
+
+                /* Get the historical command from the debugger */
+
+                NextCommand = AcpiDbGetHistoryByIndex (CurrentCommandIndex);
+                if (!NextCommand)
+                {
+                    return (AE_ERROR);
+                }
+
+                /* Make this the active command and echo it */
+
+                AcpiAcClearLine (EndOfLine, CursorPosition);
+                strcpy (Buffer, NextCommand);
+                fprintf (stdout, "%s", Buffer);
+                EndOfLine = CursorPosition = strlen (Buffer);
+
+                PreviousCommandIndex = CurrentCommandIndex;
+                CurrentCommandIndex--;
+                continue;
+
+            case _ASCII_DOWN_ARROW:
+
+                if (!MaxCommandIndex) /* Any commands available? */
+                {
+                    continue;
+                }
+
+                /* Manage our up/down progress */
+
+                if (CurrentCommandIndex < PreviousCommandIndex)
+                {
+                    CurrentCommandIndex = PreviousCommandIndex;
+                }
+
+                /* If we are the end of the history list, output a clear new line */
+
+                if ((CurrentCommandIndex + 1) > MaxCommandIndex)
+                {
+                    AcpiAcClearLine (EndOfLine, CursorPosition);
+                    EndOfLine = CursorPosition = 0;
+                    PreviousCommandIndex = CurrentCommandIndex;
+                    continue;
+                }
+
+                PreviousCommandIndex = CurrentCommandIndex;
+                CurrentCommandIndex++;
+
+                 /* Get the historical command from the debugger */
+
+                NextCommand = AcpiDbGetHistoryByIndex (CurrentCommandIndex);
+                if (!NextCommand)
+                {
+                    return (AE_ERROR);
+                }
+
+                /* Make this the active command and echo it */
+
+                AcpiAcClearLine (EndOfLine, CursorPosition);
+                strcpy (Buffer, NextCommand);
+                fprintf (stdout, "%s", Buffer);
+                EndOfLine = CursorPosition = strlen (Buffer);
+                continue;
+
+            case 0x31:
+            case 0x32:
+            case 0x33:
+            case 0x34:
+            case 0x35:
+            case 0x36:
+                /*
+                 * Ignore the various keys like insert/delete/home/end, etc.
+                 * But we must eat the final character of the ESC sequence.
+                 */
+                InputChar = getchar ();
+                continue;
+
+            default:
+
+                /* Ignore random escape sequences that we don't care about */
+
+                continue;
+            }
+            continue;
+        }
+    }
+}

--- a/sys/src/libacpi/acpica/common/adfile.c
+++ b/sys/src/libacpi/acpica/common/adfile.c
@@ -1,0 +1,430 @@
+/******************************************************************************
+ *
+ * Module Name: adfile - Application-level disassembler file support routines
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "aslcompiler.h"
+#include "acpi.h"
+#include "accommon.h"
+#include "acapps.h"
+
+#include <stdio.h>
+
+
+#define _COMPONENT          ACPI_TOOLS
+        ACPI_MODULE_NAME    ("adfile")
+
+/* Local prototypes */
+
+static INT32
+AdWriteBuffer (
+    char                    *Filename,
+    char                    *Buffer,
+    UINT32                  Length);
+
+static char                 FilenameBuf[20];
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AfGenerateFilename
+ *
+ * PARAMETERS:  Prefix              - prefix string
+ *              TableId             - The table ID
+ *
+ * RETURN:      Pointer to the completed string
+ *
+ * DESCRIPTION: Build an output filename from an ACPI table ID string
+ *
+ ******************************************************************************/
+
+char *
+AdGenerateFilename (
+    char                    *Prefix,
+    char                    *TableId)
+{
+    UINT32                  i;
+    UINT32                  j;
+
+
+    for (i = 0; Prefix[i]; i++)
+    {
+        FilenameBuf[i] = Prefix[i];
+    }
+
+    FilenameBuf[i] = '_';
+    i++;
+
+    for (j = 0; j < 8 && (TableId[j] != ' ') && (TableId[j] != 0); i++, j++)
+    {
+        FilenameBuf[i] = TableId[j];
+    }
+
+    FilenameBuf[i] = 0;
+    strcat (FilenameBuf, FILE_SUFFIX_BINARY_TABLE);
+    return (FilenameBuf);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AfWriteBuffer
+ *
+ * PARAMETERS:  Filename            - name of file
+ *              Buffer              - data to write
+ *              Length              - length of data
+ *
+ * RETURN:      Actual number of bytes written
+ *
+ * DESCRIPTION: Open a file and write out a single buffer
+ *
+ ******************************************************************************/
+
+static INT32
+AdWriteBuffer (
+    char                    *Filename,
+    char                    *Buffer,
+    UINT32                  Length)
+{
+    FILE                    *File;
+    ACPI_SIZE               Actual;
+
+
+    File = fopen (Filename, "wb");
+    if (!File)
+    {
+        printf ("Could not open file %s\n", Filename);
+        return (-1);
+    }
+
+    Actual = fwrite (Buffer, 1, (size_t) Length, File);
+    if (Actual != Length)
+    {
+        printf ("Could not write to file %s\n", Filename);
+    }
+
+    fclose (File);
+    return ((INT32) Actual);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AfWriteTable
+ *
+ * PARAMETERS:  Table               - pointer to the ACPI table
+ *              Length              - length of the table
+ *              TableName           - the table signature
+ *              OemTableID          - from the table header
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Dump the loaded tables to a file (or files)
+ *
+ ******************************************************************************/
+
+void
+AdWriteTable (
+    ACPI_TABLE_HEADER       *Table,
+    UINT32                  Length,
+    char                    *TableName,
+    char                    *OemTableId)
+{
+    char                    *Filename;
+
+
+    Filename = AdGenerateFilename (TableName, OemTableId);
+    AdWriteBuffer (Filename, (char *) Table, Length);
+
+    AcpiOsPrintf ("Table [%s] written to \"%s\"\n", TableName, Filename);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    FlGenerateFilename
+ *
+ * PARAMETERS:  InputFilename       - Original ASL source filename
+ *              Suffix              - New extension.
+ *
+ * RETURN:      New filename containing the original base + the new suffix
+ *
+ * DESCRIPTION: Generate a new filename from the ASL source filename and a new
+ *              extension. Used to create the *.LST, *.TXT, etc. files.
+ *
+ ******************************************************************************/
+
+char *
+FlGenerateFilename (
+    char                    *InputFilename,
+    char                    *Suffix)
+{
+    char                    *Position;
+    char                    *NewFilename;
+    char                    *DirectoryPosition;
+
+
+    /*
+     * Copy the original filename to a new buffer. Leave room for the worst
+     * case where we append the suffix, an added dot and the null terminator.
+     */
+    NewFilename = UtStringCacheCalloc ((ACPI_SIZE)
+        strlen (InputFilename) + strlen (Suffix) + 2);
+    if (!NewFilename)
+    {
+        return (NULL);
+    }
+
+    strcpy (NewFilename, InputFilename);
+
+    /* Try to find the last dot in the filename */
+
+    DirectoryPosition = strrchr (NewFilename, '/');
+    Position = strrchr (NewFilename, '.');
+
+    if (Position && (Position > DirectoryPosition))
+    {
+        /* Tack on the new suffix */
+
+        Position++;
+        *Position = 0;
+        strcat (Position, Suffix);
+    }
+    else
+    {
+        /* No dot, add one and then the suffix */
+
+        strcat (NewFilename, ".");
+        strcat (NewFilename, Suffix);
+    }
+
+    return (NewFilename);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    FlStrdup
+ *
+ * DESCRIPTION: Local strdup function
+ *
+ ******************************************************************************/
+
+static char *
+FlStrdup (
+    char                *String)
+{
+    char                *NewString;
+
+
+    NewString = UtStringCacheCalloc ((ACPI_SIZE) strlen (String) + 1);
+    if (!NewString)
+    {
+        return (NULL);
+    }
+
+    strcpy (NewString, String);
+    return (NewString);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    FlSplitInputPathname
+ *
+ * PARAMETERS:  InputFilename       - The user-specified ASL source file to be
+ *                                    compiled
+ *              OutDirectoryPath    - Where the directory path prefix is
+ *                                    returned
+ *              OutFilename         - Where the filename part is returned
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Split the input path into a directory and filename part
+ *              1) Directory part used to open include files
+ *              2) Filename part used to generate output filenames
+ *
+ ******************************************************************************/
+
+ACPI_STATUS
+FlSplitInputPathname (
+    char                    *InputPath,
+    char                    **OutDirectoryPath,
+    char                    **OutFilename)
+{
+    char                    *Substring;
+    char                    *DirectoryPath;
+    char                    *Filename;
+
+
+    if (OutDirectoryPath)
+    {
+        *OutDirectoryPath = NULL;
+    }
+
+    if (!InputPath)
+    {
+        return (AE_OK);
+    }
+
+    /* Get the path to the input filename's directory */
+
+    DirectoryPath = FlStrdup (InputPath);
+    if (!DirectoryPath)
+    {
+        return (AE_NO_MEMORY);
+    }
+
+    /* Convert backslashes to slashes in the entire path */
+
+    UtConvertBackslashes (DirectoryPath);
+
+    /* Backup to last slash or colon */
+
+    Substring = strrchr (DirectoryPath, '/');
+    if (!Substring)
+    {
+        Substring = strrchr (DirectoryPath, ':');
+    }
+
+    /* Extract the simple filename */
+
+    if (!Substring)
+    {
+        Filename = FlStrdup (DirectoryPath);
+        DirectoryPath[0] = 0;
+    }
+    else
+    {
+        Filename = FlStrdup (Substring + 1);
+        *(Substring+1) = 0;
+    }
+
+    if (!Filename)
+    {
+        return (AE_NO_MEMORY);
+    }
+
+    if (OutDirectoryPath)
+    {
+        *OutDirectoryPath = DirectoryPath;
+    }
+
+    if (OutFilename)
+    {
+        *OutFilename = Filename;
+        return (AE_OK);
+    }
+
+    return (AE_OK);
+}

--- a/sys/src/libacpi/acpica/common/adisasm.c
+++ b/sys/src/libacpi/acpica/common/adisasm.c
@@ -1,0 +1,728 @@
+/******************************************************************************
+ *
+ * Module Name: adisasm - Application-level disassembler routines
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "aslcompiler.h"
+#include "amlcode.h"
+#include "acdisasm.h"
+#include "acdispat.h"
+#include "acnamesp.h"
+#include "acparser.h"
+#include "acapps.h"
+
+#include <stdio.h>
+
+
+#define _COMPONENT          ACPI_TOOLS
+        ACPI_MODULE_NAME    ("adisasm")
+
+/* Local prototypes */
+
+static ACPI_STATUS
+AdDoExternalFileList (
+    char                    *Filename);
+
+static ACPI_STATUS
+AdDisassembleOneTable (
+    ACPI_TABLE_HEADER       *Table,
+    FILE                    *File,
+    char                    *Filename,
+    char                    *DisasmFilename);
+
+static ACPI_STATUS
+AdReparseOneTable (
+    ACPI_TABLE_HEADER       *Table,
+    FILE                    *File,
+    ACPI_OWNER_ID           OwnerId);
+
+
+ACPI_TABLE_DESC             LocalTables[1];
+ACPI_PARSE_OBJECT           *AcpiGbl_ParseOpRoot;
+
+
+/* Stubs for everything except ASL compiler */
+
+#ifndef ACPI_ASL_COMPILER
+BOOLEAN
+AcpiDsIsResultUsed (
+    ACPI_PARSE_OBJECT       *Op,
+    ACPI_WALK_STATE         *WalkState)
+{
+    return (TRUE);
+}
+
+ACPI_STATUS
+AcpiDsMethodError (
+    ACPI_STATUS             Status,
+    ACPI_WALK_STATE         *WalkState)
+{
+    return (Status);
+}
+#endif
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AdInitialize
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: ACPICA and local initialization
+ *
+ ******************************************************************************/
+
+ACPI_STATUS
+AdInitialize (
+    void)
+{
+    ACPI_STATUS             Status;
+
+
+    /* ACPICA subsystem initialization */
+
+    Status = AcpiOsInitialize ();
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    Status = AcpiUtInitGlobals ();
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    Status = AcpiUtMutexInitialize ();
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    Status = AcpiNsRootInitialize ();
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    /* Setup the Table Manager (cheat - there is no RSDT) */
+
+    AcpiGbl_RootTableList.MaxTableCount = 1;
+    AcpiGbl_RootTableList.CurrentTableCount = 0;
+    AcpiGbl_RootTableList.Tables = LocalTables;
+
+    return (Status);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AdAmlDisassemble
+ *
+ * PARAMETERS:  Filename            - AML input filename
+ *              OutToFile           - TRUE if output should go to a file
+ *              Prefix              - Path prefix for output
+ *              OutFilename         - where the filename is returned
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Disassembler entry point. Disassemble an entire ACPI table.
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AdAmlDisassemble (
+    BOOLEAN                 OutToFile,
+    char                    *Filename,
+    char                    *Prefix,
+    char                    **OutFilename)
+{
+    ACPI_STATUS             Status;
+    char                    *DisasmFilename = NULL;
+    FILE                    *File = NULL;
+    ACPI_TABLE_HEADER       *Table = NULL;
+    ACPI_NEW_TABLE_DESC     *ListHead = NULL;
+
+
+    /*
+     * Input: AML code from either a file or via GetTables (memory or
+     * registry)
+     */
+    if (Filename)
+    {
+        /* Get the list of all AML tables in the file */
+
+        Status = AcGetAllTablesFromFile (Filename,
+            ACPI_GET_ALL_TABLES, &ListHead);
+        if (ACPI_FAILURE (Status))
+        {
+            AcpiOsPrintf ("Could not get ACPI tables from %s, %s\n",
+                Filename, AcpiFormatException (Status));
+            return (Status);
+        }
+
+        /* Process any user-specified files for external objects */
+
+        Status = AdDoExternalFileList (Filename);
+        if (ACPI_FAILURE (Status))
+        {
+            return (Status);
+        }
+    }
+    else
+    {
+        Status = AdGetLocalTables ();
+        if (ACPI_FAILURE (Status))
+        {
+            AcpiOsPrintf ("Could not get ACPI tables, %s\n",
+                AcpiFormatException (Status));
+            return (Status);
+        }
+
+        if (!AcpiGbl_DmOpt_Disasm)
+        {
+            return (AE_OK);
+        }
+
+        /* Obtained the local tables, just disassemble the DSDT */
+
+        Status = AcpiGetTable (ACPI_SIG_DSDT, 0, &Table);
+        if (ACPI_FAILURE (Status))
+        {
+            AcpiOsPrintf ("Could not get DSDT, %s\n",
+                AcpiFormatException (Status));
+            return (Status);
+        }
+
+        AcpiOsPrintf ("\nDisassembly of DSDT\n");
+        Prefix = AdGenerateFilename ("dsdt", Table->OemTableId);
+    }
+
+    /*
+     * Output: ASL code. Redirect to a file if requested
+     */
+    if (OutToFile)
+    {
+        /* Create/Open a disassembly output file */
+
+        DisasmFilename = FlGenerateFilename (Prefix, FILE_SUFFIX_DISASSEMBLY);
+        if (!DisasmFilename)
+        {
+            fprintf (stderr, "Could not generate output filename\n");
+            Status = AE_ERROR;
+            goto Cleanup;
+        }
+
+        File = fopen (DisasmFilename, "w+");
+        if (!File)
+        {
+            fprintf (stderr, "Could not open output file %s\n",
+                DisasmFilename);
+            Status = AE_ERROR;
+            goto Cleanup;
+        }
+
+        AcpiOsRedirectOutput (File);
+    }
+
+    *OutFilename = DisasmFilename;
+
+    /* Disassemble all AML tables within the file */
+
+    while (ListHead)
+    {
+        Status = AdDisassembleOneTable (ListHead->Table,
+            File, Filename, DisasmFilename);
+        if (ACPI_FAILURE (Status))
+        {
+            break;
+        }
+
+        ListHead = ListHead->Next;
+    }
+
+Cleanup:
+
+    if (Table &&
+        !AcpiGbl_ForceAmlDisassembly &&
+        !AcpiUtIsAmlTable (Table))
+    {
+        ACPI_FREE (Table);
+    }
+
+    if (File)
+    {
+        fclose (File);
+        AcpiOsRedirectOutput (stdout);
+    }
+
+    AcpiPsDeleteParseTree (AcpiGbl_ParseOpRoot);
+    AcpiGbl_ParseOpRoot = NULL;
+    return (Status);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AdDisassembleOneTable
+ *
+ * PARAMETERS:  Table               - Raw AML table
+ *              File                - Pointer for the input file
+ *              Filename            - AML input filename
+ *              DisasmFilename      - Output filename
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Disassemble a single ACPI table. AML or data table.
+ *
+ *****************************************************************************/
+
+static ACPI_STATUS
+AdDisassembleOneTable (
+    ACPI_TABLE_HEADER       *Table,
+    FILE                    *File,
+    char                    *Filename,
+    char                    *DisasmFilename)
+{
+    ACPI_STATUS             Status;
+    ACPI_OWNER_ID           OwnerId;
+
+
+    /* ForceAmlDisassembly means to assume the table contains valid AML */
+
+    if (!AcpiGbl_ForceAmlDisassembly && !AcpiUtIsAmlTable (Table))
+    {
+        AdDisassemblerHeader (Filename, ACPI_IS_DATA_TABLE);
+
+        /* This is a "Data Table" (non-AML table) */
+
+        AcpiOsPrintf (" * ACPI Data Table [%4.4s]\n *\n",
+            Table->Signature);
+        AcpiOsPrintf (" * Format: [HexOffset DecimalOffset ByteLength]  "
+            "FieldName : FieldValue\n */\n\n");
+
+        AcpiDmDumpDataTable (Table);
+        fprintf (stderr, "Acpi Data Table [%4.4s] decoded\n",
+            Table->Signature);
+
+        if (File)
+        {
+            fprintf (stderr, "Formatted output:  %s - %u bytes\n",
+                DisasmFilename, CmGetFileSize (File));
+        }
+
+        return (AE_OK);
+    }
+
+    /*
+     * This is an AML table (DSDT or SSDT).
+     * Always parse the tables, only option is what to display
+     */
+    Status = AdParseTable (Table, &OwnerId, TRUE, FALSE);
+    if (ACPI_FAILURE (Status))
+    {
+        AcpiOsPrintf ("Could not parse ACPI tables, %s\n",
+            AcpiFormatException (Status));
+        return (Status);
+    }
+
+    /* Debug output, namespace and parse tree */
+
+    if (AslCompilerdebug && File)
+    {
+        AcpiOsPrintf ("/**** Before second load\n");
+
+        NsSetupNamespaceListing (File);
+        NsDisplayNamespace ();
+
+        AcpiOsPrintf ("*****/\n");
+    }
+
+    /* Load namespace from names created within control methods */
+
+    AcpiDmFinishNamespaceLoad (AcpiGbl_ParseOpRoot,
+        AcpiGbl_RootNode, OwnerId);
+
+    /*
+     * Cross reference the namespace here, in order to
+     * generate External() statements
+     */
+    AcpiDmCrossReferenceNamespace (AcpiGbl_ParseOpRoot,
+        AcpiGbl_RootNode, OwnerId);
+
+    if (AslCompilerdebug)
+    {
+        AcpiDmDumpTree (AcpiGbl_ParseOpRoot);
+    }
+
+    /* Find possible calls to external control methods */
+
+    AcpiDmFindOrphanMethods (AcpiGbl_ParseOpRoot);
+
+    /*
+     * If we found any external control methods, we must reparse
+     * the entire tree with the new information (namely, the
+     * number of arguments per method)
+     */
+    if (AcpiDmGetExternalMethodCount ())
+    {
+        Status = AdReparseOneTable (Table, File, OwnerId);
+        if (ACPI_FAILURE (Status))
+        {
+            return (Status);
+        }
+    }
+
+    /*
+     * Now that the namespace is finalized, we can perform namespace
+     * transforms.
+     *
+     * 1) Convert fixed-offset references to resource descriptors
+     *    to symbolic references (Note: modifies namespace)
+     */
+    AcpiDmConvertResourceIndexes (AcpiGbl_ParseOpRoot, AcpiGbl_RootNode);
+
+    /* Optional displays */
+
+    if (AcpiGbl_DmOpt_Disasm)
+    {
+        /* This is the real disassembly */
+
+        AdDisplayTables (Filename, Table);
+
+        /* Dump hex table if requested (-vt) */
+
+        AcpiDmDumpDataTable (Table);
+
+        fprintf (stderr, "Disassembly completed\n");
+        if (File)
+        {
+            fprintf (stderr, "ASL Output:    %s - %u bytes\n",
+                DisasmFilename, CmGetFileSize (File));
+        }
+
+        if (Gbl_MapfileFlag)
+        {
+            fprintf (stderr, "%14s %s - %u bytes\n",
+                Gbl_Files[ASL_FILE_MAP_OUTPUT].ShortDescription,
+                Gbl_Files[ASL_FILE_MAP_OUTPUT].Filename,
+                FlGetFileSize (ASL_FILE_MAP_OUTPUT));
+        }
+    }
+
+    return (AE_OK);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AdReparseOneTable
+ *
+ * PARAMETERS:  Table               - Raw AML table
+ *              File                - Pointer for the input file
+ *              OwnerId             - ID for this table
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Reparse a table that has already been loaded. Used to
+ *              integrate information about external control methods.
+ *              These methods may have been previously parsed incorrectly.
+ *
+ *****************************************************************************/
+
+static ACPI_STATUS
+AdReparseOneTable (
+    ACPI_TABLE_HEADER       *Table,
+    FILE                    *File,
+    ACPI_OWNER_ID           OwnerId)
+{
+    ACPI_STATUS             Status;
+
+
+    fprintf (stderr,
+        "\nFound %u external control methods, "
+        "reparsing with new information\n",
+        AcpiDmGetExternalMethodCount ());
+
+    /* Reparse, rebuild namespace */
+
+    AcpiPsDeleteParseTree (AcpiGbl_ParseOpRoot);
+    AcpiGbl_ParseOpRoot = NULL;
+    AcpiNsDeleteNamespaceSubtree (AcpiGbl_RootNode);
+
+    AcpiGbl_RootNode                    = NULL;
+    AcpiGbl_RootNodeStruct.Name.Integer = ACPI_ROOT_NAME;
+    AcpiGbl_RootNodeStruct.DescriptorType = ACPI_DESC_TYPE_NAMED;
+    AcpiGbl_RootNodeStruct.Type         = ACPI_TYPE_DEVICE;
+    AcpiGbl_RootNodeStruct.Parent       = NULL;
+    AcpiGbl_RootNodeStruct.Child        = NULL;
+    AcpiGbl_RootNodeStruct.Peer         = NULL;
+    AcpiGbl_RootNodeStruct.Object       = NULL;
+    AcpiGbl_RootNodeStruct.Flags        = 0;
+
+    Status = AcpiNsRootInitialize ();
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    /* New namespace, add the external definitions first */
+
+    AcpiDmAddExternalsToNamespace ();
+
+    /* Parse the table again. No need to reload it, however */
+
+    Status = AdParseTable (Table, NULL, FALSE, FALSE);
+    if (ACPI_FAILURE (Status))
+    {
+        AcpiOsPrintf ("Could not parse ACPI tables, %s\n",
+            AcpiFormatException (Status));
+        return (Status);
+    }
+
+    /* Cross reference the namespace again */
+
+    AcpiDmFinishNamespaceLoad (AcpiGbl_ParseOpRoot,
+        AcpiGbl_RootNode, OwnerId);
+
+    AcpiDmCrossReferenceNamespace (AcpiGbl_ParseOpRoot,
+        AcpiGbl_RootNode, OwnerId);
+
+    /* Debug output - namespace and parse tree */
+
+    if (AslCompilerdebug)
+    {
+        AcpiOsPrintf ("/**** After second load and resource conversion\n");
+        if (File)
+        {
+            NsSetupNamespaceListing (File);
+            NsDisplayNamespace ();
+        }
+
+        AcpiOsPrintf ("*****/\n");
+        AcpiDmDumpTree (AcpiGbl_ParseOpRoot);
+    }
+
+    return (AE_OK);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AdDoExternalFileList
+ *
+ * PARAMETERS:  Filename            - Input file for the table
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Process all tables found in the -e external files list
+ *
+ *****************************************************************************/
+
+static ACPI_STATUS
+AdDoExternalFileList (
+    char                    *Filename)
+{
+    ACPI_EXTERNAL_FILE      *ExternalFileList;
+    char                    *ExternalFilename;
+    ACPI_NEW_TABLE_DESC     *ExternalListHead = NULL;
+    ACPI_STATUS             Status;
+    ACPI_STATUS             GlobalStatus = AE_OK;
+    ACPI_OWNER_ID           OwnerId;
+
+
+    /*
+     * External filenames are specified on the command line like this:
+     * Example: iasl -e file1,file2,file3 -d xxx.aml
+     */
+    ExternalFileList = AcpiGbl_ExternalFileList;
+
+    /* Process each external file */
+
+    while (ExternalFileList)
+    {
+        ExternalFilename = ExternalFileList->Path;
+        if (!strcmp (ExternalFilename, Filename))
+        {
+            /* Next external file */
+
+            ExternalFileList = ExternalFileList->Next;
+            continue;
+        }
+
+        AcpiOsPrintf ("External object resolution file %16s\n",
+            ExternalFilename);
+
+        Status = AcGetAllTablesFromFile (
+            ExternalFilename, ACPI_GET_ONLY_AML_TABLES, &ExternalListHead);
+        if (ACPI_FAILURE (Status))
+        {
+            if (Status == AE_TYPE)
+            {
+                ExternalFileList = ExternalFileList->Next;
+                GlobalStatus = AE_TYPE;
+                Status = AE_OK;
+                continue;
+            }
+
+            return (Status);
+        }
+
+        /* Load external tables for symbol resolution */
+
+        while (ExternalListHead)
+        {
+            Status = AdParseTable (
+                ExternalListHead->Table, &OwnerId, TRUE, TRUE);
+            if (ACPI_FAILURE (Status))
+            {
+                AcpiOsPrintf ("Could not parse external ACPI tables, %s\n",
+                    AcpiFormatException (Status));
+                return (Status);
+            }
+
+            /*
+             * Load namespace from names created within control methods
+             * Set owner id of nodes in external table
+             */
+            AcpiDmFinishNamespaceLoad (AcpiGbl_ParseOpRoot,
+                AcpiGbl_RootNode, OwnerId);
+            AcpiPsDeleteParseTree (AcpiGbl_ParseOpRoot);
+
+            ExternalListHead = ExternalListHead->Next;
+        }
+
+        /* Next external file */
+
+        ExternalFileList = ExternalFileList->Next;
+    }
+
+    if (ACPI_FAILURE (GlobalStatus))
+    {
+        return (GlobalStatus);
+    }
+
+    /* Clear external list generated by Scope in external tables */
+
+    if (AcpiGbl_ExternalFileList)
+    {
+        AcpiDmClearExternalList ();
+    }
+
+    /* Load any externals defined in the optional external ref file */
+
+    AcpiDmGetExternalsFromFile ();
+    return (AE_OK);
+}

--- a/sys/src/libacpi/acpica/common/adwalk.c
+++ b/sys/src/libacpi/acpica/common/adwalk.c
@@ -1,0 +1,1210 @@
+/******************************************************************************
+ *
+ * Module Name: adwalk - Application-level disassembler parse tree walk routines
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+#include "acparser.h"
+#include "amlcode.h"
+#include "acdisasm.h"
+#include "acdispat.h"
+#include "acnamesp.h"
+#include "acapps.h"
+
+
+#define _COMPONENT          ACPI_TOOLS
+        ACPI_MODULE_NAME    ("adwalk")
+
+/*
+ * aslmap - opcode mappings and reserved method names
+ */
+ACPI_OBJECT_TYPE
+AslMapNamedOpcodeToDataType (
+    UINT16                  Opcode);
+
+/* Local prototypes */
+
+static ACPI_STATUS
+AcpiDmFindOrphanDescending (
+    ACPI_PARSE_OBJECT       *Op,
+    UINT32                  Level,
+    void                    *Context);
+
+static ACPI_STATUS
+AcpiDmDumpDescending (
+    ACPI_PARSE_OBJECT       *Op,
+    UINT32                  Level,
+    void                    *Context);
+
+static ACPI_STATUS
+AcpiDmXrefDescendingOp (
+    ACPI_PARSE_OBJECT       *Op,
+    UINT32                  Level,
+    void                    *Context);
+
+static ACPI_STATUS
+AcpiDmCommonAscendingOp (
+    ACPI_PARSE_OBJECT       *Op,
+    UINT32                  Level,
+    void                    *Context);
+
+static ACPI_STATUS
+AcpiDmLoadDescendingOp (
+    ACPI_PARSE_OBJECT       *Op,
+    UINT32                  Level,
+    void                    *Context);
+
+static UINT32
+AcpiDmInspectPossibleArgs (
+    UINT32                  CurrentOpArgCount,
+    UINT32                  TargetCount,
+    ACPI_PARSE_OBJECT       *Op);
+
+static ACPI_STATUS
+AcpiDmResourceDescendingOp (
+    ACPI_PARSE_OBJECT       *Op,
+    UINT32                  Level,
+    void                    *Context);
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpTree
+ *
+ * PARAMETERS:  Origin              - Starting object
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Parse tree walk to format and output the nodes
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpTree (
+    ACPI_PARSE_OBJECT       *Origin)
+{
+    ACPI_OP_WALK_INFO       Info;
+
+
+    if (!Origin)
+    {
+        return;
+    }
+
+    AcpiOsPrintf ("/*\nAML Parse Tree\n\n");
+    Info.Flags = 0;
+    Info.Count = 0;
+    Info.Level = 0;
+    Info.WalkState = NULL;
+
+    AcpiDmWalkParseTree (Origin, AcpiDmDumpDescending, NULL, &Info);
+    AcpiOsPrintf ("*/\n\n");
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmFindOrphanMethods
+ *
+ * PARAMETERS:  Origin              - Starting object
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Parse tree walk to find "orphaned" method invocations -- methods
+ *              that are not resolved in the namespace
+ *
+ ******************************************************************************/
+
+void
+AcpiDmFindOrphanMethods (
+    ACPI_PARSE_OBJECT       *Origin)
+{
+    ACPI_OP_WALK_INFO       Info;
+
+
+    if (!Origin)
+    {
+        return;
+    }
+
+    Info.Flags = 0;
+    Info.Level = 0;
+    Info.WalkState = NULL;
+
+    AcpiDmWalkParseTree (Origin, AcpiDmFindOrphanDescending, NULL, &Info);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmFinishNamespaceLoad
+ *
+ * PARAMETERS:  ParseTreeRoot       - Root of the parse tree
+ *              NamespaceRoot       - Root of the internal namespace
+ *              OwnerId             - OwnerId of the table to be disassembled
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Load all namespace items that are created within control
+ *              methods. Used before namespace cross reference
+ *
+ ******************************************************************************/
+
+void
+AcpiDmFinishNamespaceLoad (
+    ACPI_PARSE_OBJECT       *ParseTreeRoot,
+    ACPI_NAMESPACE_NODE     *NamespaceRoot,
+    ACPI_OWNER_ID           OwnerId)
+{
+    ACPI_STATUS             Status;
+    ACPI_OP_WALK_INFO       Info;
+    ACPI_WALK_STATE         *WalkState;
+
+
+    if (!ParseTreeRoot)
+    {
+        return;
+    }
+
+    /* Create and initialize a new walk state */
+
+    WalkState = AcpiDsCreateWalkState (OwnerId, ParseTreeRoot, NULL, NULL);
+    if (!WalkState)
+    {
+        return;
+    }
+
+    Status = AcpiDsScopeStackPush (NamespaceRoot, NamespaceRoot->Type,
+        WalkState);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    Info.Flags = 0;
+    Info.Level = 0;
+    Info.WalkState = WalkState;
+
+    AcpiDmWalkParseTree (ParseTreeRoot, AcpiDmLoadDescendingOp,
+        AcpiDmCommonAscendingOp, &Info);
+    ACPI_FREE (WalkState);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmCrossReferenceNamespace
+ *
+ * PARAMETERS:  ParseTreeRoot       - Root of the parse tree
+ *              NamespaceRoot       - Root of the internal namespace
+ *              OwnerId             - OwnerId of the table to be disassembled
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Cross reference the namespace to create externals
+ *
+ ******************************************************************************/
+
+void
+AcpiDmCrossReferenceNamespace (
+    ACPI_PARSE_OBJECT       *ParseTreeRoot,
+    ACPI_NAMESPACE_NODE     *NamespaceRoot,
+    ACPI_OWNER_ID           OwnerId)
+{
+    ACPI_STATUS             Status;
+    ACPI_OP_WALK_INFO       Info;
+    ACPI_WALK_STATE         *WalkState;
+
+
+    if (!ParseTreeRoot)
+    {
+        return;
+    }
+
+    /* Create and initialize a new walk state */
+
+    WalkState = AcpiDsCreateWalkState (OwnerId, ParseTreeRoot, NULL, NULL);
+    if (!WalkState)
+    {
+        return;
+    }
+
+    Status = AcpiDsScopeStackPush (NamespaceRoot, NamespaceRoot->Type,
+        WalkState);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    Info.Flags = 0;
+    Info.Level = 0;
+    Info.WalkState = WalkState;
+
+    AcpiDmWalkParseTree (ParseTreeRoot, AcpiDmXrefDescendingOp,
+        AcpiDmCommonAscendingOp, &Info);
+    ACPI_FREE (WalkState);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmConvertResourceIndexes
+ *
+ * PARAMETERS:  ParseTreeRoot       - Root of the parse tree
+ *              NamespaceRoot       - Root of the internal namespace
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Convert fixed-offset references to resource descriptors to
+ *              symbolic references. Should only be called after namespace has
+ *              been cross referenced.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmConvertResourceIndexes (
+    ACPI_PARSE_OBJECT       *ParseTreeRoot,
+    ACPI_NAMESPACE_NODE     *NamespaceRoot)
+{
+    ACPI_STATUS             Status;
+    ACPI_OP_WALK_INFO       Info;
+    ACPI_WALK_STATE         *WalkState;
+
+
+    if (!ParseTreeRoot)
+    {
+        return;
+    }
+
+    /* Create and initialize a new walk state */
+
+    WalkState = AcpiDsCreateWalkState (0, ParseTreeRoot, NULL, NULL);
+    if (!WalkState)
+    {
+        return;
+    }
+
+    Status = AcpiDsScopeStackPush (NamespaceRoot, NamespaceRoot->Type,
+        WalkState);
+    if (ACPI_FAILURE (Status))
+    {
+        ACPI_FREE (WalkState);
+        return;
+    }
+
+    Info.Flags = 0;
+    Info.Level = 0;
+    Info.WalkState = WalkState;
+
+    AcpiDmWalkParseTree (ParseTreeRoot, AcpiDmResourceDescendingOp,
+        AcpiDmCommonAscendingOp, &Info);
+    ACPI_FREE (WalkState);
+    return;
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpDescending
+ *
+ * PARAMETERS:  ASL_WALK_CALLBACK
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Format and print contents of one parse Op.
+ *
+ ******************************************************************************/
+
+static ACPI_STATUS
+AcpiDmDumpDescending (
+    ACPI_PARSE_OBJECT       *Op,
+    UINT32                  Level,
+    void                    *Context)
+{
+    ACPI_OP_WALK_INFO       *Info = Context;
+    char                    *Path;
+
+
+    if (!Op)
+    {
+        return (AE_OK);
+    }
+
+    /* Most of the information (count, level, name) here */
+
+    Info->Count++;
+    AcpiOsPrintf ("% 5d [%2.2d] ", Info->Count, Level);
+    AcpiDmIndent (Level);
+    AcpiOsPrintf ("%-28s", AcpiPsGetOpcodeName (Op->Common.AmlOpcode));
+
+    /* Extra info is helpful */
+
+    switch (Op->Common.AmlOpcode)
+    {
+    case AML_BYTE_OP:
+
+        AcpiOsPrintf ("%2.2X", (UINT32) Op->Common.Value.Integer);
+        break;
+
+    case AML_WORD_OP:
+
+        AcpiOsPrintf ("%4.4X", (UINT32) Op->Common.Value.Integer);
+        break;
+
+    case AML_DWORD_OP:
+
+        AcpiOsPrintf ("%8.8X", (UINT32) Op->Common.Value.Integer);
+        break;
+
+    case AML_QWORD_OP:
+
+        AcpiOsPrintf ("%8.8X%8.8X", ACPI_FORMAT_UINT64 (Op->Common.Value.Integer));
+        break;
+
+    case AML_INT_NAMEPATH_OP:
+
+        if (Op->Common.Value.String)
+        {
+            AcpiNsExternalizeName (ACPI_UINT32_MAX, Op->Common.Value.String,
+                NULL, &Path);
+            AcpiOsPrintf ("%s %p", Path, Op->Common.Node);
+            ACPI_FREE (Path);
+        }
+        else
+        {
+            AcpiOsPrintf ("[NULL]");
+        }
+        break;
+
+    case AML_NAME_OP:
+    case AML_METHOD_OP:
+    case AML_DEVICE_OP:
+    case AML_INT_NAMEDFIELD_OP:
+
+        AcpiOsPrintf ("%4.4s", ACPI_CAST_PTR (char, &Op->Named.Name));
+        break;
+
+    default:
+
+        break;
+    }
+
+    AcpiOsPrintf ("\n");
+    return (AE_OK);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmFindOrphanDescending
+ *
+ * PARAMETERS:  ASL_WALK_CALLBACK
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Check namepath Ops for orphaned method invocations
+ *
+ * Note: Parts of this are experimental, under possible further development.
+ *
+ ******************************************************************************/
+
+static ACPI_STATUS
+AcpiDmFindOrphanDescending (
+    ACPI_PARSE_OBJECT       *Op,
+    UINT32                  Level,
+    void                    *Context)
+{
+    const ACPI_OPCODE_INFO  *OpInfo;
+    ACPI_PARSE_OBJECT       *ChildOp;
+    ACPI_PARSE_OBJECT       *NextOp;
+    ACPI_PARSE_OBJECT       *ParentOp;
+    UINT32                  ArgCount;
+
+
+    if (!Op)
+    {
+        return (AE_OK);
+    }
+
+    OpInfo = AcpiPsGetOpcodeInfo (Op->Common.AmlOpcode);
+
+    switch (Op->Common.AmlOpcode)
+    {
+#ifdef ACPI_UNDER_DEVELOPMENT
+    case AML_ADD_OP:
+
+        ChildOp = Op->Common.Value.Arg;
+        if ((ChildOp->Common.AmlOpcode == AML_INT_NAMEPATH_OP) &&
+            !ChildOp->Common.Node)
+        {
+            AcpiNsExternalizeName (ACPI_UINT32_MAX, ChildOp->Common.Value.String,
+                NULL, &Path);
+            AcpiOsPrintf ("/* %-16s A-NAMEPATH: %s  */\n",
+                Op->Common.AmlOpName, Path);
+            ACPI_FREE (Path);
+
+            NextOp = Op->Common.Next;
+            if (!NextOp)
+            {
+                /* This NamePath has no args, assume it is an integer */
+
+                AcpiDmAddOpToExternalList (ChildOp,
+                    ChildOp->Common.Value.String, ACPI_TYPE_INTEGER, 0, 0);
+                return (AE_OK);
+            }
+
+            ArgCount = AcpiDmInspectPossibleArgs (3, 1, NextOp);
+            AcpiOsPrintf ("/* A-CHILDREN: %u Actual %u */\n",
+                ArgCount, AcpiDmCountChildren (Op));
+
+            if (ArgCount < 1)
+            {
+                /* One Arg means this is just a Store(Name,Target) */
+
+                AcpiDmAddOpToExternalList (ChildOp,
+                    ChildOp->Common.Value.String, ACPI_TYPE_INTEGER, 0, 0);
+                return (AE_OK);
+            }
+
+            AcpiDmAddOpToExternalList (ChildOp,
+                ChildOp->Common.Value.String, ACPI_TYPE_METHOD, ArgCount, 0);
+        }
+        break;
+
+#endif
+
+    case AML_STORE_OP:
+
+        ChildOp = Op->Common.Value.Arg;
+        if ((ChildOp->Common.AmlOpcode == AML_INT_NAMEPATH_OP) &&
+            !ChildOp->Common.Node)
+        {
+            NextOp = Op->Common.Next;
+            if (!NextOp)
+            {
+                /* This NamePath has no args, assume it is an integer */
+
+                AcpiDmAddOpToExternalList (ChildOp,
+                    ChildOp->Common.Value.String, ACPI_TYPE_INTEGER, 0, 0);
+                return (AE_OK);
+            }
+
+            ArgCount = AcpiDmInspectPossibleArgs (2, 1, NextOp);
+            if (ArgCount <= 1)
+            {
+                /* One Arg means this is just a Store(Name,Target) */
+
+                AcpiDmAddOpToExternalList (ChildOp,
+                    ChildOp->Common.Value.String, ACPI_TYPE_INTEGER, ArgCount, 0);
+                return (AE_OK);
+            }
+
+            AcpiDmAddOpToExternalList (ChildOp,
+                ChildOp->Common.Value.String, ACPI_TYPE_METHOD, ArgCount, 0);
+        }
+        break;
+
+    case AML_INT_NAMEPATH_OP:
+
+        /* Must examine parent to see if this namepath is an argument */
+
+        ParentOp = Op->Common.Parent;
+        OpInfo = AcpiPsGetOpcodeInfo (ParentOp->Common.AmlOpcode);
+
+        if ((OpInfo->Class != AML_CLASS_EXECUTE) &&
+            (OpInfo->Class != AML_CLASS_CREATE) &&
+            (OpInfo->ObjectType != ACPI_TYPE_LOCAL_ALIAS) &&
+            (ParentOp->Common.AmlOpcode != AML_INT_METHODCALL_OP) &&
+            !Op->Common.Node)
+        {
+            ArgCount = AcpiDmInspectPossibleArgs (0, 0, Op);
+
+            /*
+             * Check if namepath is a predicate for if/while or lone parameter to
+             * a return.
+             */
+            if (ArgCount == 0)
+            {
+                if (((ParentOp->Common.AmlOpcode == AML_IF_OP) ||
+                     (ParentOp->Common.AmlOpcode == AML_WHILE_OP) ||
+                     (ParentOp->Common.AmlOpcode == AML_RETURN_OP)) &&
+
+                     /* And namepath is the first argument */
+                     (ParentOp->Common.Value.Arg == Op))
+                {
+                    AcpiDmAddOpToExternalList (Op,
+                        Op->Common.Value.String, ACPI_TYPE_INTEGER, 0, 0);
+                    break;
+                }
+            }
+
+            /*
+             * This is a standalone namestring (not a parameter to another
+             * operator) - it *must* be a method invocation, nothing else is
+             * grammatically possible.
+             */
+            AcpiDmAddOpToExternalList (Op,
+                Op->Common.Value.String, ACPI_TYPE_METHOD, ArgCount, 0);
+        }
+        break;
+
+    default:
+
+        break;
+    }
+
+    return (AE_OK);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmLoadDescendingOp
+ *
+ * PARAMETERS:  ASL_WALK_CALLBACK
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Descending handler for namespace control method object load
+ *
+ ******************************************************************************/
+
+static ACPI_STATUS
+AcpiDmLoadDescendingOp (
+    ACPI_PARSE_OBJECT       *Op,
+    UINT32                  Level,
+    void                    *Context)
+{
+    ACPI_OP_WALK_INFO       *Info = Context;
+    const ACPI_OPCODE_INFO  *OpInfo;
+    ACPI_WALK_STATE         *WalkState;
+    ACPI_OBJECT_TYPE        ObjectType;
+    ACPI_STATUS             Status;
+    char                    *Path = NULL;
+    ACPI_PARSE_OBJECT       *NextOp;
+    ACPI_NAMESPACE_NODE     *Node;
+    char                    FieldPath[5];
+    BOOLEAN                 PreDefined = FALSE;
+    UINT8                   PreDefineIndex = 0;
+
+
+    WalkState = Info->WalkState;
+    OpInfo = AcpiPsGetOpcodeInfo (Op->Common.AmlOpcode);
+    ObjectType = OpInfo->ObjectType;
+    ObjectType = AslMapNamedOpcodeToDataType (Op->Asl.AmlOpcode);
+
+    /* Only interested in operators that create new names */
+
+    if (!(OpInfo->Flags & AML_NAMED) &&
+        !(OpInfo->Flags & AML_CREATE))
+    {
+        goto Exit;
+    }
+
+    /* Get the NamePath from the appropriate place */
+
+    if (OpInfo->Flags & AML_NAMED)
+    {
+        /* For all named operators, get the new name */
+
+        Path = (char *) Op->Named.Path;
+
+        if (!Path && Op->Common.AmlOpcode == AML_INT_NAMEDFIELD_OP)
+        {
+            *ACPI_CAST_PTR (UINT32, &FieldPath[0]) = Op->Named.Name;
+            FieldPath[4] = 0;
+            Path = FieldPath;
+        }
+    }
+    else if (OpInfo->Flags & AML_CREATE)
+    {
+        /* New name is the last child */
+
+        NextOp = Op->Common.Value.Arg;
+
+        while (NextOp->Common.Next)
+        {
+            NextOp = NextOp->Common.Next;
+        }
+
+        Path = NextOp->Common.Value.String;
+    }
+
+    if (!Path)
+    {
+        goto Exit;
+    }
+
+    /* Insert the name into the namespace */
+
+    Status = AcpiNsLookup (WalkState->ScopeInfo, Path, ObjectType,
+        ACPI_IMODE_LOAD_PASS2, ACPI_NS_DONT_OPEN_SCOPE,
+        WalkState, &Node);
+
+    Op->Common.Node = Node;
+
+    if (ACPI_SUCCESS (Status))
+    {
+        /* Check if it's a predefined node */
+
+        while (AcpiGbl_PreDefinedNames[PreDefineIndex].Name)
+        {
+            if (ACPI_COMPARE_NAME (Node->Name.Ascii,
+                AcpiGbl_PreDefinedNames[PreDefineIndex].Name))
+            {
+                PreDefined = TRUE;
+                break;
+            }
+
+            PreDefineIndex++;
+        }
+
+        /*
+         * Set node owner id if it satisfies all the following conditions:
+         * 1) Not a predefined node, _SB_ etc
+         * 2) Not the root node
+         * 3) Not a node created by Scope
+         */
+
+        if (!PreDefined && Node != AcpiGbl_RootNode &&
+            Op->Common.AmlOpcode != AML_SCOPE_OP)
+        {
+            Node->OwnerId = WalkState->OwnerId;
+        }
+    }
+
+
+Exit:
+
+    if (AcpiNsOpensScope (ObjectType))
+    {
+        if (Op->Common.Node)
+        {
+            Status = AcpiDsScopeStackPush (Op->Common.Node, ObjectType,
+                WalkState);
+            if (ACPI_FAILURE (Status))
+            {
+                return (Status);
+            }
+        }
+    }
+
+    return (AE_OK);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmXrefDescendingOp
+ *
+ * PARAMETERS:  ASL_WALK_CALLBACK
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Descending handler for namespace cross reference
+ *
+ ******************************************************************************/
+
+static ACPI_STATUS
+AcpiDmXrefDescendingOp (
+    ACPI_PARSE_OBJECT       *Op,
+    UINT32                  Level,
+    void                    *Context)
+{
+    ACPI_OP_WALK_INFO       *Info = Context;
+    const ACPI_OPCODE_INFO  *OpInfo;
+    ACPI_WALK_STATE         *WalkState;
+    ACPI_OBJECT_TYPE        ObjectType;
+    ACPI_OBJECT_TYPE        ObjectType2;
+    ACPI_STATUS             Status;
+    char                    *Path = NULL;
+    ACPI_PARSE_OBJECT       *NextOp;
+    ACPI_NAMESPACE_NODE     *Node;
+    ACPI_OPERAND_OBJECT     *Object;
+    UINT32                  ParamCount = 0;
+    char                    *Pathname;
+    UINT16                  Flags = 0;
+
+
+    WalkState = Info->WalkState;
+    OpInfo = AcpiPsGetOpcodeInfo (Op->Common.AmlOpcode);
+    ObjectType = OpInfo->ObjectType;
+    ObjectType = AslMapNamedOpcodeToDataType (Op->Asl.AmlOpcode);
+
+    if ((!(OpInfo->Flags & AML_NAMED)) &&
+        (!(OpInfo->Flags & AML_CREATE)) &&
+        (Op->Common.AmlOpcode != AML_INT_NAMEPATH_OP) &&
+        (Op->Common.AmlOpcode != AML_NOTIFY_OP))
+    {
+        goto Exit;
+    }
+    else if (Op->Common.Parent &&
+             Op->Common.Parent->Common.AmlOpcode == AML_EXTERNAL_OP)
+    {
+        /* External() NamePath */
+
+        Path = Op->Common.Value.String;
+        ObjectType = (ACPI_OBJECT_TYPE) Op->Common.Next->Common.Value.Integer;
+        if (ObjectType == ACPI_TYPE_METHOD)
+        {
+            ParamCount = (UINT32)
+                Op->Common.Next->Common.Next->Common.Value.Integer;
+        }
+
+        Flags |= ACPI_EXT_RESOLVED_REFERENCE | ACPI_EXT_ORIGIN_FROM_OPCODE;
+        AcpiDmAddOpToExternalList (Op, Path,
+            (UINT8) ObjectType, ParamCount, Flags);
+
+        goto Exit;
+    }
+
+    /* Get the NamePath from the appropriate place */
+
+    if (OpInfo->Flags & AML_NAMED)
+    {
+        /*
+         * Only these two operators (Alias, Scope) refer to an existing
+         * name, it is the first argument
+         */
+        if (Op->Common.AmlOpcode == AML_ALIAS_OP)
+        {
+            ObjectType = ACPI_TYPE_ANY;
+
+            NextOp = Op->Common.Value.Arg;
+            NextOp = NextOp->Common.Value.Arg;
+            if (NextOp->Common.AmlOpcode == AML_INT_NAMEPATH_OP)
+            {
+                Path = NextOp->Common.Value.String;
+            }
+        }
+        else if (Op->Common.AmlOpcode == AML_SCOPE_OP)
+        {
+            Path = (char *) Op->Named.Path;
+        }
+    }
+    else if (OpInfo->Flags & AML_CREATE)
+    {
+        /* Referenced Buffer Name is the first child */
+
+        ObjectType = ACPI_TYPE_BUFFER; /* Change from TYPE_BUFFER_FIELD */
+
+        NextOp = Op->Common.Value.Arg;
+        if (NextOp->Common.AmlOpcode == AML_INT_NAMEPATH_OP)
+        {
+            Path = NextOp->Common.Value.String;
+        }
+    }
+    else if (Op->Common.AmlOpcode == AML_NOTIFY_OP)
+    {
+        Path = Op->Common.Value.Arg->Asl.Value.String;
+    }
+    else
+    {
+        Path = Op->Common.Value.String;
+    }
+
+    if (!Path)
+    {
+        goto Exit;
+    }
+
+    /*
+     * Lookup the name in the namespace. Name must exist at this point, or it
+     * is an invalid reference.
+     *
+     * The namespace is also used as a lookup table for references to resource
+     * descriptors and the fields within them.
+     */
+    Node = NULL;
+    Status = AcpiNsLookup (WalkState->ScopeInfo, Path, ACPI_TYPE_ANY,
+        ACPI_IMODE_EXECUTE, ACPI_NS_SEARCH_PARENT | ACPI_NS_DONT_OPEN_SCOPE,
+        WalkState, &Node);
+
+    if (ACPI_SUCCESS (Status) && (Node->Flags & ANOBJ_IS_EXTERNAL))
+    {
+        /* Node was created by an External() statement */
+
+        Status = AE_NOT_FOUND;
+    }
+
+    if (ACPI_FAILURE (Status))
+    {
+        if (Status == AE_NOT_FOUND)
+        {
+            /*
+             * Add this symbol as an external declaration, except if the
+             * parent is a CondRefOf operator. For this operator, we do not
+             * need an external, nor do we want one, since this can cause
+             * disassembly problems if the symbol is actually a control
+             * method.
+             */
+            if (!(Op->Asl.Parent &&
+                (Op->Asl.Parent->Asl.AmlOpcode == AML_COND_REF_OF_OP)))
+            {
+                if (Node)
+                {
+                    AcpiDmAddNodeToExternalList (Node,
+                        (UINT8) ObjectType, 7, Flags);
+                }
+                else
+                {
+                    AcpiDmAddOpToExternalList (Op, Path,
+                        (UINT8) ObjectType, 7, Flags);
+                }
+            }
+        }
+    }
+
+    /*
+     * Found the node, but check if it came from an external table.
+     * Add it to external list. Note: Node->OwnerId == 0 indicates
+     * one of the built-in ACPI Names (_OS_ etc.) which can safely
+     * be ignored.
+     */
+    else if (Node->OwnerId &&
+            (WalkState->OwnerId != Node->OwnerId))
+    {
+        ObjectType2 = ObjectType;
+
+        Object = AcpiNsGetAttachedObject (Node);
+        if (Object)
+        {
+            ObjectType2 = Object->Common.Type;
+            if (ObjectType2 == ACPI_TYPE_METHOD)
+            {
+                ParamCount = Object->Method.ParamCount;
+            }
+        }
+
+        Pathname = AcpiNsGetExternalPathname (Node);
+        if (!Pathname)
+        {
+            return (AE_NO_MEMORY);
+        }
+
+        AcpiDmAddNodeToExternalList (Node, (UINT8) ObjectType2,
+            ParamCount, ACPI_EXT_RESOLVED_REFERENCE);
+
+        ACPI_FREE (Pathname);
+        Op->Common.Node = Node;
+    }
+    else
+    {
+        Op->Common.Node = Node;
+    }
+
+
+Exit:
+    /* Open new scope if necessary */
+
+    if (AcpiNsOpensScope (ObjectType))
+    {
+        if (Op->Common.Node)
+        {
+            Status = AcpiDsScopeStackPush (Op->Common.Node, ObjectType,
+                WalkState);
+            if (ACPI_FAILURE (Status))
+            {
+                return (Status);
+            }
+        }
+    }
+
+    return (AE_OK);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmResourceDescendingOp
+ *
+ * PARAMETERS:  ASL_WALK_CALLBACK
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Process one parse op during symbolic resource index conversion.
+ *
+ ******************************************************************************/
+
+static ACPI_STATUS
+AcpiDmResourceDescendingOp (
+    ACPI_PARSE_OBJECT       *Op,
+    UINT32                  Level,
+    void                    *Context)
+{
+    ACPI_OP_WALK_INFO       *Info = Context;
+    const ACPI_OPCODE_INFO  *OpInfo;
+    ACPI_WALK_STATE         *WalkState;
+    ACPI_OBJECT_TYPE        ObjectType;
+    ACPI_STATUS             Status;
+
+
+    WalkState = Info->WalkState;
+    OpInfo = AcpiPsGetOpcodeInfo (Op->Common.AmlOpcode);
+
+    /* Open new scope if necessary */
+
+    ObjectType = OpInfo->ObjectType;
+    if (AcpiNsOpensScope (ObjectType))
+    {
+        if (Op->Common.Node)
+        {
+
+            Status = AcpiDsScopeStackPush (Op->Common.Node, ObjectType,
+                WalkState);
+            if (ACPI_FAILURE (Status))
+            {
+                return (Status);
+            }
+        }
+    }
+
+    /*
+     * Check if this operator contains a reference to a resource descriptor.
+     * If so, convert the reference into a symbolic reference.
+     */
+    AcpiDmCheckResourceReference (Op, WalkState);
+    return (AE_OK);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmCommonAscendingOp
+ *
+ * PARAMETERS:  ASL_WALK_CALLBACK
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Ascending handler for combined parse/namespace walks. Closes
+ *              scope if necessary.
+ *
+ ******************************************************************************/
+
+static ACPI_STATUS
+AcpiDmCommonAscendingOp (
+    ACPI_PARSE_OBJECT       *Op,
+    UINT32                  Level,
+    void                    *Context)
+{
+    ACPI_OP_WALK_INFO       *Info = Context;
+    const ACPI_OPCODE_INFO  *OpInfo;
+    ACPI_OBJECT_TYPE        ObjectType;
+
+
+    /* Close scope if necessary */
+
+    OpInfo = AcpiPsGetOpcodeInfo (Op->Common.AmlOpcode);
+    ObjectType = OpInfo->ObjectType;
+    ObjectType = AslMapNamedOpcodeToDataType (Op->Asl.AmlOpcode);
+
+    if (AcpiNsOpensScope (ObjectType))
+    {
+        (void) AcpiDsScopeStackPop (Info->WalkState);
+    }
+
+    return (AE_OK);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmInspectPossibleArgs
+ *
+ * PARAMETERS:  CurrentOpArgCount   - Which arg of the current op was the
+ *                                    possible method invocation found
+ *              TargetCount         - Number of targets (0,1,2) for this op
+ *              Op                  - Parse op
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Examine following args and next ops for possible arguments
+ *              for an unrecognized method invocation.
+ *
+ ******************************************************************************/
+
+static UINT32
+AcpiDmInspectPossibleArgs (
+    UINT32                  CurrentOpArgCount,
+    UINT32                  TargetCount,
+    ACPI_PARSE_OBJECT       *Op)
+{
+    const ACPI_OPCODE_INFO  *OpInfo;
+    UINT32                  i;
+    UINT32                  ArgumentCount = 0;
+    ACPI_PARSE_OBJECT       *NextOp;
+    ACPI_PARSE_OBJECT       *ExecuteOp;
+
+
+    if (!Op)
+    {
+        return (0);
+    }
+
+    /* Lookahead for the maximum number of possible arguments */
+
+    NextOp = Op->Common.Next;
+
+    for (i = 0; (i < ACPI_METHOD_NUM_ARGS) && NextOp; i++)
+    {
+        OpInfo = AcpiPsGetOpcodeInfo (NextOp->Common.AmlOpcode);
+
+        /* Any one of these operators is "very probably" not a method arg */
+
+        if ((NextOp->Common.AmlOpcode == AML_STORE_OP) ||
+            (NextOp->Common.AmlOpcode == AML_NOTIFY_OP) ||
+            (OpInfo->Class == AML_CLASS_CONTROL) ||
+            (OpInfo->Class == AML_CLASS_CREATE) ||
+            (OpInfo->Class == AML_CLASS_NAMED_OBJECT))
+        {
+            break;
+        }
+
+        if (OpInfo->Class == AML_CLASS_EXECUTE)
+        {
+            /* Probable that this is method arg if there is no target */
+
+            ExecuteOp = NextOp->Common.Value.Arg;
+            while (ExecuteOp)
+            {
+                if ((ExecuteOp->Common.AmlOpcode == AML_INT_NAMEPATH_OP) &&
+                    (ExecuteOp->Common.Value.Arg == NULL))
+                {
+                    /* No target, could be a method arg */
+
+                    break;
+                }
+
+                if (NextOp->Common.AmlOpcode == AML_REF_OF_OP)
+                {
+                    break;
+                }
+
+                ExecuteOp = ExecuteOp->Common.Next;
+            }
+
+            if (!ExecuteOp)
+            {
+                /* Has a target, not method arg */
+
+                return (ArgumentCount);
+            }
+        }
+
+        ArgumentCount++;
+        NextOp = NextOp->Common.Next;
+    }
+
+    return (ArgumentCount);
+}

--- a/sys/src/libacpi/acpica/common/ahids.c
+++ b/sys/src/libacpi/acpica/common/ahids.c
@@ -1,0 +1,317 @@
+/******************************************************************************
+ *
+ * Module Name: ahids - Table of ACPI/PNP _HID/_CID values
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+
+#define _COMPONENT          ACPI_UTILITIES
+        ACPI_MODULE_NAME    ("ahids")
+
+
+/*
+ * ACPI/PNP Device IDs with description strings
+ */
+const AH_DEVICE_ID  AslDeviceIds[] =
+{
+    {"10EC5640",    "Realtek I2S Audio Codec"},
+    {"80860F09",    "Intel PWM Controller"},
+    {"80860F0A",    "Intel Atom UART Controller"},
+    {"80860F0E",    "Intel SPI Controller"},
+    {"80860F14",    "Intel Baytrail SDIO/MMC Host Controller"},
+    {"80860F28",    "Intel SST Audio DSP"},
+    {"80860F41",    "Intel Baytrail I2C Host Controller"},
+    {"ACPI0001",    "SMBus 1.0 Host Controller"},
+    {"ACPI0002",    "Smart Battery Subsystem"},
+    {"ACPI0003",    "Power Source Device"},
+    {"ACPI0004",    "Module Device"},
+    {"ACPI0005",    "SMBus 2.0 Host Controller"},
+    {"ACPI0006",    "GPE Block Device"},
+    {"ACPI0007",    "Processor Device"},
+    {"ACPI0008",    "Ambient Light Sensor Device"},
+    {"ACPI0009",    "I/O xAPIC Device"},
+    {"ACPI000A",    "I/O APIC Device"},
+    {"ACPI000B",    "I/O SAPIC Device"},
+    {"ACPI000C",    "Processor Aggregator Device"},
+    {"ACPI000D",    "Power Meter Device"},
+    {"ACPI000E",    "Time and Alarm Device"},
+    {"ACPI000F",    "User Presence Detection Device"},
+    {"ACPI0010",    "Processor Container Device"},
+    {"ACPI0011",    "Generic Buttons Device"},
+    {"ACPI0012",    "NVDIMM Root Device"},
+    {"ACPI0013",    "Generic Event Device"},
+    {"ADMA0F28",    "Intel Audio DMA"},
+    {"AMCR0F28",    "Intel Audio Machine Driver"},
+    {"ATK4001",     "Asus Radio Control Button"},
+    {"ATML1000",    "Atmel Touchscreen Controller"},
+    {"AUTH2750",    "AuthenTec AES2750"},
+    {"BCM2E39",     "Broadcom BT Serial Bus Driver over UART Bus Enumerator"},
+    {"BCM4752E",    "Broadcom GPS Controller"},
+    {"BMG0160",     "Bosch Gyro Sensor"},
+    {"CPLM3218",    "Capella Micro CM3218x Ambient Light Sensor"},
+    {"DELLABCE",    "Dell Airplane Mode Switch Driver"},
+    {"DLAC3002",    "Qualcomm Atheros Bluetooth UART Transport"},
+    {"FTTH5506",    "FocalTech 5506 Touch Controller"},
+    {"HAD0F28",     "Intel HDMI Audio Driver"},
+    {"INBC0000",    "GPIO Expander"},
+    {"INT0002",     "Virtual GPIO Controller"},
+    {"INT0800",     "Intel 82802 Firmware Hub Device"},
+    {"INT3394",     "ACPI System Fan"},
+    {"INT3396",     "Standard Power Management Controller"},
+    {"INT33A0",     "Intel Smart Connect Technology Device"},
+    {"INT33A1",     "Intel Power Engine"},
+    {"INT33BB",     "Intel Baytrail SD Host Controller"},
+    {"INT33BD",     "Intel Baytrail Mailbox Device"},
+    {"INT33BE",     "Camera Sensor OV5693"},
+    {"INT33C0",     "Intel Serial I/O SPI Host Controller"},
+    {"INT33C1",     "Intel Serial I/O SPI Host Controller"},
+    {"INT33C2",     "Intel Serial I/O I2C Host Controller"},
+    {"INT33C3",     "Intel Serial I/O I2C Host Controller"},
+    {"INT33C4",     "Intel Serial I/O UART Host Controller"},
+    {"INT33C5",     "Intel Serial I/O UART Host Controller"},
+    {"INT33C6",     "Intel SD Host Controller"},
+    {"INT33C7",     "Intel Serial I/O GPIO Host Controller"},
+    {"INT33C8",     "Intel Smart Sound Technology Host Controller"},
+    {"INT33C9",     "Wolfson Microelectronics Audio WM5102"},
+    {"INT33CA",     "Intel SPB Peripheral"},
+    {"INT33CB",     "Intel Smart Sound Technology Audio Codec"},
+    {"INT33D1",     "Intel GPIO Buttons"},
+    {"INT33D2",     "Intel GPIO Buttons"},
+    {"INT33D3",     "Intel GPIO Buttons"},
+    {"INT33D4",     "Intel GPIO Buttons"},
+    {"INT33D6",     "Intel Virtual Buttons Device"},
+    {"INT33F0",     "Camera Sensor MT9M114"},
+    {"INT33F4",     "XPOWER PMIC Controller"},
+    {"INT33F5",     "TI PMIC Controller"},
+    {"INT33FB",     "MIPI-CSI Camera Sensor OV2722"},
+    {"INT33FC",     "Intel Baytrail GPIO Controller"},
+    {"INT33FD",     "Intel Baytrail Power Management IC"},
+    {"INT33FE",     "XPOWER Battery Device"},
+    {"INT3400",     "Intel Dynamic Power Performance Management"},
+    {"INT3401",     "Intel Extended Thermal Model CPU"},
+    {"INT3403",     "DPTF Temperature Sensor"},
+    {"INT3406",     "Intel Dynamic Platform & Thermal Framework Display Participant"},
+    {"INT3407",     "DPTF Platform Power Meter"},
+    {"INT340E",     "Motherboard Resources"},
+    {"INT3420",     "Intel Bluetooth RF Kill"},
+    {"INT3F0D",     "ACPI Motherboard Resources"},
+    {"INTCF1A",     "Sony IMX175 Camera Sensor"},
+    {"INTCFD9",     "Intel Baytrail SOC GPIO Controller"},
+    {"INTL9C60",    "Intel Baytrail SOC DMA Controller"},
+    {"INVN6500",    "InvenSense MPU-6500 Six Axis Gyroscope and Accelerometer"},
+    {"LNXCPU",      "Linux Logical CPU"},
+    {"LNXPOWER",    "ACPI Power Resource (power gating)"},
+    {"LNXPWRBN",    "System Power Button"},
+    {"LNXSYBUS",    "System Bus"},
+    {"LNXSYSTM",    "ACPI Root Node"},
+    {"LNXTHERM",    "ACPI Thermal Zone"},
+    {"LNXVIDEO",    "ACPI Video Controller"},
+    {"MAX17047",    "Fuel Gauge Controller"},
+    {"MSFT0101",    "TPM 2.0 Security Device"},
+    {"NXP5442",     "NXP 5442 Near Field Communications Controller"},
+    {"NXP5472",     "NXP NFC"},
+    {"PNP0000",     "8259-compatible Programmable Interrupt Controller"},
+    {"PNP0001",     "EISA Interrupt Controller"},
+    {"PNP0002",     "MCA Interrupt Controller"},
+    {"PNP0003",     "IO-APIC Interrupt Controller"},
+    {"PNP0100",     "PC-class System Timer"},
+    {"PNP0103",     "HPET System Timer"},
+    {"PNP0200",     "PC-class DMA Controller"},
+    {"PNP0300",     "IBM PC/XT Keyboard Controller (83 key)"},
+    {"PNP0301",     "IBM PC/XT Keyboard Controller (86 key)"},
+    {"PNP0302",     "IBM PC/XT Keyboard Controller (84 key)"},
+    {"PNP0303",     "IBM Enhanced Keyboard (101/102-key, PS/2 Mouse)"},
+    {"PNP0400",     "Standard LPT Parallel Port"},
+    {"PNP0401",     "ECP Parallel Port"},
+    {"PNP0500",     "Standard PC COM Serial Port"},
+    {"PNP0501",     "16550A-compatible COM Serial Port"},
+    {"PNP0510",     "Generic IRDA-compatible Device"},
+    {"PNP0800",     "Microsoft Sound System Compatible Device"},
+    {"PNP0A03",     "PCI Bus"},
+    {"PNP0A05",     "Generic Container Device"},
+    {"PNP0A06",     "Generic Container Device"},
+    {"PNP0A08",     "PCI Express Bus"},
+    {"PNP0B00",     "AT Real-Time Clock"},
+    {"PNP0B01",     "Intel PIIX4-compatible RTC/CMOS Device"},
+    {"PNP0B02",     "Dallas Semiconductor-compatible RTC/CMOS Device"},
+    {"PNP0C01",     "System Board"},
+    {"PNP0C02",     "PNP Motherboard Resources"},
+    {"PNP0C04",     "x87-compatible Floating Point Processing Unit"},
+    {"PNP0C08",     "ACPI Core Hardware"},
+    {"PNP0C09",     "Embedded Controller Device"},
+    {"PNP0C0A",     "Control Method Battery"},
+    {"PNP0C0B",     "Fan (Thermal Solution)"},
+    {"PNP0C0C",     "Power Button Device"},
+    {"PNP0C0D",     "Lid Device"},
+    {"PNP0C0E",     "Sleep Button Device"},
+    {"PNP0C0F",     "PCI Interrupt Link Device"},
+    {"PNP0C10",     "System Indicator Device"},
+    {"PNP0C11",     "Thermal Zone"},
+    {"PNP0C12",     "Device Bay Controller"},
+    {"PNP0C14",     "Windows Management Instrumentation Device"},
+    {"PNP0C15",     "Docking Station"},
+    {"PNP0C33",     "Error Device"},
+    {"PNP0C40",     "Standard Button Controller"},
+    {"PNP0C50",     "HID Protocol Device (I2C bus)"},
+    {"PNP0C60",     "Display Sensor Device"},
+    {"PNP0C70",     "Dock Sensor Device"},
+    {"PNP0C80",     "Memory Device"},
+    {"PNP0D10",     "XHCI USB Controller with debug"},
+    {"PNP0D15",     "XHCI USB Controller without debug"},
+    {"PNP0D20",     "EHCI USB Controller without debug"},
+    {"PNP0D25",     "EHCI USB Controller with debug"},
+    {"PNP0D40",     "SDA Standard Compliant SD Host Controller"},
+    {"PNP0D80",     "Windows-compatible System Power Management Controller"},
+    {"PNP0F03",     "Microsoft PS/2-style Mouse"},
+    {"PNP0F13",     "PS/2 Mouse"},
+    {"RTL8723",     "Realtek Wireless Controller"},
+    {"SMB0349",     "Charger"},
+    {"SMO91D0",     "Sensor Hub"},
+    {"SMSC3750",    "SMSC 3750 USB MUX"},
+    {"SSPX0000",    "Intel SSP Device"},
+    {"TBQ24296",    "Charger"},
+
+    {NULL, NULL}
+};
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiAhMatchHardwareId
+ *
+ * PARAMETERS:  HardwareId          - String representation of an _HID or _CID
+ *
+ * RETURN:      ID info struct. NULL if HardwareId is not found
+ *
+ * DESCRIPTION: Lookup an _HID/_CID in the device ID table
+ *
+ ******************************************************************************/
+
+const AH_DEVICE_ID *
+AcpiAhMatchHardwareId (
+    char                    *HardwareId)
+{
+    const AH_DEVICE_ID      *Info;
+
+
+    for (Info = AslDeviceIds; Info->Name; Info++)
+    {
+        if (!strcmp (HardwareId, Info->Name))
+        {
+            return (Info);
+        }
+    }
+
+    return (NULL);
+}

--- a/sys/src/libacpi/acpica/common/ahpredef.c
+++ b/sys/src/libacpi/acpica/common/ahpredef.c
@@ -1,0 +1,444 @@
+/******************************************************************************
+ *
+ * Module Name: ahpredef - Table of all known ACPI predefined names
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+
+#define _COMPONENT          ACPI_UTILITIES
+        ACPI_MODULE_NAME    ("ahpredef")
+
+/*
+ * iASL only needs a partial table (short descriptions only).
+ * AcpiHelp needs the full table.
+ */
+#ifdef ACPI_ASL_COMPILER
+#define AH_PREDEF(Name, ShortDesc, LongDesc) {Name, ShortDesc}
+#else
+#define AH_PREDEF(Name, ShortDesc, LongDesc) {Name, ShortDesc, LongDesc}
+#endif
+
+/*
+ * Predefined ACPI names, with short description and return value.
+ * This table was extracted directly from the ACPI specification.
+ */
+const AH_PREDEFINED_NAME    AslPredefinedInfo[] =
+{
+    AH_PREDEF ("_ACx",    "Active Cooling", "Returns the active cooling policy threshold values"),
+    AH_PREDEF ("_ADR",    "Address", "Returns address of a device on parent bus, and resource field"),
+    AH_PREDEF ("_AEI",    "ACPI Event Interrupts", "Returns a list of GPIO events to be used as ACPI events"),
+    AH_PREDEF ("_ALC",    "Ambient Light Chromaticity", "Returns the ambient light color chromaticity"),
+    AH_PREDEF ("_ALI",    "Ambient Light Illuminance", "Returns the ambient light brightness"),
+    AH_PREDEF ("_ALN",    "Alignment", "Base alignment, Resource Descriptor field"),
+    AH_PREDEF ("_ALP",    "Ambient Light Polling", "Returns the ambient light sensor polling frequency"),
+    AH_PREDEF ("_ALR",    "Ambient Light Response", "Returns the ambient light brightness to display brightness mappings"),
+    AH_PREDEF ("_ALT",    "Ambient Light Temperature", "Returns the ambient light color temperature"),
+    AH_PREDEF ("_ALx",    "Active List", "Returns a list of active cooling device objects"),
+    AH_PREDEF ("_ART",    "Active Cooling Relationship Table", "Returns thermal relationship information between platform devices and fan devices"),
+    AH_PREDEF ("_ASI",    "Address Space Id", "Resource Descriptor field"),
+    AH_PREDEF ("_ASZ",    "Access Size", "Resource Descriptor field"),
+    AH_PREDEF ("_ATT",    "Type-Specific Attribute", "Resource Descriptor field"),
+    AH_PREDEF ("_BAS",    "Base Address", "Range base address, Resource Descriptor field"),
+    AH_PREDEF ("_BBN",    "BIOS Bus Number", "Returns the PCI bus number returned by the BIOS"),
+    AH_PREDEF ("_BCL",    "Brightness Control Levels", "Returns a list of supported brightness control levels"),
+    AH_PREDEF ("_BCM",    "Brightness Control Method", "Sets the brightness level of the display device"),
+    AH_PREDEF ("_BCT",    "Battery Charge Time", "Returns time remaining to complete charging battery"),
+    AH_PREDEF ("_BDN",    "BIOS Dock Name", "Returns the Dock ID returned by the BIOS"),
+    AH_PREDEF ("_BFS",    "Back From Sleep", "Inform AML of a wake event"),
+    AH_PREDEF ("_BIF",    "Battery Information", "Returns a Control Method Battery information block"),
+    AH_PREDEF ("_BIX",    "Battery Information Extended", "Returns a Control Method Battery extended information block"),
+    AH_PREDEF ("_BLT",    "Battery Level Threshold", "Set battery level threshold preferences"),
+    AH_PREDEF ("_BM_",    "Bus Master", "Resource Descriptor field"),
+    AH_PREDEF ("_BMA",    "Battery Measurement Averaging Interval", "Sets battery measurement averaging interval"),
+    AH_PREDEF ("_BMC",    "Battery Maintenance Control", "Sets battery maintenance and control features"),
+    AH_PREDEF ("_BMD",    "Battery Maintenance Data", "Returns battery maintenance, control, and state data"),
+    AH_PREDEF ("_BMS",    "Battery Measurement Sampling Time", "Sets the battery measurement sampling time"),
+    AH_PREDEF ("_BQC",    "Brightness Query Current", "Returns the current display brightness level"),
+    AH_PREDEF ("_BST",    "Battery Status", "Returns a Control Method Battery status block"),
+    AH_PREDEF ("_BTH",    "Battery Throttle Limit", "Thermal limit for charging and discharging"),
+    AH_PREDEF ("_BTM",    "Battery Time", "Returns the battery runtime"),
+    AH_PREDEF ("_BTP",    "Battery Trip Point", "Sets a Control Method Battery trip point"),
+    AH_PREDEF ("_CBA",    "Configuration Base Address", "Sets the base address for a PCI Express host bridge"),
+    AH_PREDEF ("_CCA",    "Cache Coherency Attribute", "Returns a device's support level for cache coherency"),
+    AH_PREDEF ("_CDM",    "Clock Domain", "Returns a logical processor's clock domain identifier"),
+    AH_PREDEF ("_CID",    "Compatible ID", "Returns a device's Plug and Play Compatible ID list"),
+    AH_PREDEF ("_CLS",    "Class Code", "Returns PCI class code and subclass"),
+    AH_PREDEF ("_CPC",    "Continuous Performance Control", "Returns a list of performance control interfaces"),
+    AH_PREDEF ("_CR3",    "Warm/Standby Temperature", "Temperature for a fast low power state"),
+    AH_PREDEF ("_CRS",    "Current Resource Settings", "Returns the current resource settings for a device"),
+    AH_PREDEF ("_CRT",    "Critical Temperature", "Returns the shutdown critical temperature"),
+    AH_PREDEF ("_CSD",    "C-State Dependencies", "Returns a list of C-state dependencies"),
+    AH_PREDEF ("_CST",    "C-States", "Returns a list of supported C-states"),
+    AH_PREDEF ("_CWS",    "Clear Wake Alarm Status", "Clear the status of wake alarms"),
+    AH_PREDEF ("_DBT",    "Debounce Timeout", "Timeout value, Resource Descriptor field"),
+    AH_PREDEF ("_DCK",    "Dock Present", "Sets docking isolation. Presence indicates device is a docking station"),
+    AH_PREDEF ("_DCS",    "Display Current Status", "Returns status of the display output device"),
+    AH_PREDEF ("_DDC",    "Display Data Current", "Returns the EDID for the display output device"),
+    AH_PREDEF ("_DDN",    "DOS Device Name", "Returns a device logical name"),
+    AH_PREDEF ("_DEC",    "Decode", "Device decoding type, Resource Descriptor field"),
+    AH_PREDEF ("_DEP",    "Dependencies", "Returns a list of operation region dependencies"),
+    AH_PREDEF ("_DGS",    "Display Graphics State", "Return the current state of the output device"),
+    AH_PREDEF ("_DIS",    "Disable Device", "Disables a device"),
+    AH_PREDEF ("_DLM",    "Device Lock Mutex", "Defines mutex for OS/AML sharing"),
+    AH_PREDEF ("_DMA",    "Direct Memory Access", "Returns device current resources for DMA transactions, and resource field"),
+    AH_PREDEF ("_DOD",    "Display Output Devices", "Enumerate all devices attached to the display adapter"),
+    AH_PREDEF ("_DOS",    "Disable Output Switching", "Sets the display output switching mode"),
+    AH_PREDEF ("_DPL",    "Device Selection Polarity", "Polarity of Device Selection signal, Resource Descriptor field"),
+    AH_PREDEF ("_DRS",    "Drive Strength", "Drive Strength setting for GPIO connection, Resource Descriptor field"),
+    AH_PREDEF ("_DSD",    "Device-Specific Data", "Returns a list of device property information"),
+    AH_PREDEF ("_DSM",    "Device-Specific Method", "Executes device-specific functions"),
+    AH_PREDEF ("_DSS",    "Device Set State", "Sets the display device state"),
+    AH_PREDEF ("_DSW",    "Device Sleep Wake", "Sets the sleep and wake transition states for a device"),
+    AH_PREDEF ("_DTI",    "Device Temperature Indication", "Conveys native device temperature to the platform"),
+    AH_PREDEF ("_Exx",    "Edge-Triggered GPE", "Method executed as a result of a general-purpose event"),
+    AH_PREDEF ("_EC_",    "Embedded Controller", "returns EC offset and query information"),
+    AH_PREDEF ("_EDL",    "Eject Device List", "Returns a list of devices that are dependent on a device (docking)"),
+    AH_PREDEF ("_EJD",    "Ejection Dependent Device", "Returns the name of dependent (parent) device (docking)"),
+    AH_PREDEF ("_EJx",    "Eject Device", "Begin or cancel a device ejection request (docking)"),
+    AH_PREDEF ("_END",    "Endianness", "Endian orientation, Resource Descriptor field"),
+    AH_PREDEF ("_EVT",    "Event", "Event method for GPIO events"),
+    AH_PREDEF ("_FDE",    "Floppy Disk Enumerate", "Returns floppy disk configuration information"),
+    AH_PREDEF ("_FDI",    "Floppy Drive Information", "Returns a floppy drive information block"),
+    AH_PREDEF ("_FDM",    "Floppy Drive Mode", "Sets a floppy drive speed"),
+    AH_PREDEF ("_FIF",    "Fan Information", "Returns fan device information"),
+    AH_PREDEF ("_FIT",    "Firmware Interface Table", "Returns a list of NFIT structures"),
+    AH_PREDEF ("_FIX",    "Fixed Register Resource Provider", "Returns a list of devices that implement FADT register blocks"),
+    AH_PREDEF ("_FLC",    "Flow Control", "Flow control, Resource Descriptor field"),
+    AH_PREDEF ("_FPS",    "Fan Performance States", "Returns a list of supported fan performance states"),
+    AH_PREDEF ("_FSL",    "Fan Set Level", "Control method that sets the fan device's speed level (performance state)"),
+    AH_PREDEF ("_FST",    "Fan Status", "Returns current status information for a fan device"),
+    AH_PREDEF ("_GAI",    "Get Averaging Interval", "Returns the power meter averaging interval"),
+    AH_PREDEF ("_GCP",    "Get Capabilities", "Get device time capabilities"),
+    AH_PREDEF ("_GHL",    "Get Hardware Limit", "Returns the hardware limit enforced by the power meter"),
+    AH_PREDEF ("_GL_",    "Global Lock", "OS-defined Global Lock mutex object"),
+    AH_PREDEF ("_GLK",    "Get Global Lock Requirement", "Returns a device's Global Lock requirement for device access"),
+    AH_PREDEF ("_GPD",    "Get Post Data", "Returns the value of the VGA device that will be posted at boot"),
+    AH_PREDEF ("_GPE",    "General Purpose Events", "Predefined scope (\\_GPE) or SCI number for EC"),
+    AH_PREDEF ("_GRA",    "Granularity", "Address space granularity, Resource Descriptor field"),
+    AH_PREDEF ("_GRT",    "Get Real Time", "Returns current time-of-day from a time/alarm device"),
+    AH_PREDEF ("_GSB",    "Global System Interrupt Base", "Returns the GSB for a I/O APIC device"),
+    AH_PREDEF ("_GTF",    "Get Task File", "Returns a list of ATA commands to restore a drive to default state"),
+    AH_PREDEF ("_GTM",    "Get Timing Mode", "Returns a list of IDE controller timing information"),
+    AH_PREDEF ("_GTS",    "Going To Sleep", "Inform AML of pending sleep"),
+    AH_PREDEF ("_GWS",    "Get Wake Status", "Return status of wake alarms"),
+    AH_PREDEF ("_HE_",    "High-Edge", "Interrupt triggering, Resource Descriptor field"),
+    AH_PREDEF ("_HID",    "Hardware ID", "Returns a device's Plug and Play Hardware ID"),
+    AH_PREDEF ("_HOT",    "Hot Temperature", "Returns the critical temperature for sleep (entry to S4)"),
+    AH_PREDEF ("_HPP",    "Hot Plug Parameters", "Returns a list of hot-plug information for a PCI device"),
+    AH_PREDEF ("_HPX",    "Hot Plug Parameter Extensions", "Returns a list of hot-plug information for a PCI device. Supersedes _HPP"),
+    AH_PREDEF ("_HRV",    "Hardware Revision", "Returns a hardware revision value"),
+    AH_PREDEF ("_IFT",    "IPMI Interface Type", "See the Intelligent Platform Management Interface Specification"),
+    AH_PREDEF ("_INI",    "Initialize", "Performs device specific initialization"),
+    AH_PREDEF ("_INT",    "Interrupts", "Interrupt mask bits, Resource Descriptor field"),
+    AH_PREDEF ("_IOR",    "I/O Restriction", "Restriction type, Resource Descriptor field"),
+    AH_PREDEF ("_IRC",    "Inrush Current", "Presence indicates that a device has a significant inrush current draw"),
+    AH_PREDEF ("_Lxx",    "Level-Triggered GPE", "Control method executed as a result of a general-purpose event"),
+    AH_PREDEF ("_LCK",    "Lock Device", "Locks or unlocks a device (docking)"),
+    AH_PREDEF ("_LEN",    "Length", "Range length, Resource Descriptor field"),
+    AH_PREDEF ("_LID",    "Lid Status", "Returns the open/closed status of the lid on a mobile system"),
+    AH_PREDEF ("_LIN",    "Lines In Use", "Handshake lines, Resource Descriptor field"),
+    AH_PREDEF ("_LL_",    "Low Level", "Interrupt polarity, Resource Descriptor field"),
+    AH_PREDEF ("_LPD",    "Low Power Dependencies", "Returns a list of dependencies for low power idle entry"),
+    AH_PREDEF ("_LPI",    "Low Power Idle States", "Returns a list of supported low power idle states"),
+    AH_PREDEF ("_MAF",    "Maximum Address Fixed", "Resource Descriptor field"),
+    AH_PREDEF ("_MAT",    "Multiple APIC Table Entry", "Returns a list of MADT APIC structure entries"),
+    AH_PREDEF ("_MAX",    "Maximum Base Address", "Resource Descriptor field"),
+    AH_PREDEF ("_MBM",    "Memory Bandwidth Monitoring Data", "Returns bandwidth monitoring data for a memory device"),
+    AH_PREDEF ("_MEM",    "Memory Attributes", "Resource Descriptor field"),
+    AH_PREDEF ("_MIF",    "Minimum Address Fixed", "Resource Descriptor field"),
+    AH_PREDEF ("_MIN",    "Minimum Base Address", "Resource Descriptor field"),
+    AH_PREDEF ("_MLS",    "Multiple Language String", "Returns a device description in multiple languages"),
+    AH_PREDEF ("_MOD",    "Mode", "Interrupt mode, Resource Descriptor field"),
+    AH_PREDEF ("_MSG",    "Message", "Sets the system message waiting status indicator"),
+    AH_PREDEF ("_MSM",    "Memory Set Monitoring", "Sets bandwidth monitoring parameters for a memory device"),
+    AH_PREDEF ("_MTL",    "Minimum Throttle Limit", "Returns the minimum throttle limit for a thermal zone"),
+    AH_PREDEF ("_MTP",    "Memory Type", "Resource Descriptor field"),
+    AH_PREDEF ("_NTT",    "Notification Temperature Threshold", "Returns a threshold for device temperature change that requires platform notification"),
+    AH_PREDEF ("_OFF",    "Power Off", "Sets a power resource to the off state"),
+    AH_PREDEF ("_ON_",    "Power On", "Sets a power resource to the on state"),
+    AH_PREDEF ("_OS_",    "Operating System", "Returns a string that identifies the operating system"),
+    AH_PREDEF ("_OSC",    "Operating System Capabilities", "Inform AML of host features and capabilities"),
+    AH_PREDEF ("_OSI",    "Operating System Interfaces", "Returns supported interfaces, behaviors, and features"),
+    AH_PREDEF ("_OST",    "OSPM Status Indication", "Inform AML of event processing status"),
+    AH_PREDEF ("_PAI",    "Power Averaging Interval", "Sets the averaging interval for a power meter"),
+    AH_PREDEF ("_PAR",    "Parity", "Parity bits, Resource Descriptor field"),
+    AH_PREDEF ("_PCL",    "Power Consumer List", "Returns a list of devices powered by a power source"),
+    AH_PREDEF ("_PCT",    "Performance Control", "Returns processor performance control and status registers"),
+    AH_PREDEF ("_PDC",    "Processor Driver Capabilities", "Inform AML of processor driver capabilities"),
+    AH_PREDEF ("_PDL",    "P-state Depth Limit", "Returns the lowest available performance P-state"),
+    AH_PREDEF ("_PHA",    "Clock Phase", "Clock phase, Resource Descriptor field"),
+    AH_PREDEF ("_PIC",    "Interrupt Model", "Inform AML of the interrupt model in use"),
+    AH_PREDEF ("_PIF",    "Power Source Information", "Returns a Power Source information block"),
+    AH_PREDEF ("_PIN",    "Pin List", "Pin list, Resource Descriptor field"),
+    AH_PREDEF ("_PLD",    "Physical Location of Device", "Returns a device's physical location information"),
+    AH_PREDEF ("_PMC",    "Power Meter Capabilities", "Returns a list of Power Meter capabilities info"),
+    AH_PREDEF ("_PMD",    "Power Metered Devices", "Returns a list of devices that are measured by the power meter device"),
+    AH_PREDEF ("_PMM",    "Power Meter Measurement", "Returns the current value of the Power Meter"),
+    AH_PREDEF ("_POL",    "Polarity", "Interrupt polarity, Resource Descriptor field"),
+    AH_PREDEF ("_PPC",    "Performance Present Capabilities", "Returns a list of the performance states currently supported by the platform"),
+    AH_PREDEF ("_PPE",    "Polling for Platform Error", "Returns the polling interval to retrieve Corrected Platform Error information"),
+    AH_PREDEF ("_PPI",    "Pin Configuration", "Resource Descriptor field"),
+    AH_PREDEF ("_PR",     "Processor", "Predefined scope for processor objects"),
+    AH_PREDEF ("_PR0",    "Power Resources for D0", "Returns a list of dependent power resources to enter state D0 (fully on)"),
+    AH_PREDEF ("_PR1",    "Power Resources for D1", "Returns a list of dependent power resources to enter state D1"),
+    AH_PREDEF ("_PR2",    "Power Resources for D2", "Returns a list of dependent power resources to enter state D2"),
+    AH_PREDEF ("_PR3",    "Power Resources for D3hot", "Returns a list of dependent power resources to enter state D3hot"),
+    AH_PREDEF ("_PRE",    "Power Resources for Enumeration", "Returns a list of dependent power resources to enumerate devices on a bus"),
+    AH_PREDEF ("_PRL",    "Power Source Redundancy List", "Returns a list of power source devices in the same redundancy grouping"),
+    AH_PREDEF ("_PRR",    "Power Resource for Reset", "Execute a reset on a device"),
+    AH_PREDEF ("_PRS",    "Possible Resource Settings", "Returns a list of a device's possible resource settings"),
+    AH_PREDEF ("_PRT",    "PCI Routing Table", "Returns a list of PCI interrupt mappings"),
+    AH_PREDEF ("_PRW",    "Power Resources for Wake", "Returns a list of dependent power resources for waking"),
+    AH_PREDEF ("_PS0",    "Power State 0", "Sets a device's power state to D0 (device fully on)"),
+    AH_PREDEF ("_PS1",    "Power State 1", "Sets a device's power state to D1"),
+    AH_PREDEF ("_PS2",    "Power State 2", "Sets a device's power state to D2"),
+    AH_PREDEF ("_PS3",    "Power State 3", "Sets a device's power state to D3 (device off)"),
+    AH_PREDEF ("_PSC",    "Power State Current", "Returns a device's current power state"),
+    AH_PREDEF ("_PSD",    "Power State Dependencies", "Returns processor P-State dependencies"),
+    AH_PREDEF ("_PSE",    "Power State for Enumeration", "Put a bus into enumeration power mode"),
+    AH_PREDEF ("_PSL",    "Passive List", "Returns a list of passive cooling device objects"),
+    AH_PREDEF ("_PSR",    "Power Source", "Returns the power source device currently in use"),
+    AH_PREDEF ("_PSS",    "Performance Supported States", "Returns a list of supported processor performance states"),
+    AH_PREDEF ("_PSV",    "Passive Temperature", "Returns the passive trip point temperature"),
+    AH_PREDEF ("_PSW",    "Power State Wake", "Sets a device's wake function"),
+    AH_PREDEF ("_PTC",    "Processor Throttling Control", "Returns throttling control and status registers"),
+    AH_PREDEF ("_PTP",    "Power Trip Points", "Sets trip points for the Power Meter device"),
+    AH_PREDEF ("_PTS",    "Prepare To Sleep", "Inform the platform of an impending sleep transition"),
+    AH_PREDEF ("_PUR",    "Processor Utilization Request", "Returns the number of processors that the platform would like to idle"),
+    AH_PREDEF ("_PXM",    "Device Proximity", "Returns a device's proximity domain identifier"),
+    AH_PREDEF ("_Qxx",    "EC Query", "Embedded Controller query and SMBus Alarm control method"),
+    AH_PREDEF ("_RBO",    "Register Bit Offset", "Resource Descriptor field"),
+    AH_PREDEF ("_RBW",    "Register Bit Width", "Resource Descriptor field"),
+    AH_PREDEF ("_RDI",    "Resource Dependencies for Idle", "Returns a list of dependencies for idle states"),
+    AH_PREDEF ("_REG",    "Region Availability", "Inform AML code of an operation region availability change"),
+    AH_PREDEF ("_REV",    "Supported Integer Width", "Returns the supported integer width (<= 1: 32 bits only, >=2: both 32 and 64 bits"),
+    AH_PREDEF ("_RMV",    "Removal Status", "Returns a device's removal ability status (docking)"),
+    AH_PREDEF ("_RNG",    "Range", "Memory range type, Resource Descriptor field"),
+    AH_PREDEF ("_RST",    "Device Reset", "Executes a reset on a device"),
+    AH_PREDEF ("_ROM",    "Read-Only Memory", "Returns a copy of the ROM data for a display device"),
+    AH_PREDEF ("_RT_",    "Resource Type", "Resource Descriptor field"),
+    AH_PREDEF ("_RTV",    "Relative Temperature Values", "Returns temperature value information"),
+    AH_PREDEF ("_RW_",    "Read-Write Status", "Resource Descriptor field"),
+    AH_PREDEF ("_RXL",    "Receive Buffer Size", "Serial channel buffer, Resource Descriptor field"),
+    AH_PREDEF ("_S0_",    "S0 System State", "Returns values to enter the system into the S0 state"),
+    AH_PREDEF ("_S1_",    "S1 System State", "Returns values to enter the system into the S1 state"),
+    AH_PREDEF ("_S2_",    "S2 System State", "Returns values to enter the system into the S2 state"),
+    AH_PREDEF ("_S3_",    "S3 System State", "Returns values to enter the system into the S3 state"),
+    AH_PREDEF ("_S4_",    "S4 System State", "Returns values to enter the system into the S4 state"),
+    AH_PREDEF ("_S5_",    "S5 System State", "Returns values to enter the system into the S5 state"),
+    AH_PREDEF ("_S1D",    "S1 Device State", "Returns the highest D-state supported by a device when in the S1 state"),
+    AH_PREDEF ("_S2D",    "S2 Device State", "Returns the highest D-state supported by a device when in the S2 state"),
+    AH_PREDEF ("_S3D",    "S3 Device State", "Returns the highest D-state supported by a device when in the S3 state"),
+    AH_PREDEF ("_S4D",    "S4 Device State", "Returns the highest D-state supported by a device when in the S4 state"),
+    AH_PREDEF ("_S0W",    "S0 Device Wake State", "Returns the lowest D-state that the device can wake itself from S0"),
+    AH_PREDEF ("_S1W",    "S1 Device Wake State", "Returns the lowest D-state for this device that can wake the system from S1"),
+    AH_PREDEF ("_S2W",    "S2 Device Wake State", "Returns the lowest D-state for this device that can wake the system from S2"),
+    AH_PREDEF ("_S3W",    "S3 Device Wake State", "Returns the lowest D-state for this device that can wake the system from S3"),
+    AH_PREDEF ("_S4W",    "S4 Device Wake State", "Returns the lowest D-state for this device that can wake the system from S4"),
+    AH_PREDEF ("_SB_",    "System Bus", "Predefined scope for device and bus objects"),
+    AH_PREDEF ("_SBS",    "Smart Battery Subsystem", "Returns the subsystem configuration"),
+    AH_PREDEF ("_SCP",    "Set Cooling Policy", "Sets the cooling policy (active or passive)"),
+    AH_PREDEF ("_SDD",    "Set Device Data", "Sets data for a SATA device"),
+    AH_PREDEF ("_SEG",    "PCI Segment", "Returns a device's PCI Segment Group number"),
+    AH_PREDEF ("_SHL",    "Set Hardware Limit", "Sets the hardware limit enforced by the Power Meter"),
+    AH_PREDEF ("_SHR",    "Sharable", "Interrupt share status, Resource Descriptor field"),
+    AH_PREDEF ("_SI_",    "System Indicators", "Predefined scope"),
+    AH_PREDEF ("_SIZ",    "Size", "DMA transfer size, Resource Descriptor field"),
+    AH_PREDEF ("_SLI",    "System Locality Information", "Returns a list of NUMA system localities"),
+    AH_PREDEF ("_SLV",    "Slave Mode", "Mode setting, Resource Descriptor field"),
+    AH_PREDEF ("_SPD",    "Set Post Device", "Sets which video device will be posted at boot"),
+    AH_PREDEF ("_SPE",    "Speed", "Connection speed, Resource Descriptor field"),
+    AH_PREDEF ("_SRS",    "Set Resource Settings", "Sets a device's resource allocation"),
+    AH_PREDEF ("_SRT",    "Set Real Time", "Sets the current time for a time/alarm device"),
+    AH_PREDEF ("_SRV",    "IPMI Spec Revision", "See the Intelligent Platform Management Interface Specification"),
+    AH_PREDEF ("_SST",    "System Status", "Sets the system status indicator"),
+    AH_PREDEF ("_STA",    "Status", "Returns the current status of a Device or Power Resource"),
+    AH_PREDEF ("_STB",    "Stop Bits", "Serial channel stop bits, Resource Descriptor field"),
+    AH_PREDEF ("_STM",    "Set Timing Mode", "Sets an IDE controller transfer timings"),
+    AH_PREDEF ("_STP",    "Set Expired Timer Wake Policy", "Sets expired timer policies of the wake alarm device"),
+    AH_PREDEF ("_STR",    "Description String", "Returns a device's description string"),
+    AH_PREDEF ("_STV",    "Set Timer Value", "Set timer values of the wake alarm device"),
+    AH_PREDEF ("_SUB",    "Subsystem ID", "Returns the subsystem ID for a device"),
+    AH_PREDEF ("_SUN",    "Slot User Number", "Returns the slot unique ID number"),
+    AH_PREDEF ("_SWS",    "System Wake Source", "Returns the source event that caused the system to wake"),
+    AH_PREDEF ("_T_x",    "Emitted by ASL Compiler", "Reserved for use by ASL compilers"),
+    AH_PREDEF ("_TC1",    "Thermal Constant 1", "Returns TC1 for the passive cooling formula"),
+    AH_PREDEF ("_TC2",    "Thermal Constant 2", "Returns TC2 for the passive cooling formula"),
+    AH_PREDEF ("_TDL",    "T-State Depth Limit", "Returns the _TSS entry number of the lowest power throttling state"),
+    AH_PREDEF ("_TFP",    "Thermal Fast Sampling Period", "Returns the sampling period for passive cooling"),
+    AH_PREDEF ("_TIP",    "Expired Timer Wake Policy", "Returns timer policies of the wake alarm device"),
+    AH_PREDEF ("_TIV",    "Timer Values", "Returns remaining time of the wake alarm device"),
+    AH_PREDEF ("_TMP",    "Temperature", "Returns a thermal zone's current temperature"),
+    AH_PREDEF ("_TPC",    "Throttling Present Capabilities", "Returns the current number of supported throttling states"),
+    AH_PREDEF ("_TPT",    "Trip Point Temperature", "Inform AML that a device's embedded temperature sensor has crossed a temperature trip point"),
+    AH_PREDEF ("_TRA",    "Translation", "Address translation offset, Resource Descriptor field"),
+    AH_PREDEF ("_TRS",    "Translation Sparse", "Sparse/dense flag, Resource Descriptor field"),
+    AH_PREDEF ("_TRT",    "Thermal Relationship Table", "Returns thermal relationships between platform devices"),
+    AH_PREDEF ("_TSD",    "Throttling State Dependencies", "Returns a list of T-state dependencies"),
+    AH_PREDEF ("_TSF",    "Type-Specific Flags", "Resource Descriptor field"),
+    AH_PREDEF ("_TSN",    "Thermal Sensor Device", "Returns a reference to a thermal sensor"),
+    AH_PREDEF ("_TSP",    "Thermal Sampling Period", "Returns the thermal sampling period for passive cooling"),
+    AH_PREDEF ("_TSS",    "Throttling Supported States", "Returns supported throttling state information"),
+    AH_PREDEF ("_TST",    "Temperature Sensor Threshold", "Returns the minimum separation for a device's temperature trip points"),
+    AH_PREDEF ("_TTP",    "Translation Type", "Translation/static flag, Resource Descriptor field"),
+    AH_PREDEF ("_TTS",    "Transition To State", "Inform AML of an S-state transition"),
+    AH_PREDEF ("_TXL",    "Transmit Buffer Size", "Serial Channel buffer, Resource Descriptor field"),
+    AH_PREDEF ("_TYP",    "Type", "DMA channel type (speed), Resource Descriptor field"),
+    AH_PREDEF ("_TZ_",    "Thermal Zone", "Predefined scope: ACPI 1.0"),
+    AH_PREDEF ("_TZD",    "Thermal Zone Devices", "Returns a list of device names associated with a Thermal Zone"),
+    AH_PREDEF ("_TZM",    "Thermal Zone Member", "Returns a reference to the thermal zone of which a device is a member"),
+    AH_PREDEF ("_TZP",    "Thermal Zone Polling", "Returns a Thermal zone's polling frequency"),
+    AH_PREDEF ("_UID",    "Unique ID", "Return a device's unique persistent ID"),
+    AH_PREDEF ("_UPC",    "USB Port Capabilities", "Returns a list of USB port capabilities"),
+    AH_PREDEF ("_UPD",    "User Presence Detect", "Returns user detection information"),
+    AH_PREDEF ("_UPP",    "User Presence Polling", "Returns the recommended user presence polling interval"),
+    AH_PREDEF ("_VEN",    "Vendor Data", "Resource Descriptor field"),
+    AH_PREDEF ("_VPO",    "Video Post Options", "Returns the implemented video post options"),
+    AH_PREDEF ("_Wxx",    "Wake Event", "Method executed as a result of a wake event"),
+    AH_PREDEF ("_WAK",    "Wake", "Inform AML that the system has just awakened"),
+    AH_PREDEF ("_WPC",    "Wireless Power Calibration", "Calibrate power and notify wireless device"),
+    AH_PREDEF ("_WPP",    "Wireless Power Polling", "Get recommended polling interval"),
+    AH_PREDEF (NULL,      NULL, NULL)
+};
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiAhMatchPredefinedName
+ *
+ * PARAMETERS:  Nameseg                 - Predefined name string
+ *
+ * RETURN:      ID info struct. NULL if Nameseg not found
+ *
+ * DESCRIPTION: Lookup a predefined name.
+ *
+ ******************************************************************************/
+
+const AH_PREDEFINED_NAME *
+AcpiAhMatchPredefinedName (
+    char                        *Nameseg)
+{
+    const AH_PREDEFINED_NAME    *Info;
+
+
+    for (Info = AslPredefinedInfo; Info->Name; Info++)
+    {
+        if (ACPI_COMPARE_NAME (Nameseg, Info->Name))
+        {
+            return (Info);
+        }
+    }
+
+    return (NULL);
+}

--- a/sys/src/libacpi/acpica/common/ahtable.c
+++ b/sys/src/libacpi/acpica/common/ahtable.c
@@ -1,0 +1,223 @@
+/******************************************************************************
+ *
+ * Module Name: ahtable - Table of known ACPI tables with descriptions
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+
+
+/* Local prototypes */
+
+const AH_TABLE *
+AcpiAhGetTableInfo (
+    char                    *Signature);
+
+extern const AH_TABLE      AcpiSupportedTables[];
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiAhGetTableInfo
+ *
+ * PARAMETERS:  Signature           - ACPI signature (4 chars) to match
+ *
+ * RETURN:      Pointer to a valid AH_TABLE. Null if no match found.
+ *
+ * DESCRIPTION: Find a match in the "help" table of supported ACPI tables
+ *
+ ******************************************************************************/
+
+const AH_TABLE *
+AcpiAhGetTableInfo (
+    char                    *Signature)
+{
+    const AH_TABLE      *Info;
+
+
+    for (Info = AcpiSupportedTables; Info->Signature; Info++)
+    {
+        if (ACPI_COMPARE_NAME (Signature, Info->Signature))
+        {
+            return (Info);
+        }
+    }
+
+    return (NULL);
+}
+
+
+/*
+ * Note: Any tables added here should be duplicated within AcpiDmTableData
+ * in the file common/dmtable.c
+ */
+const AH_TABLE      AcpiSupportedTables[] =
+{
+    {ACPI_SIG_ASF,  "Alert Standard Format table"},
+    {ACPI_SIG_BERT, "Boot Error Record Table"},
+    {ACPI_SIG_BGRT, "Boot Graphics Resource Table"},
+    {ACPI_SIG_BOOT, "Simple Boot Flag Table"},
+    {ACPI_SIG_CPEP, "Corrected Platform Error Polling table"},
+    {ACPI_SIG_CSRT, "Core System Resource Table"},
+    {ACPI_SIG_DBG2, "Debug Port table type 2"},
+    {ACPI_SIG_DBGP, "Debug Port table"},
+    {ACPI_SIG_DMAR, "DMA Remapping table"},
+    {ACPI_SIG_DRTM, "Dynamic Root of Trust for Measurement table"},
+    {ACPI_SIG_DSDT, "Differentiated System Description Table (AML table)"},
+    {ACPI_SIG_ECDT, "Embedded Controller Boot Resources Table"},
+    {ACPI_SIG_EINJ, "Error Injection table"},
+    {ACPI_SIG_ERST, "Error Record Serialization Table"},
+    {ACPI_SIG_FACS, "Firmware ACPI Control Structure"},
+    {ACPI_SIG_FADT, "Fixed ACPI Description Table (FADT)"},
+    {ACPI_SIG_FPDT, "Firmware Performance Data Table"},
+    {ACPI_SIG_GTDT, "Generic Timer Description Table"},
+    {ACPI_SIG_HEST, "Hardware Error Source Table"},
+    {ACPI_SIG_HPET, "High Precision Event Timer table"},
+    {ACPI_SIG_IORT, "IO Remapping Table"},
+    {ACPI_SIG_IVRS, "I/O Virtualization Reporting Structure"},
+    {ACPI_SIG_LPIT, "Low Power Idle Table"},
+    {ACPI_SIG_MADT, "Multiple APIC Description Table (MADT)"},
+    {ACPI_SIG_MCFG, "Memory Mapped Configuration table"},
+    {ACPI_SIG_MCHI, "Management Controller Host Interface table"},
+    {ACPI_SIG_MPST, "Memory Power State Table"},
+    {ACPI_SIG_MSCT, "Maximum System Characteristics Table"},
+    {ACPI_SIG_MSDM, "Microsoft Data Management table"},
+    {ACPI_SIG_MTMR, "MID Timer Table"},
+    {ACPI_SIG_NFIT, "NVDIMM Firmware Interface Table"},
+    {ACPI_SIG_PCCT, "Platform Communications Channel Table"},
+    {ACPI_SIG_PMTT, "Platform Memory Topology Table"},
+    {ACPI_SIG_RASF, "RAS Features Table"},
+    {ACPI_RSDP_NAME,"Root System Description Pointer"},
+    {ACPI_SIG_RSDT, "Root System Description Table"},
+    {ACPI_SIG_S3PT, "S3 Performance Table"},
+    {ACPI_SIG_SBST, "Smart Battery Specification Table"},
+    {ACPI_SIG_SLIC, "Software Licensing Description Table"},
+    {ACPI_SIG_SLIT, "System Locality Information Table"},
+    {ACPI_SIG_SPCR, "Serial Port Console Redirection table"},
+    {ACPI_SIG_SPMI, "Server Platform Management Interface table"},
+    {ACPI_SIG_SRAT, "System Resource Affinity Table"},
+    {ACPI_SIG_SSDT, "Secondary System Description Table (AML table)"},
+    {ACPI_SIG_STAO, "Status Override table"},
+    {ACPI_SIG_TCPA, "Trusted Computing Platform Alliance table"},
+    {ACPI_SIG_TPM2, "Trusted Platform Module hardware interface table"},
+    {ACPI_SIG_UEFI, "UEFI Boot Optimization Table"},
+    {ACPI_SIG_VRTC, "Virtual Real-Time Clock Table"},
+    {ACPI_SIG_WAET, "Windows ACPI Emulated Devices Table"},
+    {ACPI_SIG_WDAT, "Watchdog Action Table"},
+    {ACPI_SIG_WDDT, "Watchdog Description Table"},
+    {ACPI_SIG_WDRT, "Watchdog Resource Table"},
+    {ACPI_SIG_WPBT, "Windows Platform Binary Table"},
+    {ACPI_SIG_XENV, "Xen Environment table"},
+    {ACPI_SIG_XSDT, "Extended System Description Table"},
+    {NULL,          NULL}
+};

--- a/sys/src/libacpi/acpica/common/ahuuids.c
+++ b/sys/src/libacpi/acpica/common/ahuuids.c
@@ -1,0 +1,205 @@
+/******************************************************************************
+ *
+ * Module Name: ahuuids - Table of known ACPI-related UUIDs
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+#include "acuuid.h"
+
+#define _COMPONENT          ACPI_UTILITIES
+        ACPI_MODULE_NAME    ("ahuuids")
+
+
+/*
+ * Table of "known" (ACPI-related) UUIDs
+ */
+const AH_UUID  AcpiUuids[] =
+{
+    {"[Controllers]",               NULL},
+    {"GPIO Controller",             UUID_GPIO_CONTROLLER},
+    {"USB Controller",              UUID_USB_CONTROLLER},
+    {"SATA Controller",             UUID_SATA_CONTROLLER},
+
+    {"[Devices]",                   NULL},
+    {"PCI Host Bridge Device",      UUID_PCI_HOST_BRIDGE},
+    {"HID I2C Device",              UUID_I2C_DEVICE},
+    {"Power Button Device",         UUID_POWER_BUTTON},
+
+    {"[Interfaces]",                NULL},
+    {"Device Labeling Interface",   UUID_DEVICE_LABELING},
+    {"Physical Presence Interface", UUID_PHYSICAL_PRESENCE},
+
+    {"[Non-volatile DIMM and NFIT table]",       NULL},
+    {"Volatile Memory Region",      UUID_VOLATILE_MEMORY},
+    {"Persistent Memory Region",    UUID_PERSISTENT_MEMORY},
+    {"NVDIMM Control Region",       UUID_CONTROL_REGION},
+    {"NVDIMM Data Region",          UUID_DATA_REGION},
+    {"Volatile Virtual Disk",       UUID_VOLATILE_VIRTUAL_DISK},
+    {"Volatile Virtual CD",         UUID_VOLATILE_VIRTUAL_CD},
+    {"Persistent Virtual Disk",     UUID_PERSISTENT_VIRTUAL_DISK},
+    {"Persistent Virtual CD",       UUID_PERSISTENT_VIRTUAL_CD},
+
+    {"[Miscellaneous]",             NULL},
+    {"Platform-wide Capabilities",  UUID_PLATFORM_CAPABILITIES},
+    {"Dynamic Enumeration",         UUID_DYNAMIC_ENUMERATION},
+    {"Battery Thermal Limit",       UUID_BATTERY_THERMAL_LIMIT},
+    {"Thermal Extensions",          UUID_THERMAL_EXTENSIONS},
+    {"Device Properties for _DSD",  UUID_DEVICE_PROPERTIES},
+
+    {NULL, NULL}
+};
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiAhMatchUuid
+ *
+ * PARAMETERS:  Data                - Data buffer containing a UUID
+ *
+ * RETURN:      ASCII description string for the UUID if it is found.
+ *
+ * DESCRIPTION: Returns a description string for "known" UUIDs, which are
+ *              are UUIDs that are related to ACPI in some way.
+ *
+ ******************************************************************************/
+
+const char *
+AcpiAhMatchUuid (
+    UINT8                   *Data)
+{
+    const AH_UUID           *Info;
+    UINT8                   UuidBuffer[UUID_BUFFER_LENGTH];
+
+
+    /* Walk the table of known ACPI-related UUIDs */
+
+    for (Info = AcpiUuids; Info->Description; Info++)
+    {
+        /* Null string means desciption is a UUID class */
+
+        if (!Info->String)
+        {
+            continue;
+        }
+
+        AcpiUtConvertStringToUuid (Info->String, UuidBuffer);
+
+        if (!memcmp (Data, UuidBuffer, UUID_BUFFER_LENGTH))
+        {
+            return (Info->Description);
+        }
+    }
+
+    return (NULL);
+}

--- a/sys/src/libacpi/acpica/common/build.json
+++ b/sys/src/libacpi/acpica/common/build.json
@@ -1,0 +1,14 @@
+{
+	"Libacpi": {
+		"Include": [
+			"/sys/src/libacpi/acpica/acpiflags.json"
+		],
+		"Install": "/$ARCH/lib/",
+		"Library": "libacpi.a",
+		"SourceFiles": [
+			"ahids.c",
+			"ahuuids.c"
+			]
+		}
+}
+	

--- a/sys/src/libacpi/acpica/common/cmfsize.c
+++ b/sys/src/libacpi/acpica/common/cmfsize.c
@@ -1,0 +1,185 @@
+/******************************************************************************
+ *
+ * Module Name: cfsize - Common get file size function
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+#include "acapps.h"
+#include <stdio.h>
+
+#define _COMPONENT          ACPI_TOOLS
+        ACPI_MODULE_NAME    ("cmfsize")
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    CmGetFileSize
+ *
+ * PARAMETERS:  File                    - Open file descriptor
+ *
+ * RETURN:      File Size. On error, -1 (ACPI_UINT32_MAX)
+ *
+ * DESCRIPTION: Get the size of a file. Uses seek-to-EOF. File must be open.
+ *              Does not disturb the current file pointer.
+ *
+ ******************************************************************************/
+
+UINT32
+CmGetFileSize (
+    ACPI_FILE               File)
+{
+    long                    FileSize;
+    long                    CurrentOffset;
+    ACPI_STATUS             Status;
+
+
+    /* Save the current file pointer, seek to EOF to obtain file size */
+
+    CurrentOffset = AcpiOsGetFileOffset (File);
+    if (CurrentOffset < 0)
+    {
+        goto OffsetError;
+    }
+
+    Status = AcpiOsSetFileOffset (File, 0, ACPI_FILE_END);
+    if (ACPI_FAILURE (Status))
+    {
+        goto SeekError;
+    }
+
+    FileSize = AcpiOsGetFileOffset (File);
+    if (FileSize < 0)
+    {
+        goto OffsetError;
+    }
+
+    /* Restore original file pointer */
+
+    Status = AcpiOsSetFileOffset (File, CurrentOffset, ACPI_FILE_BEGIN);
+    if (ACPI_FAILURE (Status))
+    {
+        goto SeekError;
+    }
+
+    return ((UINT32) FileSize);
+
+
+OffsetError:
+    AcpiLogError ("Could not get file offset");
+    return (ACPI_UINT32_MAX);
+
+SeekError:
+    AcpiLogError ("Could not set file offset");
+    return (ACPI_UINT32_MAX);
+}

--- a/sys/src/libacpi/acpica/common/dmextern.c
+++ b/sys/src/libacpi/acpica/common/dmextern.c
@@ -1,0 +1,1424 @@
+/******************************************************************************
+ *
+ * Module Name: dmextern - Support for External() ASL statements
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+#include "amlcode.h"
+#include "acnamesp.h"
+#include "acdisasm.h"
+#include "aslcompiler.h"
+#include <stdio.h>
+#include <errno.h>
+
+
+/*
+ * This module is used for application-level code (iASL disassembler) only.
+ *
+ * It contains the code to create and emit any necessary External() ASL
+ * statements for the module being disassembled.
+ */
+#define _COMPONENT          ACPI_CA_DISASSEMBLER
+        ACPI_MODULE_NAME    ("dmextern")
+
+
+/*
+ * This table maps ACPI_OBJECT_TYPEs to the corresponding ASL
+ * ObjectTypeKeyword. Used to generate typed external declarations
+ */
+static const char           *AcpiGbl_DmTypeNames[] =
+{
+    /* 00 */ ", UnknownObj",        /* Type ANY */
+    /* 01 */ ", IntObj",
+    /* 02 */ ", StrObj",
+    /* 03 */ ", BuffObj",
+    /* 04 */ ", PkgObj",
+    /* 05 */ ", FieldUnitObj",
+    /* 06 */ ", DeviceObj",
+    /* 07 */ ", EventObj",
+    /* 08 */ ", MethodObj",
+    /* 09 */ ", MutexObj",
+    /* 10 */ ", OpRegionObj",
+    /* 11 */ ", PowerResObj",
+    /* 12 */ ", ProcessorObj",
+    /* 13 */ ", ThermalZoneObj",
+    /* 14 */ ", BuffFieldObj",
+    /* 15 */ ", DDBHandleObj",
+    /* 16 */ "",                    /* Debug object */
+    /* 17 */ ", FieldUnitObj",
+    /* 18 */ ", FieldUnitObj",
+    /* 19 */ ", FieldUnitObj"
+};
+
+#define METHOD_SEPARATORS           " \t,()\n"
+
+
+/* Local prototypes */
+
+static const char *
+AcpiDmGetObjectTypeName (
+    ACPI_OBJECT_TYPE        Type);
+
+static char *
+AcpiDmNormalizeParentPrefix (
+    ACPI_PARSE_OBJECT       *Op,
+    char                    *Path);
+
+static void
+AcpiDmAddPathToExternalList (
+    char                    *Path,
+    UINT8                   Type,
+    UINT32                  Value,
+    UINT16                  Flags);
+
+static ACPI_STATUS
+AcpiDmCreateNewExternal (
+    char                    *ExternalPath,
+    char                    *InternalPath,
+    UINT8                   Type,
+    UINT32                  Value,
+    UINT16                  Flags);
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmGetObjectTypeName
+ *
+ * PARAMETERS:  Type                - An ACPI_OBJECT_TYPE
+ *
+ * RETURN:      Pointer to a string
+ *
+ * DESCRIPTION: Map an object type to the ASL object type string.
+ *
+ ******************************************************************************/
+
+static const char *
+AcpiDmGetObjectTypeName (
+    ACPI_OBJECT_TYPE        Type)
+{
+
+    if (Type == ACPI_TYPE_LOCAL_SCOPE)
+    {
+        Type = ACPI_TYPE_DEVICE;
+    }
+    else if (Type > ACPI_TYPE_LOCAL_INDEX_FIELD)
+    {
+        return ("");
+    }
+
+    return (AcpiGbl_DmTypeNames[Type]);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmNormalizeParentPrefix
+ *
+ * PARAMETERS:  Op                  - Parse op
+ *              Path                - Path with parent prefix
+ *
+ * RETURN:      The full pathname to the object (from the namespace root)
+ *
+ * DESCRIPTION: Returns the full pathname of a path with parent prefix
+ *              The caller must free the fullpath returned.
+ *
+ ******************************************************************************/
+
+static char *
+AcpiDmNormalizeParentPrefix (
+    ACPI_PARSE_OBJECT       *Op,
+    char                    *Path)
+{
+    ACPI_NAMESPACE_NODE     *Node;
+    char                    *Fullpath;
+    char                    *ParentPath;
+    ACPI_SIZE               Length;
+    UINT32                  Index = 0;
+
+
+    if (!Op)
+    {
+        return (NULL);
+    }
+
+    /* Search upwards in the parse tree until we reach the next namespace node */
+
+    Op = Op->Common.Parent;
+    while (Op)
+    {
+        if (Op->Common.Node)
+        {
+            break;
+        }
+
+        Op = Op->Common.Parent;
+    }
+
+    if (!Op)
+    {
+        return (NULL);
+    }
+
+    /*
+     * Find the actual parent node for the reference:
+     * Remove all carat prefixes from the input path.
+     * There may be multiple parent prefixes (For example, ^^^M000)
+     */
+    Node = Op->Common.Node;
+    while (Node && (*Path == (UINT8) AML_PARENT_PREFIX))
+    {
+        Node = Node->Parent;
+        Path++;
+    }
+
+    if (!Node)
+    {
+        return (NULL);
+    }
+
+    /* Get the full pathname for the parent node */
+
+    ParentPath = AcpiNsGetExternalPathname (Node);
+    if (!ParentPath)
+    {
+        return (NULL);
+    }
+
+    Length = (strlen (ParentPath) + strlen (Path) + 1);
+    if (ParentPath[1])
+    {
+        /*
+         * If ParentPath is not just a simple '\', increment the length
+         * for the required dot separator (ParentPath.Path)
+         */
+        Length++;
+
+        /* For External() statements, we do not want a leading '\' */
+
+        if (*ParentPath == AML_ROOT_PREFIX)
+        {
+            Index = 1;
+        }
+    }
+
+    Fullpath = ACPI_ALLOCATE_ZEROED (Length);
+    if (!Fullpath)
+    {
+        goto Cleanup;
+    }
+
+    /*
+     * Concatenate parent fullpath and path. For example,
+     * parent fullpath "\_SB_", Path "^INIT", Fullpath "\_SB_.INIT"
+     *
+     * Copy the parent path
+     */
+    strcpy (Fullpath, &ParentPath[Index]);
+
+    /*
+     * Add dot separator
+     * (don't need dot if parent fullpath is a single backslash)
+     */
+    if (ParentPath[1])
+    {
+        strcat (Fullpath, ".");
+    }
+
+    /* Copy child path (carat parent prefix(es) were skipped above) */
+
+    strcat (Fullpath, Path);
+
+Cleanup:
+    ACPI_FREE (ParentPath);
+    return (Fullpath);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmAddToExternalFileList
+ *
+ * PARAMETERS:  PathList            - Single path or list separated by comma
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Add external files to global list
+ *
+ ******************************************************************************/
+
+ACPI_STATUS
+AcpiDmAddToExternalFileList (
+    char                    *Pathname)
+{
+    ACPI_EXTERNAL_FILE      *ExternalFile;
+    char                    *LocalPathname;
+
+
+    if (!Pathname)
+    {
+        return (AE_OK);
+    }
+
+    LocalPathname = ACPI_ALLOCATE (strlen (Pathname) + 1);
+    if (!LocalPathname)
+    {
+        return (AE_NO_MEMORY);
+    }
+
+    ExternalFile = ACPI_ALLOCATE_ZEROED (sizeof (ACPI_EXTERNAL_FILE));
+    if (!ExternalFile)
+    {
+        ACPI_FREE (LocalPathname);
+        return (AE_NO_MEMORY);
+    }
+
+    /* Take a copy of the file pathname */
+
+    strcpy (LocalPathname, Pathname);
+    ExternalFile->Path = LocalPathname;
+
+    if (AcpiGbl_ExternalFileList)
+    {
+        ExternalFile->Next = AcpiGbl_ExternalFileList;
+    }
+
+    AcpiGbl_ExternalFileList = ExternalFile;
+    return (AE_OK);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmClearExternalFileList
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Clear the external file list
+ *
+ ******************************************************************************/
+
+void
+AcpiDmClearExternalFileList (
+    void)
+{
+    ACPI_EXTERNAL_FILE      *NextExternal;
+
+
+    while (AcpiGbl_ExternalFileList)
+    {
+        NextExternal = AcpiGbl_ExternalFileList->Next;
+        ACPI_FREE (AcpiGbl_ExternalFileList->Path);
+        ACPI_FREE (AcpiGbl_ExternalFileList);
+        AcpiGbl_ExternalFileList = NextExternal;
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmGetExternalsFromFile
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Process the optional external reference file.
+ *
+ * Each line in the file should be of the form:
+ *      External (<Method namepath>, MethodObj, <ArgCount>)
+ *
+ * Example:
+ *      External (_SB_.PCI0.XHC_.PS0X, MethodObj, 4)
+ *
+ ******************************************************************************/
+
+void
+AcpiDmGetExternalsFromFile (
+    void)
+{
+    FILE                    *ExternalRefFile;
+    char                    *Token;
+    char                    *MethodName;
+    UINT32                  ArgCount;
+    UINT32                  ImportCount = 0;
+
+
+    if (!Gbl_ExternalRefFilename)
+    {
+        return;
+    }
+
+    /* Open the file */
+
+    ExternalRefFile = fopen (Gbl_ExternalRefFilename, "r");
+    if (!ExternalRefFile)
+    {
+        fprintf (stderr, "Could not open external reference file \"%s\"\n",
+            Gbl_ExternalRefFilename);
+        AslAbort ();
+        return;
+    }
+
+    /* Each line defines a method */
+
+    while (fgets (StringBuffer, ASL_MSG_BUFFER_SIZE, ExternalRefFile))
+    {
+        Token = strtok (StringBuffer, METHOD_SEPARATORS);   /* "External" */
+        if (!Token)
+        {
+            continue;
+        }
+
+        if (strcmp (Token, "External"))
+        {
+            continue;
+        }
+
+        MethodName = strtok (NULL, METHOD_SEPARATORS);      /* Method namepath */
+        if (!MethodName)
+        {
+            continue;
+        }
+
+        Token = strtok (NULL, METHOD_SEPARATORS);           /* "MethodObj" */
+        if (!Token)
+        {
+            continue;
+        }
+
+        if (strcmp (Token, "MethodObj"))
+        {
+            continue;
+        }
+
+        Token = strtok (NULL, METHOD_SEPARATORS);           /* Arg count */
+        if (!Token)
+        {
+            continue;
+        }
+
+        /* Convert arg count string to an integer */
+
+        errno = 0;
+        ArgCount = strtoul (Token, NULL, 0);
+        if (errno)
+        {
+            fprintf (stderr, "Invalid argument count (%s)\n", Token);
+            continue;
+        }
+
+        if (ArgCount > 7)
+        {
+            fprintf (stderr, "Invalid argument count (%u)\n", ArgCount);
+            continue;
+        }
+
+        /* Add this external to the global list */
+
+        AcpiOsPrintf ("%s: Importing method external (%u arguments) %s\n",
+            Gbl_ExternalRefFilename, ArgCount, MethodName);
+
+        AcpiDmAddPathToExternalList (MethodName, ACPI_TYPE_METHOD,
+            ArgCount, (ACPI_EXT_RESOLVED_REFERENCE | ACPI_EXT_ORIGIN_FROM_FILE));
+        ImportCount++;
+    }
+
+    if (!ImportCount)
+    {
+        fprintf (stderr,
+            "Did not find any external methods in reference file \"%s\"\n",
+            Gbl_ExternalRefFilename);
+    }
+    else
+    {
+        /* Add the external(s) to the namespace */
+
+        AcpiDmAddExternalsToNamespace ();
+
+        AcpiOsPrintf ("%s: Imported %u external method definitions\n",
+            Gbl_ExternalRefFilename, ImportCount);
+    }
+
+    fclose (ExternalRefFile);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmAddOpToExternalList
+ *
+ * PARAMETERS:  Op                  - Current parser Op
+ *              Path                - Internal (AML) path to the object
+ *              Type                - ACPI object type to be added
+ *              Value               - Arg count if adding a Method object
+ *              Flags               - To be passed to the external object
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Insert a new name into the global list of Externals which
+ *              will in turn be later emitted as an External() declaration
+ *              in the disassembled output.
+ *
+ *              This function handles the most common case where the referenced
+ *              name is simply not found in the constructed namespace.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmAddOpToExternalList (
+    ACPI_PARSE_OBJECT       *Op,
+    char                    *Path,
+    UINT8                   Type,
+    UINT32                  Value,
+    UINT16                  Flags)
+{
+    char                    *ExternalPath;
+    char                    *InternalPath = Path;
+    char                    *Temp;
+    ACPI_STATUS             Status;
+
+
+    ACPI_FUNCTION_TRACE (DmAddOpToExternalList);
+
+
+    if (!Path)
+    {
+        return_VOID;
+    }
+
+    /* Remove a root backslash if present */
+
+    if ((*Path == AML_ROOT_PREFIX) && (Path[1]))
+    {
+        Path++;
+    }
+
+    /* Externalize the pathname */
+
+    Status = AcpiNsExternalizeName (ACPI_UINT32_MAX, Path,
+        NULL, &ExternalPath);
+    if (ACPI_FAILURE (Status))
+    {
+        return_VOID;
+    }
+
+    /*
+     * Get the full pathname from the root if "Path" has one or more
+     * parent prefixes (^). Note: path will not contain a leading '\'.
+     */
+    if (*Path == (UINT8) AML_PARENT_PREFIX)
+    {
+        Temp = AcpiDmNormalizeParentPrefix (Op, ExternalPath);
+
+        /* Set new external path */
+
+        ACPI_FREE (ExternalPath);
+        ExternalPath = Temp;
+        if (!Temp)
+        {
+            return_VOID;
+        }
+
+        /* Create the new internal pathname */
+
+        Flags |= ACPI_EXT_INTERNAL_PATH_ALLOCATED;
+        Status = AcpiNsInternalizeName (ExternalPath, &InternalPath);
+        if (ACPI_FAILURE (Status))
+        {
+            ACPI_FREE (ExternalPath);
+            return_VOID;
+        }
+    }
+
+    /* Create the new External() declaration node */
+
+    Status = AcpiDmCreateNewExternal (ExternalPath, InternalPath,
+        Type, Value, Flags);
+    if (ACPI_FAILURE (Status))
+    {
+        ACPI_FREE (ExternalPath);
+        if (Flags & ACPI_EXT_INTERNAL_PATH_ALLOCATED)
+        {
+            ACPI_FREE (InternalPath);
+        }
+    }
+
+    return_VOID;
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmAddNodeToExternalList
+ *
+ * PARAMETERS:  Node                - Namespace node for object to be added
+ *              Type                - ACPI object type to be added
+ *              Value               - Arg count if adding a Method object
+ *              Flags               - To be passed to the external object
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Insert a new name into the global list of Externals which
+ *              will in turn be later emitted as an External() declaration
+ *              in the disassembled output.
+ *
+ *              This function handles the case where the referenced name has
+ *              been found in the namespace, but the name originated in a
+ *              table other than the one that is being disassembled (such
+ *              as a table that is added via the iASL -e option).
+ *
+ ******************************************************************************/
+
+void
+AcpiDmAddNodeToExternalList (
+    ACPI_NAMESPACE_NODE     *Node,
+    UINT8                   Type,
+    UINT32                  Value,
+    UINT16                  Flags)
+{
+    char                    *ExternalPath;
+    char                    *InternalPath;
+    char                    *Temp;
+    ACPI_STATUS             Status;
+
+
+    ACPI_FUNCTION_TRACE (DmAddNodeToExternalList);
+
+
+    if (!Node)
+    {
+        return_VOID;
+    }
+
+    /* Get the full external and internal pathnames to the node */
+
+    ExternalPath = AcpiNsGetExternalPathname (Node);
+    if (!ExternalPath)
+    {
+        return_VOID;
+    }
+
+    Status = AcpiNsInternalizeName (ExternalPath, &InternalPath);
+    if (ACPI_FAILURE (Status))
+    {
+        ACPI_FREE (ExternalPath);
+        return_VOID;
+    }
+
+    /* Remove the root backslash */
+
+    if ((*ExternalPath == AML_ROOT_PREFIX) && (ExternalPath[1]))
+    {
+        Temp = ACPI_ALLOCATE_ZEROED (strlen (ExternalPath) + 1);
+        if (!Temp)
+        {
+            return_VOID;
+        }
+
+        strcpy (Temp, &ExternalPath[1]);
+        ACPI_FREE (ExternalPath);
+        ExternalPath = Temp;
+    }
+
+    /* Create the new External() declaration node */
+
+    Status = AcpiDmCreateNewExternal (ExternalPath, InternalPath, Type,
+        Value, (Flags | ACPI_EXT_INTERNAL_PATH_ALLOCATED));
+    if (ACPI_FAILURE (Status))
+    {
+        ACPI_FREE (ExternalPath);
+        ACPI_FREE (InternalPath);
+    }
+
+    return_VOID;
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmAddPathToExternalList
+ *
+ * PARAMETERS:  Path                - External name of the object to be added
+ *              Type                - ACPI object type to be added
+ *              Value               - Arg count if adding a Method object
+ *              Flags               - To be passed to the external object
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Insert a new name into the global list of Externals which
+ *              will in turn be later emitted as an External() declaration
+ *              in the disassembled output.
+ *
+ *              This function currently is used to add externals via a
+ *              reference file (via the -fe iASL option).
+ *
+ ******************************************************************************/
+
+static void
+AcpiDmAddPathToExternalList (
+    char                    *Path,
+    UINT8                   Type,
+    UINT32                  Value,
+    UINT16                  Flags)
+{
+    char                    *InternalPath;
+    char                    *ExternalPath;
+    ACPI_STATUS             Status;
+
+
+    ACPI_FUNCTION_TRACE (DmAddPathToExternalList);
+
+
+    if (!Path)
+    {
+        return_VOID;
+    }
+
+    /* Remove a root backslash if present */
+
+    if ((*Path == AML_ROOT_PREFIX) && (Path[1]))
+    {
+        Path++;
+    }
+
+    /* Create the internal and external pathnames */
+
+    Status = AcpiNsInternalizeName (Path, &InternalPath);
+    if (ACPI_FAILURE (Status))
+    {
+        return_VOID;
+    }
+
+    Status = AcpiNsExternalizeName (ACPI_UINT32_MAX, InternalPath,
+        NULL, &ExternalPath);
+    if (ACPI_FAILURE (Status))
+    {
+        ACPI_FREE (InternalPath);
+        return_VOID;
+    }
+
+    /* Create the new External() declaration node */
+
+    Status = AcpiDmCreateNewExternal (ExternalPath, InternalPath,
+        Type, Value, (Flags | ACPI_EXT_INTERNAL_PATH_ALLOCATED));
+    if (ACPI_FAILURE (Status))
+    {
+        ACPI_FREE (ExternalPath);
+        ACPI_FREE (InternalPath);
+    }
+
+    return_VOID;
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmCreateNewExternal
+ *
+ * PARAMETERS:  ExternalPath        - External path to the object
+ *              InternalPath        - Internal (AML) path to the object
+ *              Type                - ACPI object type to be added
+ *              Value               - Arg count if adding a Method object
+ *              Flags               - To be passed to the external object
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Common low-level function to insert a new name into the global
+ *              list of Externals which will in turn be later emitted as
+ *              External() declarations in the disassembled output.
+ *
+ *              Note: The external name should not include a root prefix
+ *              (backslash). We do not want External() statements to contain
+ *              a leading '\', as this prevents duplicate external statements
+ *              of the form:
+ *
+ *                  External (\ABCD)
+ *                  External (ABCD)
+ *
+ *              This would cause a compile time error when the disassembled
+ *              output file is recompiled.
+ *
+ *              There are two cases that are handled here. For both, we emit
+ *              an External() statement:
+ *              1) The name was simply not found in the namespace.
+ *              2) The name was found, but it originated in a table other than
+ *              the table that is being disassembled.
+ *
+ ******************************************************************************/
+
+static ACPI_STATUS
+AcpiDmCreateNewExternal (
+    char                    *ExternalPath,
+    char                    *InternalPath,
+    UINT8                   Type,
+    UINT32                  Value,
+    UINT16                  Flags)
+{
+    ACPI_EXTERNAL_LIST      *NewExternal;
+    ACPI_EXTERNAL_LIST      *NextExternal;
+    ACPI_EXTERNAL_LIST      *PrevExternal = NULL;
+
+
+    ACPI_FUNCTION_TRACE (DmCreateNewExternal);
+
+
+    /* Check all existing externals to ensure no duplicates */
+
+    NextExternal = AcpiGbl_ExternalList;
+    while (NextExternal)
+    {
+        /* Check for duplicates */
+
+        if (!strcmp (ExternalPath, NextExternal->Path))
+        {
+            /*
+             * If this external came from an External() opcode, we are
+             * finished with this one. (No need to check any further).
+             */
+            if (NextExternal->Flags & ACPI_EXT_ORIGIN_FROM_OPCODE)
+            {
+                return_ACPI_STATUS (AE_ALREADY_EXISTS);
+            }
+
+            /* Allow upgrade of type from ANY */
+
+            else if ((NextExternal->Type == ACPI_TYPE_ANY) &&
+                (Type != ACPI_TYPE_ANY))
+            {
+                NextExternal->Type = Type;
+            }
+
+            /* Update the argument count as necessary */
+
+            if (Value < NextExternal->Value)
+            {
+                NextExternal->Value = Value;
+            }
+
+            /* Update flags. */
+
+            NextExternal->Flags |= Flags;
+            NextExternal->Flags &= ~ACPI_EXT_INTERNAL_PATH_ALLOCATED;
+
+            return_ACPI_STATUS (AE_ALREADY_EXISTS);
+        }
+
+        NextExternal = NextExternal->Next;
+    }
+
+    /* Allocate and init a new External() descriptor */
+
+    NewExternal = ACPI_ALLOCATE_ZEROED (sizeof (ACPI_EXTERNAL_LIST));
+    if (!NewExternal)
+    {
+        return_ACPI_STATUS (AE_NO_MEMORY);
+    }
+
+    ACPI_DEBUG_PRINT ((ACPI_DB_NAMES,
+        "Adding external reference node (%s) type [%s]\n",
+        ExternalPath, AcpiUtGetTypeName (Type)));
+
+    NewExternal->Flags = Flags;
+    NewExternal->Value = Value;
+    NewExternal->Path = ExternalPath;
+    NewExternal->Type = Type;
+    NewExternal->Length = (UINT16) strlen (ExternalPath);
+    NewExternal->InternalPath = InternalPath;
+
+    /* Link the new descriptor into the global list, alphabetically ordered */
+
+    NextExternal = AcpiGbl_ExternalList;
+    while (NextExternal)
+    {
+        if (AcpiUtStricmp (NewExternal->Path, NextExternal->Path) < 0)
+        {
+            if (PrevExternal)
+            {
+                PrevExternal->Next = NewExternal;
+            }
+            else
+            {
+                AcpiGbl_ExternalList = NewExternal;
+            }
+
+            NewExternal->Next = NextExternal;
+            return_ACPI_STATUS (AE_OK);
+        }
+
+        PrevExternal = NextExternal;
+        NextExternal = NextExternal->Next;
+    }
+
+    if (PrevExternal)
+    {
+        PrevExternal->Next = NewExternal;
+    }
+    else
+    {
+        AcpiGbl_ExternalList = NewExternal;
+    }
+
+    return_ACPI_STATUS (AE_OK);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmAddExternalsToNamespace
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Add all externals to the namespace. Allows externals to be
+ *              "resolved".
+ *
+ ******************************************************************************/
+
+void
+AcpiDmAddExternalsToNamespace (
+    void)
+{
+    ACPI_STATUS             Status;
+    ACPI_NAMESPACE_NODE     *Node;
+    ACPI_OPERAND_OBJECT     *ObjDesc;
+    ACPI_EXTERNAL_LIST      *External = AcpiGbl_ExternalList;
+
+
+    while (External)
+    {
+        /* Add the external name (object) into the namespace */
+
+        Status = AcpiNsLookup (NULL, External->InternalPath, External->Type,
+            ACPI_IMODE_LOAD_PASS1,
+            ACPI_NS_ERROR_IF_FOUND | ACPI_NS_EXTERNAL | ACPI_NS_DONT_OPEN_SCOPE,
+            NULL, &Node);
+
+        if (ACPI_FAILURE (Status))
+        {
+            ACPI_EXCEPTION ((AE_INFO, Status,
+                "while adding external to namespace [%s]",
+                External->Path));
+        }
+
+        else switch (External->Type)
+        {
+        case ACPI_TYPE_METHOD:
+
+            /* For methods, we need to save the argument count */
+
+            ObjDesc = AcpiUtCreateInternalObject (ACPI_TYPE_METHOD);
+            ObjDesc->Method.ParamCount = (UINT8) External->Value;
+            Node->Object = ObjDesc;
+            break;
+
+        case ACPI_TYPE_REGION:
+
+            /* Regions require a region sub-object */
+
+            ObjDesc = AcpiUtCreateInternalObject (ACPI_TYPE_REGION);
+            ObjDesc->Region.Node = Node;
+            Node->Object = ObjDesc;
+            break;
+
+        default:
+
+            break;
+        }
+
+        External = External->Next;
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmGetExternalMethodCount
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      The number of control method externals in the external list
+ *
+ * DESCRIPTION: Return the number of method externals that have been generated.
+ *              If any control method externals have been found, we must
+ *              re-parse the entire definition block with the new information
+ *              (number of arguments for the methods.) This is limitation of
+ *              AML, we don't know the number of arguments from the control
+ *              method invocation itself.
+ *
+ ******************************************************************************/
+
+UINT32
+AcpiDmGetExternalMethodCount (
+    void)
+{
+    ACPI_EXTERNAL_LIST      *External = AcpiGbl_ExternalList;
+    UINT32                  Count = 0;
+
+
+    while (External)
+    {
+        if (External->Type == ACPI_TYPE_METHOD)
+        {
+            Count++;
+        }
+
+        External = External->Next;
+    }
+
+    return (Count);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmClearExternalList
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Free the entire External info list
+ *
+ ******************************************************************************/
+
+void
+AcpiDmClearExternalList (
+    void)
+{
+    ACPI_EXTERNAL_LIST      *NextExternal;
+
+
+    while (AcpiGbl_ExternalList)
+    {
+        NextExternal = AcpiGbl_ExternalList->Next;
+        ACPI_FREE (AcpiGbl_ExternalList->Path);
+        ACPI_FREE (AcpiGbl_ExternalList);
+        AcpiGbl_ExternalList = NextExternal;
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmEmitExternals
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Emit an External() ASL statement for each of the externals in
+ *              the global external info list.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmEmitExternals (
+    void)
+{
+    ACPI_EXTERNAL_LIST      *NextExternal;
+
+
+    if (!AcpiGbl_ExternalList)
+    {
+        return;
+    }
+
+    /*
+     * Determine the number of control methods in the external list, and
+     * also how many of those externals were resolved via the namespace.
+     */
+    NextExternal = AcpiGbl_ExternalList;
+    while (NextExternal)
+    {
+        if (NextExternal->Type == ACPI_TYPE_METHOD)
+        {
+            AcpiGbl_NumExternalMethods++;
+            if (NextExternal->Flags & ACPI_EXT_RESOLVED_REFERENCE)
+            {
+                AcpiGbl_ResolvedExternalMethods++;
+            }
+        }
+
+        NextExternal = NextExternal->Next;
+    }
+
+    /* Check if any control methods were unresolved */
+
+    AcpiDmUnresolvedWarning (1);
+
+    if (Gbl_ExternalRefFilename)
+    {
+        AcpiOsPrintf (
+            "    /*\n     * External declarations were imported from\n"
+            "     * a reference file -- %s\n     */\n\n",
+            Gbl_ExternalRefFilename);
+    }
+
+    /*
+     * Walk and emit the list of externals found during the AML parsing
+     */
+    while (AcpiGbl_ExternalList)
+    {
+        if (!(AcpiGbl_ExternalList->Flags & ACPI_EXT_EXTERNAL_EMITTED))
+        {
+            AcpiOsPrintf ("    External (%s%s)",
+                AcpiGbl_ExternalList->Path,
+                AcpiDmGetObjectTypeName (AcpiGbl_ExternalList->Type));
+
+            /* Check for "unresolved" method reference */
+
+            if ((AcpiGbl_ExternalList->Type == ACPI_TYPE_METHOD) &&
+                (!(AcpiGbl_ExternalList->Flags & ACPI_EXT_RESOLVED_REFERENCE)))
+            {
+                AcpiOsPrintf ("    // Warning: Unknown method, "
+                    "guessing %u arguments",
+                    AcpiGbl_ExternalList->Value);
+            }
+
+            /* Check for external from a external references file */
+
+            else if (AcpiGbl_ExternalList->Flags & ACPI_EXT_ORIGIN_FROM_FILE)
+            {
+                if (AcpiGbl_ExternalList->Type == ACPI_TYPE_METHOD)
+                {
+                    AcpiOsPrintf ("    // %u Arguments",
+                        AcpiGbl_ExternalList->Value);
+                }
+
+                AcpiOsPrintf ("    // From external reference file");
+            }
+
+            /* This is the normal external case */
+
+            else
+            {
+                /* For methods, add a comment with the number of arguments */
+
+                if (AcpiGbl_ExternalList->Type == ACPI_TYPE_METHOD)
+                {
+                    AcpiOsPrintf ("    // %u Arguments",
+                        AcpiGbl_ExternalList->Value);
+                }
+            }
+
+            AcpiOsPrintf ("\n");
+        }
+
+        /* Free this external info block and move on to next external */
+
+        NextExternal = AcpiGbl_ExternalList->Next;
+        if (AcpiGbl_ExternalList->Flags & ACPI_EXT_INTERNAL_PATH_ALLOCATED)
+        {
+            ACPI_FREE (AcpiGbl_ExternalList->InternalPath);
+        }
+
+        ACPI_FREE (AcpiGbl_ExternalList->Path);
+        ACPI_FREE (AcpiGbl_ExternalList);
+        AcpiGbl_ExternalList = NextExternal;
+    }
+
+    AcpiOsPrintf ("\n");
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmUnresolvedWarning
+ *
+ * PARAMETERS:  Type                - Where to output the warning.
+ *                                    0 means write to stderr
+ *                                    1 means write to AcpiOsPrintf
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Issue warning message if there are unresolved external control
+ *              methods within the disassembly.
+ *
+ ******************************************************************************/
+
+#if 0
+Summary of the external control method problem:
+
+When the -e option is used with disassembly, the various SSDTs are simply
+loaded into a global namespace for the disassembler to use in order to
+resolve control method references (invocations).
+
+The disassembler tracks any such references, and will emit an External()
+statement for these types of methods, with the proper number of arguments .
+
+Without the SSDTs, the AML does not contain enough information to properly
+disassemble the control method invocation -- because the disassembler does
+not know how many arguments to parse.
+
+An example: Assume we have two control methods. ABCD has one argument, and
+EFGH has zero arguments. Further, we have two additional control methods
+that invoke ABCD and EFGH, named T1 and T2:
+
+    Method (ABCD, 1)
+    {
+    }
+    Method (EFGH, 0)
+    {
+    }
+    Method (T1)
+    {
+        ABCD (Add (2, 7, Local0))
+    }
+    Method (T2)
+    {
+        EFGH ()
+        Add (2, 7, Local0)
+    }
+
+Here is the AML code that is generated for T1 and T2:
+
+     185:      Method (T1)
+
+0000034C:  14 10 54 31 5F 5F 00 ...    "..T1__."
+
+     186:      {
+     187:          ABCD (Add (2, 7, Local0))
+
+00000353:  41 42 43 44 ............    "ABCD"
+00000357:  72 0A 02 0A 07 60 ......    "r....`"
+
+     188:      }
+
+     190:      Method (T2)
+
+0000035D:  14 10 54 32 5F 5F 00 ...    "..T2__."
+
+     191:      {
+     192:          EFGH ()
+
+00000364:  45 46 47 48 ............    "EFGH"
+
+     193:          Add (2, 7, Local0)
+
+00000368:  72 0A 02 0A 07 60 ......    "r....`"
+     194:      }
+
+Note that the AML code for T1 and T2 is essentially identical. When
+disassembling this code, the methods ABCD and EFGH must be known to the
+disassembler, otherwise it does not know how to handle the method invocations.
+
+In other words, if ABCD and EFGH are actually external control methods
+appearing in an SSDT, the disassembler does not know what to do unless
+the owning SSDT has been loaded via the -e option.
+#endif
+
+static char             ExternalWarningPart1[600];
+static char             ExternalWarningPart2[400];
+static char             ExternalWarningPart3[400];
+static char             ExternalWarningPart4[200];
+
+void
+AcpiDmUnresolvedWarning (
+    UINT8                   Type)
+{
+    char                    *Format;
+    char                    Pad[] = "     *";
+    char                    NoPad[] = "";
+
+
+    if (!AcpiGbl_NumExternalMethods)
+    {
+        return;
+    }
+
+    if (AcpiGbl_NumExternalMethods == AcpiGbl_ResolvedExternalMethods)
+    {
+        return;
+    }
+
+    Format = Type ? Pad : NoPad;
+
+    sprintf (ExternalWarningPart1,
+        "%s iASL Warning: There %s %u external control method%s found during\n"
+        "%s disassembly, but only %u %s resolved (%u unresolved). Additional\n"
+        "%s ACPI tables may be required to properly disassemble the code. This\n"
+        "%s resulting disassembler output file may not compile because the\n"
+        "%s disassembler did not know how many arguments to assign to the\n"
+        "%s unresolved methods. Note: SSDTs can be dynamically loaded at\n"
+        "%s runtime and may or may not be available via the host OS.\n",
+        Format, (AcpiGbl_NumExternalMethods != 1 ? "were" : "was"),
+        AcpiGbl_NumExternalMethods, (AcpiGbl_NumExternalMethods != 1 ? "s" : ""),
+        Format, AcpiGbl_ResolvedExternalMethods,
+        (AcpiGbl_ResolvedExternalMethods != 1 ? "were" : "was"),
+        (AcpiGbl_NumExternalMethods - AcpiGbl_ResolvedExternalMethods),
+        Format, Format, Format, Format, Format);
+
+    sprintf (ExternalWarningPart2,
+        "%s To specify the tables needed to resolve external control method\n"
+        "%s references, the -e option can be used to specify the filenames.\n"
+        "%s Example iASL invocations:\n"
+        "%s     iasl -e ssdt1.aml ssdt2.aml ssdt3.aml -d dsdt.aml\n"
+        "%s     iasl -e dsdt.aml ssdt2.aml -d ssdt1.aml\n"
+        "%s     iasl -e ssdt*.aml -d dsdt.aml\n",
+        Format, Format, Format, Format, Format, Format);
+
+    sprintf (ExternalWarningPart3,
+        "%s In addition, the -fe option can be used to specify a file containing\n"
+        "%s control method external declarations with the associated method\n"
+        "%s argument counts. Each line of the file must be of the form:\n"
+        "%s     External (<method pathname>, MethodObj, <argument count>)\n"
+        "%s Invocation:\n"
+        "%s     iasl -fe refs.txt -d dsdt.aml\n",
+        Format, Format, Format, Format, Format, Format);
+
+    sprintf (ExternalWarningPart4,
+        "%s The following methods were unresolved and many not compile properly\n"
+        "%s because the disassembler had to guess at the number of arguments\n"
+        "%s required for each:\n",
+        Format, Format, Format);
+
+    if (Type)
+    {
+        if (!AcpiGbl_ExternalFileList)
+        {
+            /* The -e option was not specified */
+
+           AcpiOsPrintf ("    /*\n%s     *\n%s     *\n%s     *\n%s     */\n",
+               ExternalWarningPart1, ExternalWarningPart2, ExternalWarningPart3,
+               ExternalWarningPart4);
+        }
+        else
+        {
+            /* The -e option was specified, but there are still some unresolved externals */
+
+            AcpiOsPrintf ("    /*\n%s     *\n%s     *\n%s     */\n",
+               ExternalWarningPart1, ExternalWarningPart3, ExternalWarningPart4);
+        }
+    }
+    else
+    {
+        if (!AcpiGbl_ExternalFileList)
+        {
+            /* The -e option was not specified */
+
+            fprintf (stderr, "\n%s\n%s\n%s\n",
+               ExternalWarningPart1, ExternalWarningPart2, ExternalWarningPart3);
+        }
+        else
+        {
+            /* The -e option was specified, but there are still some unresolved externals */
+
+            fprintf (stderr, "\n%s\n%s\n",
+               ExternalWarningPart1, ExternalWarningPart3);
+        }
+    }
+}

--- a/sys/src/libacpi/acpica/common/dmrestag.c
+++ b/sys/src/libacpi/acpica/common/dmrestag.c
@@ -1,0 +1,1124 @@
+/******************************************************************************
+ *
+ * Module Name: dmrestag - Add tags to resource descriptors (Application-level)
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+#include "acparser.h"
+#include "acdisasm.h"
+#include "acnamesp.h"
+#include "amlcode.h"
+
+/* This module used for application-level code only */
+
+#define _COMPONENT          ACPI_CA_DISASSEMBLER
+        ACPI_MODULE_NAME    ("dmrestag")
+
+/* Local prototypes */
+
+static void
+AcpiDmUpdateResourceName (
+    ACPI_NAMESPACE_NODE     *ResourceNode);
+
+static char *
+AcpiDmSearchTagList (
+    UINT32                  BitIndex,
+    const ACPI_RESOURCE_TAG *TagList);
+
+static char *
+AcpiDmGetResourceTag (
+    UINT32                  BitIndex,
+    AML_RESOURCE            *Resource,
+    UINT8                   ResourceIndex);
+
+static char *
+AcpiGetTagPathname (
+    ACPI_PARSE_OBJECT       *Op,
+    ACPI_NAMESPACE_NODE     *BufferNode,
+    ACPI_NAMESPACE_NODE     *ResourceNode,
+    UINT32                  BitIndex);
+
+static ACPI_NAMESPACE_NODE *
+AcpiDmGetResourceNode (
+    ACPI_NAMESPACE_NODE     *BufferNode,
+    UINT32                  BitIndex);
+
+static ACPI_STATUS
+AcpiDmAddResourceToNamespace (
+    UINT8                   *Aml,
+    UINT32                  Length,
+    UINT32                  Offset,
+    UINT8                   ResourceIndex,
+    void                    **Context);
+
+static void
+AcpiDmAddResourcesToNamespace (
+    ACPI_NAMESPACE_NODE     *BufferNode,
+    ACPI_PARSE_OBJECT       *Op);
+
+
+/******************************************************************************
+ *
+ * Resource Tag tables
+ *
+ * These are the predefined tags that refer to elements of a resource
+ * descriptor. Each name and offset is defined in the ACPI specification.
+ *
+ * Each table entry contains the bit offset of the field and the associated
+ * name.
+ *
+ ******************************************************************************/
+
+static const ACPI_RESOURCE_TAG      AcpiDmIrqTags[] =
+{
+    {( 1 * 8),      ACPI_RESTAG_INTERRUPT},
+    {( 3 * 8) + 0,  ACPI_RESTAG_INTERRUPTTYPE},
+    {( 3 * 8) + 3,  ACPI_RESTAG_INTERRUPTLEVEL},
+    {( 3 * 8) + 4,  ACPI_RESTAG_INTERRUPTSHARE},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmDmaTags[] =
+{
+    {( 1 * 8),      ACPI_RESTAG_DMA},
+    {( 2 * 8) + 0,  ACPI_RESTAG_XFERTYPE},
+    {( 2 * 8) + 2,  ACPI_RESTAG_BUSMASTER},
+    {( 2 * 8) + 5,  ACPI_RESTAG_DMATYPE},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmIoTags[] =
+{
+    {( 1 * 8) + 0,  ACPI_RESTAG_DECODE},
+    {( 2 * 8),      ACPI_RESTAG_MINADDR},
+    {( 4 * 8),      ACPI_RESTAG_MAXADDR},
+    {( 6 * 8),      ACPI_RESTAG_ALIGNMENT},
+    {( 7 * 8),      ACPI_RESTAG_LENGTH},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmFixedIoTags[] =
+{
+    {( 1 * 8),      ACPI_RESTAG_BASEADDRESS},
+    {( 3 * 8),      ACPI_RESTAG_LENGTH},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmFixedDmaTags[] =
+{
+    {( 1 * 8),      ACPI_RESTAG_DMA},
+    {( 3 * 8),      ACPI_RESTAG_DMATYPE},
+    {( 5 * 8),      ACPI_RESTAG_XFERTYPE},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmMemory24Tags[] =
+{
+    {( 3 * 8) + 0,  ACPI_RESTAG_READWRITETYPE},
+    {( 4 * 8),      ACPI_RESTAG_MINADDR},
+    {( 6 * 8),      ACPI_RESTAG_MAXADDR},
+    {( 8 * 8),      ACPI_RESTAG_ALIGNMENT},
+    {(10 * 8),      ACPI_RESTAG_LENGTH},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmRegisterTags[] =
+{
+    {( 3 * 8),      ACPI_RESTAG_ADDRESSSPACE},
+    {( 4 * 8),      ACPI_RESTAG_REGISTERBITWIDTH},
+    {( 5 * 8),      ACPI_RESTAG_REGISTERBITOFFSET},
+    {( 6 * 8),      ACPI_RESTAG_ACCESSSIZE},
+    {( 7 * 8),      ACPI_RESTAG_ADDRESS},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmMemory32Tags[] =
+{
+    {( 3 * 8) + 0,  ACPI_RESTAG_READWRITETYPE},
+    {( 4 * 8),      ACPI_RESTAG_MINADDR},
+    {( 8 * 8),      ACPI_RESTAG_MAXADDR},
+    {(12 * 8),      ACPI_RESTAG_ALIGNMENT},
+    {(16 * 8),      ACPI_RESTAG_LENGTH},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmFixedMemory32Tags[] =
+{
+    {( 3 * 8) + 0,  ACPI_RESTAG_READWRITETYPE},
+    {( 4 * 8),      ACPI_RESTAG_BASEADDRESS},
+    {( 8 * 8),      ACPI_RESTAG_LENGTH},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmInterruptTags[] =
+{
+    {( 3 * 8) + 1,  ACPI_RESTAG_INTERRUPTTYPE},
+    {( 3 * 8) + 2,  ACPI_RESTAG_INTERRUPTLEVEL},
+    {( 3 * 8) + 3,  ACPI_RESTAG_INTERRUPTSHARE},
+    {( 5 * 8),      ACPI_RESTAG_INTERRUPT},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmAddress16Tags[] =
+{
+    {( 4 * 8) + 1,  ACPI_RESTAG_DECODE},
+    {( 4 * 8) + 2,  ACPI_RESTAG_MINTYPE},
+    {( 4 * 8) + 3,  ACPI_RESTAG_MAXTYPE},
+    {( 6 * 8),      ACPI_RESTAG_GRANULARITY},
+    {( 8 * 8),      ACPI_RESTAG_MINADDR},
+    {(10 * 8),      ACPI_RESTAG_MAXADDR},
+    {(12 * 8),      ACPI_RESTAG_TRANSLATION},
+    {(14 * 8),      ACPI_RESTAG_LENGTH},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmAddress32Tags[] =
+{
+    {( 4 * 8) + 1,  ACPI_RESTAG_DECODE},
+    {( 4 * 8) + 2,  ACPI_RESTAG_MINTYPE},
+    {( 4 * 8) + 3,  ACPI_RESTAG_MAXTYPE},
+    {( 6 * 8),      ACPI_RESTAG_GRANULARITY},
+    {(10 * 8),      ACPI_RESTAG_MINADDR},
+    {(14 * 8),      ACPI_RESTAG_MAXADDR},
+    {(18 * 8),      ACPI_RESTAG_TRANSLATION},
+    {(22 * 8),      ACPI_RESTAG_LENGTH},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmAddress64Tags[] =
+{
+    {( 4 * 8) + 1,  ACPI_RESTAG_DECODE},
+    {( 4 * 8) + 2,  ACPI_RESTAG_MINTYPE},
+    {( 4 * 8) + 3,  ACPI_RESTAG_MAXTYPE},
+    {( 6 * 8),      ACPI_RESTAG_GRANULARITY},
+    {(14 * 8),      ACPI_RESTAG_MINADDR},
+    {(22 * 8),      ACPI_RESTAG_MAXADDR},
+    {(30 * 8),      ACPI_RESTAG_TRANSLATION},
+    {(38 * 8),      ACPI_RESTAG_LENGTH},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmExtendedAddressTags[] =
+{
+    {( 4 * 8) + 1,  ACPI_RESTAG_DECODE},
+    {( 4 * 8) + 2,  ACPI_RESTAG_MINTYPE},
+    {( 4 * 8) + 3,  ACPI_RESTAG_MAXTYPE},
+    {( 8 * 8),      ACPI_RESTAG_GRANULARITY},
+    {(16 * 8),      ACPI_RESTAG_MINADDR},
+    {(24 * 8),      ACPI_RESTAG_MAXADDR},
+    {(32 * 8),      ACPI_RESTAG_TRANSLATION},
+    {(40 * 8),      ACPI_RESTAG_LENGTH},
+    {(48 * 8),      ACPI_RESTAG_TYPESPECIFICATTRIBUTES},
+    {0,             NULL}
+};
+
+/* Subtype tables for GPIO descriptors */
+
+static const ACPI_RESOURCE_TAG      AcpiDmGpioIntTags[] =
+{
+    {( 7 * 8) + 0,  ACPI_RESTAG_MODE},
+    {( 7 * 8) + 1,  ACPI_RESTAG_POLARITY},
+    {( 7 * 8) + 3,  ACPI_RESTAG_INTERRUPTSHARE},
+    {( 9 * 8),      ACPI_RESTAG_PINCONFIG},
+    {(10 * 8),      ACPI_RESTAG_DRIVESTRENGTH},
+    {(12 * 8),      ACPI_RESTAG_DEBOUNCETIME},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmGpioIoTags[] =
+{
+    {( 7 * 8) + 0,  ACPI_RESTAG_IORESTRICTION},
+    {( 7 * 8) + 3,  ACPI_RESTAG_INTERRUPTSHARE},
+    {( 9 * 8),      ACPI_RESTAG_PINCONFIG},
+    {(10 * 8),      ACPI_RESTAG_DRIVESTRENGTH},
+    {(12 * 8),      ACPI_RESTAG_DEBOUNCETIME},
+    {0,             NULL}
+};
+
+/* Subtype tables for SerialBus descriptors */
+
+static const ACPI_RESOURCE_TAG      AcpiDmI2cSerialBusTags[] =
+{
+    {( 6 * 8) + 0,  ACPI_RESTAG_SLAVEMODE},
+    {( 6 * 8) + 2,  ACPI_RESTAG_INTERRUPTSHARE},    /* V2 - ACPI 6.0 */
+    {( 7 * 8) + 0,  ACPI_RESTAG_MODE},
+    {(12 * 8),      ACPI_RESTAG_SPEED},
+    {(16 * 8),      ACPI_RESTAG_ADDRESS},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmSpiSerialBusTags[] =
+{
+    {( 6 * 8) + 0,  ACPI_RESTAG_SLAVEMODE},
+    {( 6 * 8) + 2,  ACPI_RESTAG_INTERRUPTSHARE},    /* V2 - ACPI 6.0 */
+    {( 7 * 8) + 0,  ACPI_RESTAG_MODE},
+    {( 7 * 8) + 1,  ACPI_RESTAG_DEVICEPOLARITY},
+    {(12 * 8),      ACPI_RESTAG_SPEED},
+    {(16 * 8),      ACPI_RESTAG_LENGTH},
+    {(17 * 8),      ACPI_RESTAG_PHASE},
+    {(18 * 8),      ACPI_RESTAG_POLARITY},
+    {(19 * 8),      ACPI_RESTAG_ADDRESS},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmUartSerialBusTags[] =
+{
+    {( 6 * 8) + 0,  ACPI_RESTAG_SLAVEMODE},         /* Note: not part of original macro */
+    {( 6 * 8) + 2,  ACPI_RESTAG_INTERRUPTSHARE},    /* V2 - ACPI 6.0 */
+    {( 7 * 8) + 0,  ACPI_RESTAG_FLOWCONTROL},
+    {( 7 * 8) + 2,  ACPI_RESTAG_STOPBITS},
+    {( 7 * 8) + 4,  ACPI_RESTAG_LENGTH},
+    {( 7 * 8) + 7,  ACPI_RESTAG_ENDIANNESS},
+    {(12 * 8),      ACPI_RESTAG_SPEED},
+    {(16 * 8),      ACPI_RESTAG_LENGTH_RX},
+    {(18 * 8),      ACPI_RESTAG_LENGTH_TX},
+    {(20 * 8),      ACPI_RESTAG_PARITY},
+    {(21 * 8),      ACPI_RESTAG_LINE},
+    {0,             NULL}
+};
+
+/* Subtype tables for Address descriptor type-specific flags */
+
+static const ACPI_RESOURCE_TAG      AcpiDmMemoryFlagTags[] =
+{
+    {( 5 * 8) + 0,  ACPI_RESTAG_READWRITETYPE},
+    {( 5 * 8) + 1,  ACPI_RESTAG_MEMTYPE},
+    {( 5 * 8) + 3,  ACPI_RESTAG_MEMATTRIBUTES},
+    {( 5 * 8) + 5,  ACPI_RESTAG_TYPE},
+    {0,             NULL}
+};
+
+static const ACPI_RESOURCE_TAG      AcpiDmIoFlagTags[] =
+{
+    {( 5 * 8) + 0,  ACPI_RESTAG_RANGETYPE},
+    {( 5 * 8) + 4,  ACPI_RESTAG_TYPE},
+    {( 5 * 8) + 5,  ACPI_RESTAG_TRANSTYPE},
+    {0,             NULL}
+};
+
+
+/*
+ * Dispatch table used to obtain the correct tag table for a descriptor.
+ *
+ * A NULL in this table means one of three things:
+ * 1) The descriptor ID is reserved and invalid
+ * 2) The descriptor has no tags associated with it
+ * 3) The descriptor has subtypes and a separate table will be used.
+ */
+static const ACPI_RESOURCE_TAG      *AcpiGbl_ResourceTags[] =
+{
+    /* Small descriptors */
+
+    NULL,                           /* 0x00, Reserved */
+    NULL,                           /* 0x01, Reserved */
+    NULL,                           /* 0x02, Reserved */
+    NULL,                           /* 0x03, Reserved */
+    AcpiDmIrqTags,                  /* 0x04, ACPI_RESOURCE_NAME_IRQ_FORMAT */
+    AcpiDmDmaTags,                  /* 0x05, ACPI_RESOURCE_NAME_DMA_FORMAT */
+    NULL,                           /* 0x06, ACPI_RESOURCE_NAME_START_DEPENDENT */
+    NULL,                           /* 0x07, ACPI_RESOURCE_NAME_END_DEPENDENT */
+    AcpiDmIoTags,                   /* 0x08, ACPI_RESOURCE_NAME_IO_PORT */
+    AcpiDmFixedIoTags,              /* 0x09, ACPI_RESOURCE_NAME_FIXED_IO_PORT */
+    AcpiDmFixedDmaTags,             /* 0x0A, ACPI_RESOURCE_NAME_FIXED_DMA */
+    NULL,                           /* 0x0B, Reserved */
+    NULL,                           /* 0x0C, Reserved */
+    NULL,                           /* 0x0D, Reserved */
+    NULL,                           /* 0x0E, ACPI_RESOURCE_NAME_SMALL_VENDOR */
+    NULL,                           /* 0x0F, ACPI_RESOURCE_NAME_END_TAG (not used) */
+
+    /* Large descriptors */
+
+    NULL,                           /* 0x00, Reserved */
+    AcpiDmMemory24Tags,             /* 0x01, ACPI_RESOURCE_NAME_MEMORY_24 */
+    AcpiDmRegisterTags,             /* 0x02, ACPI_RESOURCE_NAME_GENERIC_REGISTER */
+    NULL,                           /* 0x03, Reserved */
+    NULL,                           /* 0x04, ACPI_RESOURCE_NAME_LARGE_VENDOR */
+    AcpiDmMemory32Tags,             /* 0x05, ACPI_RESOURCE_NAME_MEMORY_32 */
+    AcpiDmFixedMemory32Tags,        /* 0x06, ACPI_RESOURCE_NAME_FIXED_MEMORY_32 */
+    AcpiDmAddress32Tags,            /* 0x07, ACPI_RESOURCE_NAME_DWORD_ADDRESS_SPACE */
+    AcpiDmAddress16Tags,            /* 0x08, ACPI_RESOURCE_NAME_WORD_ADDRESS_SPACE */
+    AcpiDmInterruptTags,            /* 0x09, ACPI_RESOURCE_NAME_EXTENDED_XRUPT */
+    AcpiDmAddress64Tags,            /* 0x0A, ACPI_RESOURCE_NAME_QWORD_ADDRESS_SPACE */
+    AcpiDmExtendedAddressTags,      /* 0x0B, ACPI_RESOURCE_NAME_EXTENDED_ADDRESS_SPACE */
+    NULL,                           /* 0x0C, ACPI_RESOURCE_NAME_GPIO - Use Subtype table below */
+    NULL,                           /* 0x0D, Reserved */
+    NULL                            /* 0x0E, ACPI_RESOURCE_NAME_SERIAL_BUS - Use Subtype table below */
+};
+
+/* GPIO Subtypes */
+
+static const ACPI_RESOURCE_TAG      *AcpiGbl_GpioResourceTags[] =
+{
+    AcpiDmGpioIntTags,              /* 0x00 Interrupt Connection */
+    AcpiDmGpioIoTags                /* 0x01 I/O Connection */
+};
+
+/* Serial Bus Subtypes */
+
+static const ACPI_RESOURCE_TAG      *AcpiGbl_SerialResourceTags[] =
+{
+    NULL,                           /* 0x00 Reserved */
+    AcpiDmI2cSerialBusTags,         /* 0x01 I2C SerialBus */
+    AcpiDmSpiSerialBusTags,         /* 0x02 SPI SerialBus */
+    AcpiDmUartSerialBusTags         /* 0x03 UART SerialBus */
+};
+
+/*
+ * Globals used to generate unique resource descriptor names. We use names that
+ * start with underscore and a prefix letter that is not used by other ACPI
+ * reserved names. To this, we append hex 0x00 through 0xFF. These 5 prefixes
+ * allow for 5*256 = 1280 unique names, probably sufficient for any single ASL
+ * file. If this becomes too small, we can use alpha+numerals for a total
+ * of 5*36*36 = 6480.
+ */
+#define ACPI_NUM_RES_PREFIX     5
+
+static UINT32                   AcpiGbl_NextResourceId = 0;
+static UINT8                    AcpiGbl_NextPrefix = 0;
+static char                     AcpiGbl_Prefix[ACPI_NUM_RES_PREFIX] =
+                                    {'Y','Z','J','K','X'};
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmCheckResourceReference
+ *
+ * PARAMETERS:  Op                  - Parse Op for the AML opcode
+ *              WalkState           - Current walk state (with valid scope)
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Convert a reference to a resource descriptor to a symbolic
+ *              reference if possible
+ *
+ * NOTE:        Bit index is used to transparently handle both resource bit
+ *              fields and byte fields.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmCheckResourceReference (
+    ACPI_PARSE_OBJECT       *Op,
+    ACPI_WALK_STATE         *WalkState)
+{
+    ACPI_STATUS             Status;
+    ACPI_PARSE_OBJECT       *BufferNameOp;
+    ACPI_PARSE_OBJECT       *IndexOp;
+    ACPI_NAMESPACE_NODE     *BufferNode;
+    ACPI_NAMESPACE_NODE     *ResourceNode;
+    const ACPI_OPCODE_INFO  *OpInfo;
+    UINT32                  BitIndex;
+
+
+    /* We are only interested in the CreateXxxxField opcodes */
+
+    OpInfo = AcpiPsGetOpcodeInfo (Op->Common.AmlOpcode);
+    if (OpInfo->Type != AML_TYPE_CREATE_FIELD)
+    {
+        return;
+    }
+
+    /* Get the buffer term operand */
+
+    BufferNameOp = AcpiPsGetDepthNext (NULL, Op);
+
+    /* Must be a named buffer, not an arg or local or method call */
+
+    if (BufferNameOp->Common.AmlOpcode != AML_INT_NAMEPATH_OP)
+    {
+        return;
+    }
+
+    /* Get the Index term, must be an integer constant to convert */
+
+    IndexOp = BufferNameOp->Common.Next;
+
+    /* Major cheat: The Node field is also used for the Tag ptr. Clear it now */
+
+    IndexOp->Common.Node = NULL;
+
+    OpInfo = AcpiPsGetOpcodeInfo (IndexOp->Common.AmlOpcode);
+    if (OpInfo->ObjectType != ACPI_TYPE_INTEGER)
+    {
+        return;
+    }
+
+    /* Get the bit offset of the descriptor within the buffer */
+
+    if ((Op->Common.AmlOpcode == AML_CREATE_BIT_FIELD_OP) ||
+        (Op->Common.AmlOpcode == AML_CREATE_FIELD_OP))
+    {
+        /* Index operand is a bit offset */
+
+        BitIndex = (UINT32) IndexOp->Common.Value.Integer;
+    }
+    else
+    {
+        /* Index operand is a byte offset, convert to bits */
+
+        BitIndex = (UINT32) ACPI_MUL_8 (IndexOp->Common.Value.Integer);
+    }
+
+    /* Lookup the buffer in the namespace */
+
+    Status = AcpiNsLookup (WalkState->ScopeInfo,
+        BufferNameOp->Common.Value.String, ACPI_TYPE_BUFFER,
+        ACPI_IMODE_EXECUTE, ACPI_NS_SEARCH_PARENT, WalkState,
+        &BufferNode);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Validate object type, we must have a buffer */
+
+    if (BufferNode->Type != ACPI_TYPE_BUFFER)
+    {
+        return;
+    }
+
+    /* Find the resource descriptor node corresponding to the index */
+
+    ResourceNode = AcpiDmGetResourceNode (BufferNode, BitIndex);
+    if (!ResourceNode)
+    {
+        return;
+    }
+
+    /* Translate the Index to a resource tag pathname */
+
+    AcpiGetTagPathname (IndexOp, BufferNode, ResourceNode, BitIndex);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmGetResourceNode
+ *
+ * PARAMETERS:  BufferNode          - Node for the parent buffer
+ *              BitIndex            - Index into the resource descriptor
+ *
+ * RETURN:      Namespace node for the resource descriptor. NULL if not found
+ *
+ * DESCRIPTION: Find a resource descriptor that corresponds to the bit index
+ *
+ ******************************************************************************/
+
+static ACPI_NAMESPACE_NODE *
+AcpiDmGetResourceNode (
+    ACPI_NAMESPACE_NODE     *BufferNode,
+    UINT32                  BitIndex)
+{
+    ACPI_NAMESPACE_NODE     *Node;
+    UINT32                  ByteIndex = ACPI_DIV_8 (BitIndex);
+
+
+    /*
+     * Child list contains an entry for each resource descriptor. Find
+     * the descriptor that corresponds to the Index.
+     *
+     * If there are no children, this is not a resource template
+     */
+    Node = BufferNode->Child;
+    while (Node)
+    {
+        /*
+         * Check if the Index falls within this resource.
+         *
+         * Value contains the resource offset, Object contains the resource
+         * length (both in bytes)
+         */
+        if ((ByteIndex >= Node->Value) &&
+            (ByteIndex < (Node->Value + Node->Length)))
+        {
+            return (Node);
+        }
+
+        Node = Node->Peer;
+    }
+
+    return (NULL);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiGetTagPathname
+ *
+ * PARAMETERS:  BufferNode          - Node for the parent buffer
+ *              ResourceNode        - Node for a resource descriptor
+ *              BitIndex            - Index into the resource descriptor
+ *
+ * RETURN:      Full pathname for a resource tag. NULL if no match.
+ *              Path is returned in AML (packed) format.
+ *
+ * DESCRIPTION: Convert a BitIndex into a symbolic resource tag (full pathname)
+ *
+ ******************************************************************************/
+
+static char *
+AcpiGetTagPathname (
+    ACPI_PARSE_OBJECT       *IndexOp,
+    ACPI_NAMESPACE_NODE     *BufferNode,
+    ACPI_NAMESPACE_NODE     *ResourceNode,
+    UINT32                  BitIndex)
+{
+    ACPI_STATUS             Status;
+    UINT32                  ResourceBitIndex;
+    UINT8                   ResourceTableIndex;
+    ACPI_SIZE               RequiredSize;
+    char                    *Pathname;
+    AML_RESOURCE            *Aml;
+    ACPI_PARSE_OBJECT       *Op;
+    char                    *InternalPath;
+    char                    *Tag;
+
+
+    /* Get the Op that contains the actual buffer data */
+
+    Op = BufferNode->Op->Common.Value.Arg;
+    Op = Op->Common.Next;
+    if (!Op)
+    {
+        return (NULL);
+    }
+
+    /* Get the individual resource descriptor and validate it */
+
+    Aml = ACPI_CAST_PTR (
+        AML_RESOURCE, &Op->Named.Data[ResourceNode->Value]);
+
+    Status = AcpiUtValidateResource (NULL, Aml, &ResourceTableIndex);
+    if (ACPI_FAILURE (Status))
+    {
+        return (NULL);
+    }
+
+    /* Get offset into this descriptor (from offset into entire buffer) */
+
+    ResourceBitIndex = BitIndex - ACPI_MUL_8 (ResourceNode->Value);
+
+    /* Get the tag associated with this resource descriptor and offset */
+
+    Tag = AcpiDmGetResourceTag (ResourceBitIndex, Aml, ResourceTableIndex);
+    if (!Tag)
+    {
+        return (NULL);
+    }
+
+    /*
+     * Now that we know that we have a reference that can be converted to a
+     * symbol, change the name of the resource to a unique name.
+     */
+    AcpiDmUpdateResourceName (ResourceNode);
+
+    /* Get the full pathname to the parent buffer */
+
+    RequiredSize = AcpiNsBuildNormalizedPath (BufferNode, NULL, 0, FALSE);
+    if (!RequiredSize)
+    {
+        return (NULL);
+    }
+
+    Pathname = ACPI_ALLOCATE_ZEROED (RequiredSize + ACPI_PATH_SEGMENT_LENGTH);
+    if (!Pathname)
+    {
+        return (NULL);
+    }
+
+    (void) AcpiNsBuildNormalizedPath (BufferNode, Pathname,
+        RequiredSize, FALSE);
+
+    /*
+     * Create the full path to the resource and tag by: remove the buffer name,
+     * append the resource descriptor name, append a dot, append the tag name.
+     *
+     * TBD: Always using the full path is a bit brute force, the path can be
+     * often be optimized with carats (if the original buffer namepath is a
+     * single nameseg). This doesn't really matter, because these paths do not
+     * end up in the final compiled AML, it's just an appearance issue for the
+     * disassembled code.
+     */
+    Pathname[strlen (Pathname) - ACPI_NAME_SIZE] = 0;
+    strncat (Pathname, ResourceNode->Name.Ascii, ACPI_NAME_SIZE);
+    strcat (Pathname, ".");
+    strncat (Pathname, Tag, ACPI_NAME_SIZE);
+
+    /* Internalize the namepath to AML format */
+
+    AcpiNsInternalizeName (Pathname, &InternalPath);
+    ACPI_FREE (Pathname);
+
+    /* Update the Op with the symbol */
+
+    AcpiPsInitOp (IndexOp, AML_INT_NAMEPATH_OP);
+    IndexOp->Common.Value.String = InternalPath;
+
+    /* We will need the tag later. Cheat by putting it in the Node field */
+
+    IndexOp->Common.Node = ACPI_CAST_PTR (ACPI_NAMESPACE_NODE, Tag);
+    return (InternalPath);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmUpdateResourceName
+ *
+ * PARAMETERS:  ResourceNode        - Node for a resource descriptor
+ *
+ * RETURN:      Stores new name in the ResourceNode
+ *
+ * DESCRIPTION: Create a new, unique name for a resource descriptor. Used by
+ *              both the disassembly of the descriptor itself and any symbolic
+ *              references to the descriptor. Ignored if a unique name has
+ *              already been assigned to the resource.
+ *
+ * NOTE: Single threaded, suitable for applications only!
+ *
+ ******************************************************************************/
+
+static void
+AcpiDmUpdateResourceName (
+    ACPI_NAMESPACE_NODE     *ResourceNode)
+{
+    char                    Name[ACPI_NAME_SIZE];
+
+
+    /* Ignore if a unique name has already been assigned */
+
+    if (ResourceNode->Name.Integer != ACPI_DEFAULT_RESNAME)
+    {
+        return;
+    }
+
+    /* Generate a new ACPI name for the descriptor */
+
+    Name[0] = '_';
+    Name[1] = AcpiGbl_Prefix[AcpiGbl_NextPrefix];
+    Name[2] = AcpiUtHexToAsciiChar ((UINT64) AcpiGbl_NextResourceId, 4);
+    Name[3] = AcpiUtHexToAsciiChar ((UINT64) AcpiGbl_NextResourceId, 0);
+
+    /* Update globals for next name */
+
+    AcpiGbl_NextResourceId++;
+    if (AcpiGbl_NextResourceId >= 256)
+    {
+        AcpiGbl_NextResourceId = 0;
+        AcpiGbl_NextPrefix++;
+
+        if (AcpiGbl_NextPrefix > ACPI_NUM_RES_PREFIX)
+        {
+            AcpiGbl_NextPrefix = 0;
+        }
+    }
+
+    /* Change the resource descriptor name */
+
+    ResourceNode->Name.Integer = *ACPI_CAST_PTR (UINT32, &Name[0]);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmGetResourceTag
+ *
+ * PARAMETERS:  BitIndex            - Index into the resource descriptor
+ *              Resource            - Pointer to the raw resource data
+ *              ResourceIndex       - Index correspoinding to the resource type
+ *
+ * RETURN:      Pointer to the resource tag (ACPI_NAME). NULL if no match.
+ *
+ * DESCRIPTION: Convert a BitIndex into a symbolic resource tag.
+ *
+ * Note: ResourceIndex should be previously validated and guaranteed to ve
+ *       valid.
+ *
+ ******************************************************************************/
+
+static char *
+AcpiDmGetResourceTag (
+    UINT32                  BitIndex,
+    AML_RESOURCE            *Resource,
+    UINT8                   ResourceIndex)
+{
+    const ACPI_RESOURCE_TAG *TagList;
+    char                    *Tag = NULL;
+
+
+    /* Get the tag list for this resource descriptor type */
+
+    TagList = AcpiGbl_ResourceTags[ResourceIndex];
+
+    /*
+     * Handle descriptors that have multiple subtypes
+     */
+    switch (Resource->DescriptorType)
+    {
+    case ACPI_RESOURCE_NAME_ADDRESS16:
+    case ACPI_RESOURCE_NAME_ADDRESS32:
+    case ACPI_RESOURCE_NAME_ADDRESS64:
+    case ACPI_RESOURCE_NAME_EXTENDED_ADDRESS64:
+        /*
+         * Subtype differentiation is the flags.
+         * Kindof brute force, but just blindly search for an index match
+         */
+        if (Resource->Address.ResourceType == ACPI_ADDRESS_TYPE_MEMORY_RANGE)
+        {
+            Tag = AcpiDmSearchTagList (BitIndex, AcpiDmMemoryFlagTags);
+        }
+        else if (Resource->Address.ResourceType == ACPI_ADDRESS_TYPE_IO_RANGE)
+        {
+            Tag = AcpiDmSearchTagList (BitIndex, AcpiDmIoFlagTags);
+        }
+
+        /* If we found a match, all done. Else, drop to normal search below */
+
+        if (Tag)
+        {
+            return (Tag);
+        }
+        break;
+
+    case ACPI_RESOURCE_NAME_GPIO:
+
+        /* GPIO connection has 2 subtypes: Interrupt and I/O */
+
+        if (Resource->Gpio.ConnectionType > AML_RESOURCE_MAX_GPIOTYPE)
+        {
+            return (NULL);
+        }
+
+        TagList = AcpiGbl_GpioResourceTags[Resource->Gpio.ConnectionType];
+        break;
+
+    case ACPI_RESOURCE_NAME_SERIAL_BUS:
+
+        /* SerialBus has 3 subtypes: I2C, SPI, and UART */
+
+        if ((Resource->CommonSerialBus.Type == 0) ||
+            (Resource->CommonSerialBus.Type > AML_RESOURCE_MAX_SERIALBUSTYPE))
+        {
+            return (NULL);
+        }
+
+        TagList = AcpiGbl_SerialResourceTags[Resource->CommonSerialBus.Type];
+        break;
+
+    default:
+
+        break;
+    }
+
+    /* Search for a match against the BitIndex */
+
+    if (TagList)
+    {
+        Tag = AcpiDmSearchTagList (BitIndex, TagList);
+    }
+
+    return (Tag);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmSearchTagList
+ *
+ * PARAMETERS:  BitIndex            - Index into the resource descriptor
+ *              TagList             - List to search
+ *
+ * RETURN:      Pointer to a tag (ACPI_NAME). NULL if no match found.
+ *
+ * DESCRIPTION: Search a tag list for a match to the input BitIndex. Matches
+ *              a fixed offset to a symbolic resource tag name.
+ *
+ ******************************************************************************/
+
+static char *
+AcpiDmSearchTagList (
+    UINT32                  BitIndex,
+    const ACPI_RESOURCE_TAG *TagList)
+{
+
+    /*
+     * Walk the null-terminated tag list to find a matching bit offset.
+     * We are looking for an exact match.
+     */
+    for ( ; TagList->Tag; TagList++)
+    {
+        if (BitIndex == TagList->BitIndex)
+        {
+            return (TagList->Tag);
+        }
+    }
+
+    /* A matching offset was not found */
+
+    return (NULL);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmFindResources
+ *
+ * PARAMETERS:  Root                - Root of the parse tree
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Add all ResourceTemplate declarations to the namespace. Each
+ *              resource descriptor in each template is given a node -- used
+ *              for later conversion of resource references to symbolic refs.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmFindResources (
+    ACPI_PARSE_OBJECT       *Root)
+{
+    ACPI_PARSE_OBJECT       *Op = Root;
+    ACPI_PARSE_OBJECT       *Parent;
+
+
+    /* Walk the entire parse tree */
+
+    while (Op)
+    {
+        /* We are interested in Buffer() declarations */
+
+        if (Op->Common.AmlOpcode == AML_BUFFER_OP)
+        {
+            /* And only declarations of the form Name (XXXX, Buffer()... ) */
+
+            Parent = Op->Common.Parent;
+            if (Parent->Common.AmlOpcode == AML_NAME_OP)
+            {
+                /*
+                 * If the buffer is a resource template, add the individual
+                 * resource descriptors to the namespace, as children of the
+                 * buffer node.
+                 */
+                if (ACPI_SUCCESS (AcpiDmIsResourceTemplate (NULL, Op)))
+                {
+                    Op->Common.DisasmOpcode = ACPI_DASM_RESOURCE;
+                    AcpiDmAddResourcesToNamespace (Parent->Common.Node, Op);
+                }
+            }
+        }
+
+        Op = AcpiPsGetDepthNext (Root, Op);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmAddResourcesToNamespace
+ *
+ * PARAMETERS:  BufferNode          - Node for the parent buffer
+ *              Op                  - Parse op for the buffer
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Add an entire resource template to the namespace. Each
+ *              resource descriptor is added as a namespace node.
+ *
+ ******************************************************************************/
+
+static void
+AcpiDmAddResourcesToNamespace (
+    ACPI_NAMESPACE_NODE     *BufferNode,
+    ACPI_PARSE_OBJECT       *Op)
+{
+    ACPI_PARSE_OBJECT       *NextOp;
+
+
+    /* Get to the ByteData list */
+
+    NextOp = Op->Common.Value.Arg;
+    NextOp = NextOp->Common.Next;
+    if (!NextOp)
+    {
+        return;
+    }
+
+    /* Set Node and Op to point to each other */
+
+    BufferNode->Op = Op;
+    Op->Common.Node = BufferNode;
+
+    /*
+     * Insert each resource into the namespace
+     * NextOp contains the Aml pointer and the Aml length
+     */
+    AcpiUtWalkAmlResources (NULL, (UINT8 *) NextOp->Named.Data,
+        (ACPI_SIZE) NextOp->Common.Value.Integer,
+        AcpiDmAddResourceToNamespace, (void **) BufferNode);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmAddResourceToNamespace
+ *
+ * PARAMETERS:  ACPI_WALK_AML_CALLBACK
+ *              BufferNode              - Node for the parent buffer
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Add one resource descriptor to the namespace as a child of the
+ *              parent buffer. The same name is used for each descriptor. This
+ *              is changed later to a unique name if the resource is actually
+ *              referenced by an AML operator.
+ *
+ ******************************************************************************/
+
+static ACPI_STATUS
+AcpiDmAddResourceToNamespace (
+    UINT8                   *Aml,
+    UINT32                  Length,
+    UINT32                  Offset,
+    UINT8                   ResourceIndex,
+    void                    **Context)
+{
+    ACPI_STATUS             Status;
+    ACPI_GENERIC_STATE      ScopeInfo;
+    ACPI_NAMESPACE_NODE     *Node;
+
+
+    /* TBD: Don't need to add descriptors that have no tags defined? */
+
+    /* Add the resource to the namespace, as child of the buffer */
+
+    ScopeInfo.Scope.Node = ACPI_CAST_PTR (ACPI_NAMESPACE_NODE, Context);
+    Status = AcpiNsLookup (&ScopeInfo, "_TMP", ACPI_TYPE_LOCAL_RESOURCE,
+        ACPI_IMODE_LOAD_PASS2,
+        ACPI_NS_NO_UPSEARCH | ACPI_NS_DONT_OPEN_SCOPE | ACPI_NS_PREFIX_IS_SCOPE,
+        NULL, &Node);
+    if (ACPI_FAILURE (Status))
+    {
+        return (AE_OK);
+    }
+
+    /* Set the name to the default, changed later if resource is referenced */
+
+    Node->Name.Integer = ACPI_DEFAULT_RESNAME;
+
+    /* Save the offset of the descriptor (within the original buffer) */
+
+    Node->Value = Offset;
+    Node->Length = Length;
+    return (AE_OK);
+}

--- a/sys/src/libacpi/acpica/common/dmtable.c
+++ b/sys/src/libacpi/acpica/common/dmtable.c
@@ -1,0 +1,1563 @@
+/******************************************************************************
+ *
+ * Module Name: dmtable - Support for ACPI tables that contain no AML code
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+#include "acdisasm.h"
+#include "actables.h"
+#include "aslcompiler.h"
+#include "dtcompiler.h"
+
+/* This module used for application-level code only */
+
+#define _COMPONENT          ACPI_CA_DISASSEMBLER
+        ACPI_MODULE_NAME    ("dmtable")
+
+const AH_TABLE *
+AcpiAhGetTableInfo (
+    char                    *Signature);
+
+
+/* Common format strings for commented values */
+
+#define UINT8_FORMAT        "%2.2X [%s]\n"
+#define UINT16_FORMAT       "%4.4X [%s]\n"
+#define UINT32_FORMAT       "%8.8X [%s]\n"
+#define STRING_FORMAT       "[%s]\n"
+
+/* These tables map a subtable type to a description string */
+
+static const char           *AcpiDmAsfSubnames[] =
+{
+    "ASF Information",
+    "ASF Alerts",
+    "ASF Remote Control",
+    "ASF RMCP Boot Options",
+    "ASF Address",
+    "Unknown Subtable Type"         /* Reserved */
+};
+
+static const char           *AcpiDmDmarSubnames[] =
+{
+    "Hardware Unit Definition",
+    "Reserved Memory Region",
+    "Root Port ATS Capability",
+    "Remapping Hardware Static Affinity",
+    "ACPI Namespace Device Declaration",
+    "Unknown Subtable Type"         /* Reserved */
+};
+
+static const char           *AcpiDmDmarScope[] =
+{
+    "Reserved value",
+    "PCI Endpoint Device",
+    "PCI Bridge Device",
+    "IOAPIC Device",
+    "Message-capable HPET Device",
+    "Namespace Device",
+    "Unknown Scope Type"            /* Reserved */
+};
+
+static const char           *AcpiDmEinjActions[] =
+{
+    "Begin Operation",
+    "Get Trigger Table",
+    "Set Error Type",
+    "Get Error Type",
+    "End Operation",
+    "Execute Operation",
+    "Check Busy Status",
+    "Get Command Status",
+    "Set Error Type With Address",
+    "Get Execute Timings",
+    "Unknown Action"
+};
+
+static const char           *AcpiDmEinjInstructions[] =
+{
+    "Read Register",
+    "Read Register Value",
+    "Write Register",
+    "Write Register Value",
+    "Noop",
+    "Flush Cacheline",
+    "Unknown Instruction"
+};
+
+static const char           *AcpiDmErstActions[] =
+{
+    "Begin Write Operation",
+    "Begin Read Operation",
+    "Begin Clear Operation",
+    "End Operation",
+    "Set Record Offset",
+    "Execute Operation",
+    "Check Busy Status",
+    "Get Command Status",
+    "Get Record Identifier",
+    "Set Record Identifier",
+    "Get Record Count",
+    "Begin Dummy Write",
+    "Unused/Unknown Action",
+    "Get Error Address Range",
+    "Get Error Address Length",
+    "Get Error Attributes",
+    "Execute Timings",
+    "Unknown Action"
+};
+
+static const char           *AcpiDmErstInstructions[] =
+{
+    "Read Register",
+    "Read Register Value",
+    "Write Register",
+    "Write Register Value",
+    "Noop",
+    "Load Var1",
+    "Load Var2",
+    "Store Var1",
+    "Add",
+    "Subtract",
+    "Add Value",
+    "Subtract Value",
+    "Stall",
+    "Stall While True",
+    "Skip Next If True",
+    "GoTo",
+    "Set Source Address",
+    "Set Destination Address",
+    "Move Data",
+    "Unknown Instruction"
+};
+
+static const char           *AcpiDmGtdtSubnames[] =
+{
+    "Generic Timer Block",
+    "Generic Watchdog Timer",
+    "Unknown Subtable Type"         /* Reserved */
+};
+
+static const char           *AcpiDmHestSubnames[] =
+{
+    "IA-32 Machine Check Exception",
+    "IA-32 Corrected Machine Check",
+    "IA-32 Non-Maskable Interrupt",
+    "Unknown SubTable Type",        /* 3 - Reserved */
+    "Unknown SubTable Type",        /* 4 - Reserved */
+    "Unknown SubTable Type",        /* 5 - Reserved */
+    "PCI Express Root Port AER",
+    "PCI Express AER (AER Endpoint)",
+    "PCI Express/PCI-X Bridge AER",
+    "Generic Hardware Error Source",
+    "Generic Hardware Error Source V2",
+    "Unknown Subtable Type"         /* Reserved */
+};
+
+static const char           *AcpiDmHestNotifySubnames[] =
+{
+    "Polled",
+    "External Interrupt",
+    "Local Interrupt",
+    "SCI",
+    "NMI",
+    "CMCI",                         /* ACPI 5.0 */
+    "MCE",                          /* ACPI 5.0 */
+    "GPIO",                         /* ACPI 6.0 */
+    "SEA",                          /* ACPI 6.1 */
+    "SEI",                          /* ACPI 6.1 */
+    "GSIV",                         /* ACPI 6.1 */
+    "Unknown Notify Type"           /* Reserved */
+};
+
+static const char           *AcpiDmMadtSubnames[] =
+{
+    "Processor Local APIC",             /* ACPI_MADT_TYPE_LOCAL_APIC */
+    "I/O APIC",                         /* ACPI_MADT_TYPE_IO_APIC */
+    "Interrupt Source Override",        /* ACPI_MADT_TYPE_INTERRUPT_OVERRIDE */
+    "NMI Source",                       /* ACPI_MADT_TYPE_NMI_SOURCE */
+    "Local APIC NMI",                   /* ACPI_MADT_TYPE_LOCAL_APIC_NMI */
+    "Local APIC Address Override",      /* ACPI_MADT_TYPE_LOCAL_APIC_OVERRIDE */
+    "I/O SAPIC",                        /* ACPI_MADT_TYPE_IO_SAPIC */
+    "Local SAPIC",                      /* ACPI_MADT_TYPE_LOCAL_SAPIC */
+    "Platform Interrupt Sources",       /* ACPI_MADT_TYPE_INTERRUPT_SOURCE */
+    "Processor Local x2APIC",           /* ACPI_MADT_TYPE_LOCAL_X2APIC */
+    "Local x2APIC NMI",                 /* ACPI_MADT_TYPE_LOCAL_X2APIC_NMI */
+    "Generic Interrupt Controller",     /* ACPI_MADT_GENERIC_INTERRUPT */
+    "Generic Interrupt Distributor",    /* ACPI_MADT_GENERIC_DISTRIBUTOR */
+    "Generic MSI Frame",                /* ACPI_MADT_GENERIC_MSI_FRAME */
+    "Generic Interrupt Redistributor",  /* ACPI_MADT_GENERIC_REDISTRIBUTOR */
+    "Generic Interrupt Translator",     /* ACPI_MADT_GENERIC_TRANSLATOR */
+    "Unknown Subtable Type"             /* Reserved */
+};
+
+static const char           *AcpiDmNfitSubnames[] =
+{
+    "System Physical Address Range",    /* ACPI_NFIT_TYPE_SYSTEM_ADDRESS */
+    "Memory Range Map",                 /* ACPI_NFIT_TYPE_MEMORY_MAP */
+    "Interleave Info",                  /* ACPI_NFIT_TYPE_INTERLEAVE */
+    "SMBIOS Information",               /* ACPI_NFIT_TYPE_SMBIOS */
+    "NVDIMM Control Region",            /* ACPI_NFIT_TYPE_CONTROL_REGION */
+    "NVDIMM Block Data Window Region",  /* ACPI_NFIT_TYPE_DATA_REGION */
+    "Flush Hint Address",               /* ACPI_NFIT_TYPE_FLUSH_ADDRESS */
+    "Unknown Subtable Type"             /* Reserved */
+};
+
+static const char           *AcpiDmPcctSubnames[] =
+{
+    "Generic Communications Subspace",  /* ACPI_PCCT_TYPE_GENERIC_SUBSPACE */
+    "HW-Reduced Comm Subspace",         /* ACPI_PCCT_TYPE_HW_REDUCED_SUBSPACE */
+    "HW-Reduced Comm Subspace Type2",   /* ACPI_PCCT_TYPE_HW_REDUCED_SUBSPACE_TYPE2 */
+    "Unknown Subtable Type"             /* Reserved */
+};
+
+static const char           *AcpiDmPmttSubnames[] =
+{
+    "Socket",                       /* ACPI_PMTT_TYPE_SOCKET */
+    "Memory Controller",            /* ACPI_PMTT_TYPE_CONTROLLER */
+    "Physical Component (DIMM)",    /* ACPI_PMTT_TYPE_DIMM  */
+    "Unknown Subtable Type"         /* Reserved */
+};
+
+static const char           *AcpiDmSratSubnames[] =
+{
+    "Processor Local APIC/SAPIC Affinity",
+    "Memory Affinity",
+    "Processor Local x2APIC Affinity",
+    "GICC Affinity",
+    "Unknown Subtable Type"         /* Reserved */
+};
+
+static const char           *AcpiDmIvrsSubnames[] =
+{
+    "Hardware Definition Block",
+    "Memory Definition Block",
+    "Unknown Subtable Type"         /* Reserved */
+};
+
+static const char           *AcpiDmLpitSubnames[] =
+{
+    "Native C-state Idle Structure",
+    "Unknown Subtable Type"         /* Reserved */
+};
+
+#define ACPI_FADT_PM_RESERVED       9
+
+static const char           *AcpiDmFadtProfiles[] =
+{
+    "Unspecified",
+    "Desktop",
+    "Mobile",
+    "Workstation",
+    "Enterprise Server",
+    "SOHO Server",
+    "Appliance PC",
+    "Performance Server",
+    "Tablet",
+    "Unknown Profile Type"
+};
+
+#define ACPI_GAS_WIDTH_RESERVED     5
+
+static const char           *AcpiDmGasAccessWidth[] =
+{
+    "Undefined/Legacy",
+    "Byte Access:8",
+    "Word Access:16",
+    "DWord Access:32",
+    "QWord Access:64",
+    "Unknown Width Encoding"
+};
+
+
+/*******************************************************************************
+ *
+ * ACPI Table Data, indexed by signature.
+ *
+ * Each entry contains: Signature, Table Info, Handler, DtHandler,
+ *  Template, Description
+ *
+ * Simple tables have only a TableInfo structure, complex tables have a
+ * handler. This table must be NULL terminated. RSDP and FACS are
+ * special-cased elsewhere.
+ *
+ * Note: Any tables added here should be duplicated within AcpiSupportedTables
+ * in the file common/ahtable.c
+ *
+ ******************************************************************************/
+
+const ACPI_DMTABLE_DATA     AcpiDmTableData[] =
+{
+    {ACPI_SIG_ASF,  NULL,                   AcpiDmDumpAsf,  DtCompileAsf,   TemplateAsf},
+    {ACPI_SIG_BERT, AcpiDmTableInfoBert,    NULL,           NULL,           TemplateBert},
+    {ACPI_SIG_BGRT, AcpiDmTableInfoBgrt,    NULL,           NULL,           TemplateBgrt},
+    {ACPI_SIG_BOOT, AcpiDmTableInfoBoot,    NULL,           NULL,           TemplateBoot},
+    {ACPI_SIG_CPEP, NULL,                   AcpiDmDumpCpep, DtCompileCpep,  TemplateCpep},
+    {ACPI_SIG_CSRT, NULL,                   AcpiDmDumpCsrt, DtCompileCsrt,  TemplateCsrt},
+    {ACPI_SIG_DBG2, AcpiDmTableInfoDbg2,    AcpiDmDumpDbg2, DtCompileDbg2,  TemplateDbg2},
+    {ACPI_SIG_DBGP, AcpiDmTableInfoDbgp,    NULL,           NULL,           TemplateDbgp},
+    {ACPI_SIG_DMAR, NULL,                   AcpiDmDumpDmar, DtCompileDmar,  TemplateDmar},
+    {ACPI_SIG_DRTM, NULL,                   AcpiDmDumpDrtm, DtCompileDrtm,  TemplateDrtm},
+    {ACPI_SIG_ECDT, AcpiDmTableInfoEcdt,    NULL,           NULL,           TemplateEcdt},
+    {ACPI_SIG_EINJ, NULL,                   AcpiDmDumpEinj, DtCompileEinj,  TemplateEinj},
+    {ACPI_SIG_ERST, NULL,                   AcpiDmDumpErst, DtCompileErst,  TemplateErst},
+    {ACPI_SIG_FADT, NULL,                   AcpiDmDumpFadt, DtCompileFadt,  TemplateFadt},
+    {ACPI_SIG_FPDT, NULL,                   AcpiDmDumpFpdt, DtCompileFpdt,  TemplateFpdt},
+    {ACPI_SIG_GTDT, NULL,                   AcpiDmDumpGtdt, DtCompileGtdt,  TemplateGtdt},
+    {ACPI_SIG_HEST, NULL,                   AcpiDmDumpHest, DtCompileHest,  TemplateHest},
+    {ACPI_SIG_HPET, AcpiDmTableInfoHpet,    NULL,           NULL,           TemplateHpet},
+    {ACPI_SIG_IORT, NULL,                   AcpiDmDumpIort, DtCompileIort,  TemplateIort},
+    {ACPI_SIG_IVRS, NULL,                   AcpiDmDumpIvrs, DtCompileIvrs,  TemplateIvrs},
+    {ACPI_SIG_LPIT, NULL,                   AcpiDmDumpLpit, DtCompileLpit,  TemplateLpit},
+    {ACPI_SIG_MADT, NULL,                   AcpiDmDumpMadt, DtCompileMadt,  TemplateMadt},
+    {ACPI_SIG_MCFG, NULL,                   AcpiDmDumpMcfg, DtCompileMcfg,  TemplateMcfg},
+    {ACPI_SIG_MCHI, AcpiDmTableInfoMchi,    NULL,           NULL,           TemplateMchi},
+    {ACPI_SIG_MPST, AcpiDmTableInfoMpst,    AcpiDmDumpMpst, DtCompileMpst,  TemplateMpst},
+    {ACPI_SIG_MSCT, NULL,                   AcpiDmDumpMsct, DtCompileMsct,  TemplateMsct},
+    {ACPI_SIG_MSDM, NULL,                   AcpiDmDumpSlic, DtCompileSlic,  TemplateMsdm},
+    {ACPI_SIG_MTMR, NULL,                   AcpiDmDumpMtmr, DtCompileMtmr,  TemplateMtmr},
+    {ACPI_SIG_NFIT, AcpiDmTableInfoNfit,    AcpiDmDumpNfit, DtCompileNfit,  TemplateNfit},
+    {ACPI_SIG_PCCT, AcpiDmTableInfoPcct,    AcpiDmDumpPcct, DtCompilePcct,  TemplatePcct},
+    {ACPI_SIG_PMTT, NULL,                   AcpiDmDumpPmtt, DtCompilePmtt,  TemplatePmtt},
+    {ACPI_SIG_RASF, AcpiDmTableInfoRasf,    NULL,           NULL,           TemplateRasf},
+    {ACPI_SIG_RSDT, NULL,                   AcpiDmDumpRsdt, DtCompileRsdt,  TemplateRsdt},
+    {ACPI_SIG_S3PT, NULL,                   NULL,           NULL,           TemplateS3pt},
+    {ACPI_SIG_SBST, AcpiDmTableInfoSbst,    NULL,           NULL,           TemplateSbst},
+    {ACPI_SIG_SLIC, NULL,                   AcpiDmDumpSlic, DtCompileSlic,  TemplateSlic},
+    {ACPI_SIG_SLIT, NULL,                   AcpiDmDumpSlit, DtCompileSlit,  TemplateSlit},
+    {ACPI_SIG_SPCR, AcpiDmTableInfoSpcr,    NULL,           NULL,           TemplateSpcr},
+    {ACPI_SIG_SPMI, AcpiDmTableInfoSpmi,    NULL,           NULL,           TemplateSpmi},
+    {ACPI_SIG_SRAT, NULL,                   AcpiDmDumpSrat, DtCompileSrat,  TemplateSrat},
+    {ACPI_SIG_STAO, NULL,                   AcpiDmDumpStao, DtCompileStao,  TemplateStao},
+    {ACPI_SIG_TCPA, NULL,                   AcpiDmDumpTcpa, DtCompileTcpa,  TemplateTcpa},
+    {ACPI_SIG_TPM2, AcpiDmTableInfoTpm2,    NULL,           NULL,           TemplateTpm2},
+    {ACPI_SIG_UEFI, AcpiDmTableInfoUefi,    NULL,           DtCompileUefi,  TemplateUefi},
+    {ACPI_SIG_VRTC, AcpiDmTableInfoVrtc,    AcpiDmDumpVrtc, DtCompileVrtc,  TemplateVrtc},
+    {ACPI_SIG_WAET, AcpiDmTableInfoWaet,    NULL,           NULL,           TemplateWaet},
+    {ACPI_SIG_WDAT, NULL,                   AcpiDmDumpWdat, DtCompileWdat,  TemplateWdat},
+    {ACPI_SIG_WDDT, AcpiDmTableInfoWddt,    NULL,           NULL,           TemplateWddt},
+    {ACPI_SIG_WDRT, AcpiDmTableInfoWdrt,    NULL,           NULL,           TemplateWdrt},
+    {ACPI_SIG_WPBT, NULL,                   AcpiDmDumpWpbt, DtCompileWpbt,  TemplateWpbt},
+    {ACPI_SIG_XENV, AcpiDmTableInfoXenv,    NULL,           NULL,           TemplateXenv},
+    {ACPI_SIG_XSDT, NULL,                   AcpiDmDumpXsdt, DtCompileXsdt,  TemplateXsdt},
+    {NULL,          NULL,                   NULL,           NULL,           NULL}
+};
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmGenerateChecksum
+ *
+ * PARAMETERS:  Table               - Pointer to table to be checksummed
+ *              Length              - Length of the table
+ *              OriginalChecksum    - Value of the checksum field
+ *
+ * RETURN:      8 bit checksum of buffer
+ *
+ * DESCRIPTION: Computes an 8 bit checksum of the table.
+ *
+ ******************************************************************************/
+
+UINT8
+AcpiDmGenerateChecksum (
+    void                    *Table,
+    UINT32                  Length,
+    UINT8                   OriginalChecksum)
+{
+    UINT8                   Checksum;
+
+
+    /* Sum the entire table as-is */
+
+    Checksum = AcpiTbChecksum ((UINT8 *) Table, Length);
+
+    /* Subtract off the existing checksum value in the table */
+
+    Checksum = (UINT8) (Checksum - OriginalChecksum);
+
+    /* Compute the final checksum */
+
+    Checksum = (UINT8) (0 - Checksum);
+    return (Checksum);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmGetTableData
+ *
+ * PARAMETERS:  Signature           - ACPI signature (4 chars) to match
+ *
+ * RETURN:      Pointer to a valid ACPI_DMTABLE_DATA. Null if no match found.
+ *
+ * DESCRIPTION: Find a match in the global table of supported ACPI tables
+ *
+ ******************************************************************************/
+
+const ACPI_DMTABLE_DATA *
+AcpiDmGetTableData (
+    char                    *Signature)
+{
+    const ACPI_DMTABLE_DATA *Info;
+
+
+    for (Info = AcpiDmTableData; Info->Signature; Info++)
+    {
+        if (ACPI_COMPARE_NAME (Signature, Info->Signature))
+        {
+            return (Info);
+        }
+    }
+
+    return (NULL);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpDataTable
+ *
+ * PARAMETERS:  Table               - An ACPI table
+ *
+ * RETURN:      None.
+ *
+ * DESCRIPTION: Format the contents of an ACPI data table (any table other
+ *              than an SSDT or DSDT that does not contain executable AML code)
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpDataTable (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    const ACPI_DMTABLE_DATA *TableData;
+    UINT32                  Length;
+
+
+    /* Ignore tables that contain AML */
+
+    if (AcpiUtIsAmlTable (Table))
+    {
+        if (Gbl_VerboseTemplates)
+        {
+            /* Dump the raw table data */
+
+            Length = Table->Length;
+
+            AcpiOsPrintf ("\n/*\n%s: Length %d (0x%X)\n\n",
+                ACPI_RAW_TABLE_DATA_HEADER, Length, Length);
+            AcpiUtDumpBuffer (ACPI_CAST_PTR (UINT8, Table),
+                Length, DB_BYTE_DISPLAY, 0);
+            AcpiOsPrintf (" */\n");
+        }
+        return;
+    }
+
+    /*
+     * Handle tables that don't use the common ACPI table header structure.
+     * Currently, these are the FACS, RSDP, and S3PT.
+     */
+    if (ACPI_COMPARE_NAME (Table->Signature, ACPI_SIG_FACS))
+    {
+        Length = Table->Length;
+        Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoFacs);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+    }
+    else if (ACPI_VALIDATE_RSDP_SIG (Table->Signature))
+    {
+        Length = AcpiDmDumpRsdp (Table);
+    }
+    else if (ACPI_COMPARE_NAME (Table->Signature, ACPI_SIG_S3PT))
+    {
+        Length = AcpiDmDumpS3pt (Table);
+    }
+    else
+    {
+        /*
+         * All other tables must use the common ACPI table header, dump it now
+         */
+        Length = Table->Length;
+        Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoHeader);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+        AcpiOsPrintf ("\n");
+
+        /* Match signature and dispatch appropriately */
+
+        TableData = AcpiDmGetTableData (Table->Signature);
+        if (!TableData)
+        {
+            if (!strncmp (Table->Signature, "OEM", 3))
+            {
+                AcpiOsPrintf ("\n**** OEM-defined ACPI table [%4.4s], unknown contents\n\n",
+                    Table->Signature);
+            }
+            else
+            {
+                AcpiOsPrintf ("\n**** Unknown ACPI table signature [%4.4s]\n\n",
+                    Table->Signature);
+
+                fprintf (stderr, "Unknown ACPI table signature [%4.4s], ",
+                    Table->Signature);
+
+                if (!AcpiGbl_ForceAmlDisassembly)
+                {
+                    fprintf (stderr, "decoding ACPI table header only\n");
+                }
+                else
+                {
+                    fprintf (stderr, "assuming table contains valid AML code\n");
+                }
+            }
+        }
+        else if (TableData->TableHandler)
+        {
+            /* Complex table, has a handler */
+
+            TableData->TableHandler (Table);
+        }
+        else if (TableData->TableInfo)
+        {
+            /* Simple table, just walk the info table */
+
+            Status = AcpiDmDumpTable (Length, 0, Table, 0, TableData->TableInfo);
+            if (ACPI_FAILURE (Status))
+            {
+                return;
+            }
+        }
+    }
+
+    if (!Gbl_DoTemplates || Gbl_VerboseTemplates)
+    {
+        /* Dump the raw table data */
+
+        AcpiOsPrintf ("\n%s: Length %d (0x%X)\n\n",
+            ACPI_RAW_TABLE_DATA_HEADER, Length, Length);
+        AcpiUtDumpBuffer (ACPI_CAST_PTR (UINT8, Table),
+            Length, DB_BYTE_DISPLAY, 0);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmLineHeader
+ *
+ * PARAMETERS:  Offset              - Current byte offset, from table start
+ *              ByteLength          - Length of the field in bytes, 0 for flags
+ *              Name                - Name of this field
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Utility routines for formatting output lines. Displays the
+ *              current table offset in hex and decimal, the field length,
+ *              and the field name.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmLineHeader (
+    UINT32                  Offset,
+    UINT32                  ByteLength,
+    char                    *Name)
+{
+
+    /* Allow a null name for fields that span multiple lines (large buffers) */
+
+    if (!Name)
+    {
+        Name = "";
+    }
+
+    if (Gbl_DoTemplates && !Gbl_VerboseTemplates) /* Terse template */
+    {
+        if (ByteLength)
+        {
+            AcpiOsPrintf ("[%.4d] %34s : ", ByteLength, Name);
+        }
+        else
+        {
+            if (*Name)
+            {
+                AcpiOsPrintf ("%41s : ", Name);
+            }
+            else
+            {
+                AcpiOsPrintf ("%41s   ", Name);
+            }
+        }
+    }
+    else /* Normal disassembler or verbose template */
+    {
+        if (ByteLength)
+        {
+            AcpiOsPrintf ("[%3.3Xh %4.4d% 4d] %28s : ",
+                Offset, Offset, ByteLength, Name);
+        }
+        else
+        {
+            if (*Name)
+            {
+                AcpiOsPrintf ("%44s : ", Name);
+            }
+            else
+            {
+                AcpiOsPrintf ("%44s   ", Name);
+            }
+        }
+    }
+}
+
+void
+AcpiDmLineHeader2 (
+    UINT32                  Offset,
+    UINT32                  ByteLength,
+    char                    *Name,
+    UINT32                  Value)
+{
+
+    if (Gbl_DoTemplates && !Gbl_VerboseTemplates) /* Terse template */
+    {
+        if (ByteLength)
+        {
+            AcpiOsPrintf ("[%.4d] %30s %3d : ",
+                ByteLength, Name, Value);
+        }
+        else
+        {
+            AcpiOsPrintf ("%36s % 3d : ",
+                Name, Value);
+        }
+    }
+    else /* Normal disassembler or verbose template */
+    {
+        if (ByteLength)
+        {
+            AcpiOsPrintf ("[%3.3Xh %4.4d %3d] %24s %3d : ",
+                Offset, Offset, ByteLength, Name, Value);
+        }
+        else
+        {
+            AcpiOsPrintf ("[%3.3Xh %4.4d   ] %24s %3d : ",
+                Offset, Offset, Name, Value);
+        }
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpTable
+ *
+ * PARAMETERS:  TableLength         - Length of the entire ACPI table
+ *              TableOffset         - Starting offset within the table for this
+ *                                    sub-descriptor (0 if main table)
+ *              Table               - The ACPI table
+ *              SubtableLength      - Length of this sub-descriptor
+ *              Info                - Info table for this ACPI table
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Display ACPI table contents by walking the Info table.
+ *
+ * Note: This function must remain in sync with DtGetFieldLength.
+ *
+ ******************************************************************************/
+
+ACPI_STATUS
+AcpiDmDumpTable (
+    UINT32                  TableLength,
+    UINT32                  TableOffset,
+    void                    *Table,
+    UINT32                  SubtableLength,
+    ACPI_DMTABLE_INFO       *Info)
+{
+    UINT8                   *Target;
+    UINT32                  CurrentOffset;
+    UINT32                  ByteLength;
+    UINT8                   Temp8;
+    UINT16                  Temp16;
+    UINT32                  Temp32;
+    UINT64                  Value;
+    const AH_TABLE          *TableData;
+    const char              *Name;
+    BOOLEAN                 LastOutputBlankLine = FALSE;
+    ACPI_STATUS             Status;
+    char                    RepairedName[8];
+
+
+    if (!Info)
+    {
+        AcpiOsPrintf ("Display not implemented\n");
+        return (AE_NOT_IMPLEMENTED);
+    }
+
+    /* Walk entire Info table; Null name terminates */
+
+    for (; Info->Name; Info++)
+    {
+        /*
+         * Target points to the field within the ACPI Table. CurrentOffset is
+         * the offset of the field from the start of the main table.
+         */
+        Target = ACPI_ADD_PTR (UINT8, Table, Info->Offset);
+        CurrentOffset = TableOffset + Info->Offset;
+
+        /* Check for beyond subtable end or (worse) beyond EOT */
+
+        if (SubtableLength && (Info->Offset >= SubtableLength))
+        {
+            AcpiOsPrintf (
+                "/**** ACPI subtable terminates early - "
+                "may be older version (dump table) */\n");
+
+            /* Move on to next subtable */
+
+            return (AE_OK);
+        }
+
+        if (CurrentOffset >= TableLength)
+        {
+            AcpiOsPrintf (
+                "/**** ACPI table terminates "
+                "in the middle of a data structure! (dump table) */\n");
+            return (AE_BAD_DATA);
+        }
+
+        /* Generate the byte length for this field */
+
+        switch (Info->Opcode)
+        {
+        case ACPI_DMT_UINT8:
+        case ACPI_DMT_CHKSUM:
+        case ACPI_DMT_SPACEID:
+        case ACPI_DMT_ACCWIDTH:
+        case ACPI_DMT_IVRS:
+        case ACPI_DMT_GTDT:
+        case ACPI_DMT_MADT:
+        case ACPI_DMT_PCCT:
+        case ACPI_DMT_PMTT:
+        case ACPI_DMT_SRAT:
+        case ACPI_DMT_ASF:
+        case ACPI_DMT_HESTNTYP:
+        case ACPI_DMT_FADTPM:
+        case ACPI_DMT_EINJACT:
+        case ACPI_DMT_EINJINST:
+        case ACPI_DMT_ERSTACT:
+        case ACPI_DMT_ERSTINST:
+        case ACPI_DMT_DMAR_SCOPE:
+
+            ByteLength = 1;
+            break;
+
+        case ACPI_DMT_UINT16:
+        case ACPI_DMT_DMAR:
+        case ACPI_DMT_HEST:
+        case ACPI_DMT_NFIT:
+
+            ByteLength = 2;
+            break;
+
+        case ACPI_DMT_UINT24:
+
+            ByteLength = 3;
+            break;
+
+        case ACPI_DMT_UINT32:
+        case ACPI_DMT_NAME4:
+        case ACPI_DMT_SIG:
+        case ACPI_DMT_LPIT:
+
+            ByteLength = 4;
+            break;
+
+        case ACPI_DMT_UINT40:
+
+            ByteLength = 5;
+            break;
+
+        case ACPI_DMT_UINT48:
+        case ACPI_DMT_NAME6:
+
+            ByteLength = 6;
+            break;
+
+        case ACPI_DMT_UINT56:
+        case ACPI_DMT_BUF7:
+
+            ByteLength = 7;
+            break;
+
+        case ACPI_DMT_UINT64:
+        case ACPI_DMT_NAME8:
+
+            ByteLength = 8;
+            break;
+
+        case ACPI_DMT_BUF10:
+
+            ByteLength = 10;
+            break;
+
+        case ACPI_DMT_BUF12:
+
+            ByteLength = 12;
+            break;
+
+        case ACPI_DMT_BUF16:
+        case ACPI_DMT_UUID:
+
+            ByteLength = 16;
+            break;
+
+        case ACPI_DMT_BUF128:
+
+            ByteLength = 128;
+            break;
+
+        case ACPI_DMT_UNICODE:
+        case ACPI_DMT_BUFFER:
+        case ACPI_DMT_RAW_BUFFER:
+
+            ByteLength = SubtableLength;
+            break;
+
+        case ACPI_DMT_STRING:
+
+            ByteLength = strlen (ACPI_CAST_PTR (char, Target)) + 1;
+            break;
+
+        case ACPI_DMT_GAS:
+
+            if (!LastOutputBlankLine)
+            {
+                AcpiOsPrintf ("\n");
+                LastOutputBlankLine = TRUE;
+            }
+
+            ByteLength = sizeof (ACPI_GENERIC_ADDRESS);
+            break;
+
+        case ACPI_DMT_HESTNTFY:
+
+            if (!LastOutputBlankLine)
+            {
+                AcpiOsPrintf ("\n");
+                LastOutputBlankLine = TRUE;
+            }
+
+            ByteLength = sizeof (ACPI_HEST_NOTIFY);
+            break;
+
+        case ACPI_DMT_IORTMEM:
+
+            if (!LastOutputBlankLine)
+            {
+                LastOutputBlankLine = FALSE;
+            }
+
+            ByteLength = sizeof (ACPI_IORT_MEMORY_ACCESS);
+            break;
+
+        default:
+
+            ByteLength = 0;
+            break;
+        }
+
+        /* Check if we are beyond a subtable, or (worse) beyond EOT */
+
+        if (CurrentOffset + ByteLength > TableLength)
+        {
+            if (SubtableLength)
+            {
+                AcpiOsPrintf (
+                    "/**** ACPI subtable terminates early - "
+                    "may be older version (dump table) */\n");
+
+                /* Move on to next subtable */
+
+                return (AE_OK);
+            }
+
+            AcpiOsPrintf (
+                "/**** ACPI table terminates "
+                "in the middle of a data structure! */\n");
+            return (AE_BAD_DATA);
+        }
+
+        if (Info->Opcode == ACPI_DMT_EXTRA_TEXT)
+        {
+            AcpiOsPrintf ("%s", Info->Name);
+            continue;
+        }
+
+        /* Start a new line and decode the opcode */
+
+        AcpiDmLineHeader (CurrentOffset, ByteLength, Info->Name);
+
+        switch (Info->Opcode)
+        {
+        /* Single-bit Flag fields. Note: Opcode is the bit position */
+
+        case ACPI_DMT_FLAG0:
+        case ACPI_DMT_FLAG1:
+        case ACPI_DMT_FLAG2:
+        case ACPI_DMT_FLAG3:
+        case ACPI_DMT_FLAG4:
+        case ACPI_DMT_FLAG5:
+        case ACPI_DMT_FLAG6:
+        case ACPI_DMT_FLAG7:
+
+            AcpiOsPrintf ("%1.1X\n", (*Target >> Info->Opcode) & 0x01);
+            break;
+
+        /* 2-bit Flag fields */
+
+        case ACPI_DMT_FLAGS0:
+
+            AcpiOsPrintf ("%1.1X\n", *Target & 0x03);
+            break;
+
+        case ACPI_DMT_FLAGS1:
+
+            AcpiOsPrintf ("%1.1X\n", (*Target >> 1) & 0x03);
+            break;
+
+        case ACPI_DMT_FLAGS2:
+
+            AcpiOsPrintf ("%1.1X\n", (*Target >> 2) & 0x03);
+            break;
+
+        case ACPI_DMT_FLAGS4:
+
+            AcpiOsPrintf ("%1.1X\n", (*Target >> 4) & 0x03);
+            break;
+
+        /* Integer Data Types */
+
+        case ACPI_DMT_UINT8:
+        case ACPI_DMT_UINT16:
+        case ACPI_DMT_UINT24:
+        case ACPI_DMT_UINT32:
+        case ACPI_DMT_UINT40:
+        case ACPI_DMT_UINT48:
+        case ACPI_DMT_UINT56:
+        case ACPI_DMT_UINT64:
+            /*
+             * Dump bytes - high byte first, low byte last.
+             * Note: All ACPI tables are little-endian.
+             */
+            Value = 0;
+            for (Temp8 = (UINT8) ByteLength; Temp8 > 0; Temp8--)
+            {
+                AcpiOsPrintf ("%2.2X", Target[Temp8 - 1]);
+                Value |= Target[Temp8 - 1];
+                Value <<= 8;
+            }
+
+            if (!Value && (Info->Flags & DT_DESCRIBES_OPTIONAL))
+            {
+                AcpiOsPrintf (" [Optional field not present]");
+            }
+
+            AcpiOsPrintf ("\n");
+            break;
+
+        case ACPI_DMT_BUF7:
+        case ACPI_DMT_BUF10:
+        case ACPI_DMT_BUF12:
+        case ACPI_DMT_BUF16:
+        case ACPI_DMT_BUF128:
+            /*
+             * Buffer: Size depends on the opcode and was set above.
+             * Each hex byte is separated with a space.
+             * Multiple lines are separated by line continuation char.
+             */
+            for (Temp16 = 0; Temp16 < ByteLength; Temp16++)
+            {
+                AcpiOsPrintf ("%2.2X", Target[Temp16]);
+                if ((UINT32) (Temp16 + 1) < ByteLength)
+                {
+                    if ((Temp16 > 0) && (!((Temp16+1) % 16)))
+                    {
+                        AcpiOsPrintf (" \\\n"); /* Line continuation */
+                        AcpiDmLineHeader (0, 0, NULL);
+                    }
+                    else
+                    {
+                        AcpiOsPrintf (" ");
+                    }
+                }
+            }
+
+            AcpiOsPrintf ("\n");
+            break;
+
+        case ACPI_DMT_UUID:
+
+            /* Convert 16-byte UUID buffer to 36-byte formatted UUID string */
+
+            (void) AuConvertUuidToString ((char *) Target, MsgBuffer);
+
+            AcpiOsPrintf ("%s\n", MsgBuffer);
+            break;
+
+        case ACPI_DMT_STRING:
+
+            AcpiOsPrintf ("\"%s\"\n", ACPI_CAST_PTR (char, Target));
+            break;
+
+        /* Fixed length ASCII name fields */
+
+        case ACPI_DMT_SIG:
+
+            AcpiUtCheckAndRepairAscii (Target, RepairedName, 4);
+            AcpiOsPrintf ("\"%.4s\"    ", RepairedName);
+
+            TableData = AcpiAhGetTableInfo (ACPI_CAST_PTR (char, Target));
+            if (TableData)
+            {
+                AcpiOsPrintf (STRING_FORMAT, TableData->Description);
+            }
+            else
+            {
+                AcpiOsPrintf ("\n");
+            }
+            break;
+
+        case ACPI_DMT_NAME4:
+
+            AcpiUtCheckAndRepairAscii (Target, RepairedName, 4);
+            AcpiOsPrintf ("\"%.4s\"\n", RepairedName);
+            break;
+
+        case ACPI_DMT_NAME6:
+
+            AcpiUtCheckAndRepairAscii (Target, RepairedName, 6);
+            AcpiOsPrintf ("\"%.6s\"\n", RepairedName);
+            break;
+
+        case ACPI_DMT_NAME8:
+
+            AcpiUtCheckAndRepairAscii (Target, RepairedName, 8);
+            AcpiOsPrintf ("\"%.8s\"\n", RepairedName);
+            break;
+
+        /* Special Data Types */
+
+        case ACPI_DMT_CHKSUM:
+
+            /* Checksum, display and validate */
+
+            AcpiOsPrintf ("%2.2X", *Target);
+            Temp8 = AcpiDmGenerateChecksum (Table,
+                ACPI_CAST_PTR (ACPI_TABLE_HEADER, Table)->Length,
+                ACPI_CAST_PTR (ACPI_TABLE_HEADER, Table)->Checksum);
+
+            if (Temp8 != ACPI_CAST_PTR (ACPI_TABLE_HEADER, Table)->Checksum)
+            {
+                AcpiOsPrintf (
+                    "     /* Incorrect checksum, should be %2.2X */", Temp8);
+            }
+
+            AcpiOsPrintf ("\n");
+            break;
+
+        case ACPI_DMT_SPACEID:
+
+            /* Address Space ID */
+
+            AcpiOsPrintf (UINT8_FORMAT, *Target, AcpiUtGetRegionName (*Target));
+            break;
+
+        case ACPI_DMT_ACCWIDTH:
+
+            /* Encoded Access Width */
+
+            Temp8 = *Target;
+            if (Temp8 > ACPI_GAS_WIDTH_RESERVED)
+            {
+                Temp8 = ACPI_GAS_WIDTH_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT8_FORMAT, *Target, AcpiDmGasAccessWidth[Temp8]);
+            break;
+
+        case ACPI_DMT_GAS:
+
+            /* Generic Address Structure */
+
+            AcpiOsPrintf (STRING_FORMAT, "Generic Address Structure");
+            Status = AcpiDmDumpTable (TableLength, CurrentOffset, Target,
+                sizeof (ACPI_GENERIC_ADDRESS), AcpiDmTableInfoGas);
+            if (ACPI_FAILURE (Status))
+            {
+                return (Status);
+            }
+
+            AcpiOsPrintf ("\n");
+            LastOutputBlankLine = TRUE;
+            break;
+
+        case ACPI_DMT_ASF:
+
+            /* ASF subtable types */
+
+            Temp16 = (UINT16) ((*Target) & 0x7F);  /* Top bit can be zero or one */
+            if (Temp16 > ACPI_ASF_TYPE_RESERVED)
+            {
+                Temp16 = ACPI_ASF_TYPE_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT8_FORMAT, *Target, AcpiDmAsfSubnames[Temp16]);
+            break;
+
+        case ACPI_DMT_DMAR:
+
+            /* DMAR subtable types */
+
+            Temp16 = ACPI_GET16 (Target);
+            if (Temp16 > ACPI_DMAR_TYPE_RESERVED)
+            {
+                Temp16 = ACPI_DMAR_TYPE_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT16_FORMAT, ACPI_GET16 (Target),
+                AcpiDmDmarSubnames[Temp16]);
+            break;
+
+        case ACPI_DMT_DMAR_SCOPE:
+
+            /* DMAR device scope types */
+
+            Temp8 = *Target;
+            if (Temp8 > ACPI_DMAR_SCOPE_TYPE_RESERVED)
+            {
+                Temp8 = ACPI_DMAR_SCOPE_TYPE_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT8_FORMAT, *Target,
+                AcpiDmDmarScope[Temp8]);
+            break;
+
+        case ACPI_DMT_EINJACT:
+
+            /* EINJ Action types */
+
+            Temp8 = *Target;
+            if (Temp8 > ACPI_EINJ_ACTION_RESERVED)
+            {
+                Temp8 = ACPI_EINJ_ACTION_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT8_FORMAT, *Target,
+                AcpiDmEinjActions[Temp8]);
+            break;
+
+        case ACPI_DMT_EINJINST:
+
+            /* EINJ Instruction types */
+
+            Temp8 = *Target;
+            if (Temp8 > ACPI_EINJ_INSTRUCTION_RESERVED)
+            {
+                Temp8 = ACPI_EINJ_INSTRUCTION_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT8_FORMAT, *Target,
+                AcpiDmEinjInstructions[Temp8]);
+            break;
+
+        case ACPI_DMT_ERSTACT:
+
+            /* ERST Action types */
+
+            Temp8 = *Target;
+            if (Temp8 > ACPI_ERST_ACTION_RESERVED)
+            {
+                Temp8 = ACPI_ERST_ACTION_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT8_FORMAT, *Target,
+                AcpiDmErstActions[Temp8]);
+            break;
+
+        case ACPI_DMT_ERSTINST:
+
+            /* ERST Instruction types */
+
+            Temp8 = *Target;
+            if (Temp8 > ACPI_ERST_INSTRUCTION_RESERVED)
+            {
+                Temp8 = ACPI_ERST_INSTRUCTION_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT8_FORMAT, *Target,
+                AcpiDmErstInstructions[Temp8]);
+            break;
+
+        case ACPI_DMT_GTDT:
+
+            /* GTDT subtable types */
+
+            Temp8 = *Target;
+            if (Temp8 > ACPI_GTDT_TYPE_RESERVED)
+            {
+                Temp8 = ACPI_GTDT_TYPE_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT8_FORMAT, *Target,
+                AcpiDmGtdtSubnames[Temp8]);
+            break;
+
+        case ACPI_DMT_HEST:
+
+            /* HEST subtable types */
+
+            Temp16 = ACPI_GET16 (Target);
+            if (Temp16 > ACPI_HEST_TYPE_RESERVED)
+            {
+                Temp16 = ACPI_HEST_TYPE_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT16_FORMAT, ACPI_GET16 (Target),
+                AcpiDmHestSubnames[Temp16]);
+            break;
+
+        case ACPI_DMT_HESTNTFY:
+
+            AcpiOsPrintf (STRING_FORMAT,
+                "Hardware Error Notification Structure");
+
+            Status = AcpiDmDumpTable (TableLength, CurrentOffset, Target,
+                sizeof (ACPI_HEST_NOTIFY), AcpiDmTableInfoHestNotify);
+            if (ACPI_FAILURE (Status))
+            {
+                return (Status);
+            }
+
+            AcpiOsPrintf ("\n");
+            LastOutputBlankLine = TRUE;
+            break;
+
+        case ACPI_DMT_HESTNTYP:
+
+            /* HEST Notify types */
+
+            Temp8 = *Target;
+            if (Temp8 > ACPI_HEST_NOTIFY_RESERVED)
+            {
+                Temp8 = ACPI_HEST_NOTIFY_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT8_FORMAT, *Target,
+                AcpiDmHestNotifySubnames[Temp8]);
+            break;
+
+        case ACPI_DMT_IORTMEM:
+
+            AcpiOsPrintf (STRING_FORMAT,
+                "IORT Memory Access Properties");
+
+            Status = AcpiDmDumpTable (TableLength, CurrentOffset, Target,
+                sizeof (ACPI_IORT_MEMORY_ACCESS), AcpiDmTableInfoIortAcc);
+            if (ACPI_FAILURE (Status))
+            {
+                return (Status);
+            }
+
+            LastOutputBlankLine = TRUE;
+            break;
+
+        case ACPI_DMT_MADT:
+
+            /* MADT subtable types */
+
+            Temp8 = *Target;
+            if (Temp8 > ACPI_MADT_TYPE_RESERVED)
+            {
+                Temp8 = ACPI_MADT_TYPE_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT8_FORMAT, *Target,
+                AcpiDmMadtSubnames[Temp8]);
+            break;
+
+        case ACPI_DMT_NFIT:
+
+            /* NFIT subtable types */
+
+            Temp16 = ACPI_GET16 (Target);
+            if (Temp16 > ACPI_NFIT_TYPE_RESERVED)
+            {
+                Temp16 = ACPI_NFIT_TYPE_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT16_FORMAT, ACPI_GET16 (Target),
+                AcpiDmNfitSubnames[Temp16]);
+            break;
+
+        case ACPI_DMT_PCCT:
+
+            /* PCCT subtable types */
+
+            Temp8 = *Target;
+            if (Temp8 > ACPI_PCCT_TYPE_RESERVED)
+            {
+                Temp8 = ACPI_PCCT_TYPE_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT8_FORMAT, *Target,
+                AcpiDmPcctSubnames[Temp8]);
+            break;
+
+        case ACPI_DMT_PMTT:
+
+            /* PMTT subtable types */
+
+            Temp8 = *Target;
+            if (Temp8 > ACPI_PMTT_TYPE_RESERVED)
+            {
+                Temp8 = ACPI_PMTT_TYPE_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT8_FORMAT, *Target,
+                AcpiDmPmttSubnames[Temp8]);
+            break;
+
+        case ACPI_DMT_UNICODE:
+
+            if (ByteLength == 0)
+            {
+                AcpiOsPrintf ("/* Zero-length Data */\n");
+                break;
+            }
+
+            AcpiDmDumpUnicode (Table, CurrentOffset, ByteLength);
+            break;
+
+        case ACPI_DMT_RAW_BUFFER:
+
+            if (ByteLength == 0)
+            {
+                AcpiOsPrintf ("/* Zero-length Data */\n");
+                break;
+            }
+
+            AcpiDmDumpBuffer (Table, CurrentOffset, ByteLength,
+                CurrentOffset, NULL);
+            break;
+
+        case ACPI_DMT_SRAT:
+
+            /* SRAT subtable types */
+
+            Temp8 = *Target;
+            if (Temp8 > ACPI_SRAT_TYPE_RESERVED)
+            {
+                Temp8 = ACPI_SRAT_TYPE_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT8_FORMAT, *Target,
+                AcpiDmSratSubnames[Temp8]);
+            break;
+
+        case ACPI_DMT_FADTPM:
+
+            /* FADT Preferred PM Profile names */
+
+            Temp8 = *Target;
+            if (Temp8 > ACPI_FADT_PM_RESERVED)
+            {
+                Temp8 = ACPI_FADT_PM_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT8_FORMAT, *Target,
+                AcpiDmFadtProfiles[Temp8]);
+            break;
+
+        case ACPI_DMT_IVRS:
+
+            /* IVRS subtable types */
+
+            Temp8 = *Target;
+            switch (Temp8)
+            {
+            case ACPI_IVRS_TYPE_HARDWARE:
+
+                Name = AcpiDmIvrsSubnames[0];
+                break;
+
+            case ACPI_IVRS_TYPE_MEMORY1:
+            case ACPI_IVRS_TYPE_MEMORY2:
+            case ACPI_IVRS_TYPE_MEMORY3:
+
+                Name = AcpiDmIvrsSubnames[1];
+                break;
+
+            default:
+
+                Name = AcpiDmIvrsSubnames[2];
+                break;
+            }
+
+            AcpiOsPrintf (UINT8_FORMAT, *Target, Name);
+            break;
+
+        case ACPI_DMT_LPIT:
+
+            /* LPIT subtable types */
+
+            Temp32 = ACPI_GET32 (Target);
+            if (Temp32 > ACPI_LPIT_TYPE_RESERVED)
+            {
+                Temp32 = ACPI_LPIT_TYPE_RESERVED;
+            }
+
+            AcpiOsPrintf (UINT32_FORMAT, ACPI_GET32 (Target),
+                AcpiDmLpitSubnames[Temp32]);
+            break;
+
+        case ACPI_DMT_EXIT:
+
+            return (AE_OK);
+
+        default:
+
+            ACPI_ERROR ((AE_INFO,
+                "**** Invalid table opcode [0x%X] ****\n", Info->Opcode));
+            return (AE_SUPPORT);
+        }
+    }
+
+    if (TableOffset && !SubtableLength)
+    {
+        /*
+         * If this table is not the main table, the subtable must have a
+         * valid length
+         */
+        AcpiOsPrintf ("Invalid zero length subtable\n");
+        return (AE_BAD_DATA);
+    }
+
+    return (AE_OK);
+}

--- a/sys/src/libacpi/acpica/common/dmtables.c
+++ b/sys/src/libacpi/acpica/common/dmtables.c
@@ -1,0 +1,557 @@
+/******************************************************************************
+ *
+ * Module Name: dmtables - disassembler ACPI table support
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "aslcompiler.h"
+#include "acapps.h"
+#include "acdispat.h"
+#include "acnamesp.h"
+#include "actables.h"
+#include "acparser.h"
+
+#include <stdio.h>
+#include <time.h>
+
+#define _COMPONENT          ACPI_TOOLS
+        ACPI_MODULE_NAME    ("dmtables")
+
+
+/* Local prototypes */
+
+static void
+AdCreateTableHeader (
+    char                    *Filename,
+    ACPI_TABLE_HEADER       *Table);
+
+static ACPI_STATUS
+AdStoreTable (
+    ACPI_TABLE_HEADER       *Table,
+    UINT32                  *TableIndex);
+
+
+extern ACPI_TABLE_DESC      LocalTables[1];
+extern ACPI_PARSE_OBJECT    *AcpiGbl_ParseOpRoot;
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AdDisassemblerHeader
+ *
+ * PARAMETERS:  Filename            - Input file for the table
+ *              TableType           - Either AML or DataTable
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Create the disassembler header, including ACPICA signon with
+ *              current time and date.
+ *
+ *****************************************************************************/
+
+void
+AdDisassemblerHeader (
+    char                    *Filename,
+    UINT8                   TableType)
+{
+    time_t                  Timer;
+
+
+    time (&Timer);
+
+    /* Header and input table info */
+
+    AcpiOsPrintf ("/*\n");
+    AcpiOsPrintf (ACPI_COMMON_HEADER (AML_DISASSEMBLER_NAME, " * "));
+
+    if (TableType == ACPI_IS_AML_TABLE)
+    {
+        if (AcpiGbl_CstyleDisassembly)
+        {
+            AcpiOsPrintf (
+                " * Disassembling to symbolic ASL+ operators\n"
+                " *\n");
+        }
+        else
+        {
+            AcpiOsPrintf (
+                " * Disassembling to non-symbolic legacy ASL operators\n"
+                " *\n");
+        }
+    }
+
+    AcpiOsPrintf (" * Disassembly of %s, %s", Filename, ctime (&Timer));
+    AcpiOsPrintf (" *\n");
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AdCreateTableHeader
+ *
+ * PARAMETERS:  Filename            - Input file for the table
+ *              Table               - Pointer to the raw table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Create the ASL table header, including ACPICA signon with
+ *              current time and date.
+ *
+ *****************************************************************************/
+
+static void
+AdCreateTableHeader (
+    char                    *Filename,
+    ACPI_TABLE_HEADER       *Table)
+{
+    UINT8                   Checksum;
+
+
+    /* Reset globals for External statements */
+
+    AcpiGbl_NumExternalMethods = 0;
+    AcpiGbl_ResolvedExternalMethods = 0;
+
+    /*
+     * Print file header and dump original table header
+     */
+    AdDisassemblerHeader (Filename, ACPI_IS_AML_TABLE);
+
+    AcpiOsPrintf (" * Original Table Header:\n");
+    AcpiOsPrintf (" *     Signature        \"%4.4s\"\n",    Table->Signature);
+    AcpiOsPrintf (" *     Length           0x%8.8X (%u)\n", Table->Length, Table->Length);
+
+    /* Print and validate the revision */
+
+    AcpiOsPrintf (" *     Revision         0x%2.2X",      Table->Revision);
+
+    switch (Table->Revision)
+    {
+    case 0:
+
+        AcpiOsPrintf (" **** Invalid Revision");
+        break;
+
+    case 1:
+
+        /* Revision of DSDT controls the ACPI integer width */
+
+        if (ACPI_COMPARE_NAME (Table->Signature, ACPI_SIG_DSDT))
+        {
+            AcpiOsPrintf (" **** 32-bit table (V1), no 64-bit math support");
+        }
+        break;
+
+    default:
+
+        break;
+    }
+
+    /* Print and validate the table checksum */
+
+    AcpiOsPrintf ("\n *     Checksum         0x%2.2X",        Table->Checksum);
+
+    Checksum = AcpiTbChecksum (ACPI_CAST_PTR (UINT8, Table), Table->Length);
+    if (Checksum)
+    {
+        AcpiOsPrintf (" **** Incorrect checksum, should be 0x%2.2X",
+            (UINT8) (Table->Checksum - Checksum));
+    }
+
+    AcpiOsPrintf ("\n");
+    AcpiOsPrintf (" *     OEM ID           \"%.6s\"\n",     Table->OemId);
+    AcpiOsPrintf (" *     OEM Table ID     \"%.8s\"\n",     Table->OemTableId);
+    AcpiOsPrintf (" *     OEM Revision     0x%8.8X (%u)\n", Table->OemRevision, Table->OemRevision);
+    AcpiOsPrintf (" *     Compiler ID      \"%.4s\"\n",     Table->AslCompilerId);
+    AcpiOsPrintf (" *     Compiler Version 0x%8.8X (%u)\n", Table->AslCompilerRevision, Table->AslCompilerRevision);
+    AcpiOsPrintf (" */\n");
+
+    /*
+     * Open the ASL definition block.
+     *
+     * Note: the AMLFilename string is left zero-length in order to just let
+     * the compiler create it when the disassembled file is compiled. This
+     * makes it easier to rename the disassembled ASL file if needed.
+     */
+    AcpiOsPrintf (
+        "DefinitionBlock (\"\", \"%4.4s\", %hu, \"%.6s\", \"%.8s\", 0x%8.8X)\n",
+        Table->Signature, Table->Revision,
+        Table->OemId, Table->OemTableId, Table->OemRevision);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AdDisplayTables
+ *
+ * PARAMETERS:  Filename            - Input file for the table
+ *              Table               - Pointer to the raw table
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Display (disassemble) loaded tables and dump raw tables
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AdDisplayTables (
+    char                    *Filename,
+    ACPI_TABLE_HEADER       *Table)
+{
+
+
+    if (!AcpiGbl_ParseOpRoot)
+    {
+        return (AE_NOT_EXIST);
+    }
+
+    if (!AcpiGbl_DmOpt_Listing)
+    {
+        AdCreateTableHeader (Filename, Table);
+    }
+
+    AcpiDmDisassemble (NULL, AcpiGbl_ParseOpRoot, ACPI_UINT32_MAX);
+    MpEmitMappingInfo ();
+
+    if (AcpiGbl_DmOpt_Listing)
+    {
+        AcpiOsPrintf ("\n\nTable Header:\n");
+        AcpiUtDebugDumpBuffer ((UINT8 *) Table, sizeof (ACPI_TABLE_HEADER),
+            DB_BYTE_DISPLAY, ACPI_UINT32_MAX);
+
+        AcpiOsPrintf ("Table Body (Length 0x%X)\n", Table->Length);
+        AcpiUtDebugDumpBuffer (((UINT8 *) Table + sizeof (ACPI_TABLE_HEADER)),
+            Table->Length, DB_BYTE_DISPLAY, ACPI_UINT32_MAX);
+    }
+
+    return (AE_OK);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AdStoreTable
+ *
+ * PARAMETERS:  Table               - Table header
+ *              TableIndex          - Where the table index is returned
+ *
+ * RETURN:      Status and table index.
+ *
+ * DESCRIPTION: Add an ACPI table to the global table list
+ *
+ ******************************************************************************/
+
+static ACPI_STATUS
+AdStoreTable (
+    ACPI_TABLE_HEADER       *Table,
+    UINT32                  *TableIndex)
+{
+    ACPI_STATUS             Status;
+    ACPI_TABLE_DESC         *TableDesc;
+
+
+    Status = AcpiTbGetNextTableDescriptor (TableIndex, &TableDesc);
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    /* Initialize added table */
+
+    AcpiTbInitTableDescriptor (TableDesc, ACPI_PTR_TO_PHYSADDR (Table),
+        ACPI_TABLE_ORIGIN_INTERNAL_VIRTUAL, Table);
+    Status = AcpiTbValidateTable (TableDesc);
+    return (Status);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AdGetLocalTables
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Get the ACPI tables from either memory or a file
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AdGetLocalTables (
+    void)
+{
+    ACPI_STATUS             Status;
+    ACPI_TABLE_HEADER       TableHeader;
+    ACPI_TABLE_HEADER       *NewTable;
+    UINT32                  TableIndex;
+
+
+    /* Get the DSDT via table override */
+
+    ACPI_MOVE_32_TO_32 (TableHeader.Signature, ACPI_SIG_DSDT);
+    AcpiOsTableOverride (&TableHeader, &NewTable);
+    if (!NewTable)
+    {
+        fprintf (stderr, "Could not obtain DSDT\n");
+        return (AE_NO_ACPI_TABLES);
+    }
+
+    AdWriteTable (NewTable, NewTable->Length,
+        ACPI_SIG_DSDT, NewTable->OemTableId);
+
+    /* Store DSDT in the Table Manager */
+
+    Status = AdStoreTable (NewTable, &TableIndex);
+    if (ACPI_FAILURE (Status))
+    {
+        fprintf (stderr, "Could not store DSDT\n");
+        return (AE_NO_ACPI_TABLES);
+    }
+
+    return (AE_OK);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AdParseTable
+ *
+ * PARAMETERS:  Table               - Pointer to the raw table
+ *              OwnerId             - Returned OwnerId of the table
+ *              LoadTable           - If add table to the global table list
+ *              External            - If this is an external table
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Parse an ACPI AML table
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AdParseTable (
+    ACPI_TABLE_HEADER       *Table,
+    ACPI_OWNER_ID           *OwnerId,
+    BOOLEAN                 LoadTable,
+    BOOLEAN                 External)
+{
+    ACPI_STATUS             Status = AE_OK;
+    ACPI_WALK_STATE         *WalkState;
+    UINT8                   *AmlStart;
+    UINT32                  AmlLength;
+    UINT32                  TableIndex;
+
+
+    if (!Table)
+    {
+        return (AE_NOT_EXIST);
+    }
+
+    /* Pass 1:  Parse everything except control method bodies */
+
+    fprintf (stderr, "Pass 1 parse of [%4.4s]\n", (char *) Table->Signature);
+
+    AmlLength = Table->Length - sizeof (ACPI_TABLE_HEADER);
+    AmlStart = ((UINT8 *) Table + sizeof (ACPI_TABLE_HEADER));
+
+    /* Create the root object */
+
+    AcpiGbl_ParseOpRoot = AcpiPsCreateScopeOp (AmlStart);
+    if (!AcpiGbl_ParseOpRoot)
+    {
+        return (AE_NO_MEMORY);
+    }
+
+    /* Create and initialize a new walk state */
+
+    WalkState = AcpiDsCreateWalkState (0, AcpiGbl_ParseOpRoot, NULL, NULL);
+    if (!WalkState)
+    {
+        return (AE_NO_MEMORY);
+    }
+
+    Status = AcpiDsInitAmlWalk (WalkState, AcpiGbl_ParseOpRoot,
+        NULL, AmlStart, AmlLength, NULL, ACPI_IMODE_LOAD_PASS1);
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    WalkState->ParseFlags &= ~ACPI_PARSE_DELETE_TREE;
+    WalkState->ParseFlags |= ACPI_PARSE_DISASSEMBLE;
+
+    Status = AcpiPsParseAml (WalkState);
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    /* If LoadTable is FALSE, we are parsing the last loaded table */
+
+    TableIndex = AcpiGbl_RootTableList.CurrentTableCount - 1;
+
+    /* Pass 2 */
+
+    if (LoadTable)
+    {
+        Status = AdStoreTable (Table, &TableIndex);
+        if (ACPI_FAILURE (Status))
+        {
+            return (Status);
+        }
+        Status = AcpiTbAllocateOwnerId (TableIndex);
+        if (ACPI_FAILURE (Status))
+        {
+            return (Status);
+        }
+        if (OwnerId)
+        {
+            Status = AcpiTbGetOwnerId (TableIndex, OwnerId);
+            if (ACPI_FAILURE (Status))
+            {
+                return (Status);
+            }
+        }
+    }
+
+    fprintf (stderr, "Pass 2 parse of [%4.4s]\n", (char *) Table->Signature);
+
+    Status = AcpiNsOneCompleteParse (ACPI_IMODE_LOAD_PASS2, TableIndex, NULL);
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    /* No need to parse control methods of external table */
+
+    if (External)
+    {
+        return (AE_OK);
+    }
+
+    /*
+     * Pass 3: Parse control methods and link their parse trees
+     * into the main parse tree
+     */
+    fprintf (stderr,
+        "Parsing Deferred Opcodes (Methods/Buffers/Packages/Regions)\n");
+
+    Status = AcpiDmParseDeferredOps (AcpiGbl_ParseOpRoot);
+    fprintf (stderr, "\n");
+
+    /* Process Resource Templates */
+
+    AcpiDmFindResources (AcpiGbl_ParseOpRoot);
+
+    fprintf (stderr, "Parsing completed\n");
+    return (AE_OK);
+}

--- a/sys/src/libacpi/acpica/common/dmtbdump.c
+++ b/sys/src/libacpi/acpica/common/dmtbdump.c
@@ -1,0 +1,3764 @@
+/******************************************************************************
+ *
+ * Module Name: dmtbdump - Dump ACPI data tables that contain no AML code
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+#include "acdisasm.h"
+#include "actables.h"
+
+/* This module used for application-level code only */
+
+#define _COMPONENT          ACPI_CA_DISASSEMBLER
+        ACPI_MODULE_NAME    ("dmtbdump")
+
+
+/* Local prototypes */
+
+static void
+AcpiDmValidateFadtLength (
+    UINT32                  Revision,
+    UINT32                  Length);
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpBuffer
+ *
+ * PARAMETERS:  Table               - ACPI Table or subtable
+ *              BufferOffset        - Offset of buffer from Table above
+ *              Length              - Length of the buffer
+ *              AbsoluteOffset      - Offset of buffer in the main ACPI table
+ *              Header              - Name of the buffer field (printed on the
+ *                                    first line only.)
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of an arbitrary length data buffer (in the
+ *              disassembler output format.)
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpBuffer (
+    void                    *Table,
+    UINT32                  BufferOffset,
+    UINT32                  Length,
+    UINT32                  AbsoluteOffset,
+    char                    *Header)
+{
+    UINT8                   *Buffer;
+    UINT32                  i;
+
+
+    if (!Length)
+    {
+        return;
+    }
+
+    Buffer = ACPI_CAST_PTR (UINT8, Table) + BufferOffset;
+    i = 0;
+
+    while (i < Length)
+    {
+        if (!(i % 16))
+        {
+            /* Insert a backslash - line continuation character */
+
+            if (Length > 16)
+            {
+                AcpiOsPrintf ("\\\n    ");
+            }
+        }
+
+        AcpiOsPrintf ("%.02X ", *Buffer);
+        i++;
+        Buffer++;
+        AbsoluteOffset++;
+    }
+
+    AcpiOsPrintf ("\n");
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpUnicode
+ *
+ * PARAMETERS:  Table               - ACPI Table or subtable
+ *              BufferOffset        - Offset of buffer from Table above
+ *              ByteLength          - Length of the buffer
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Validate and dump the contents of a buffer that contains
+ *              unicode data. The output is a standard ASCII string. If it
+ *              appears that the data is not unicode, the buffer is dumped
+ *              as hex characters.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpUnicode (
+    void                    *Table,
+    UINT32                  BufferOffset,
+    UINT32                  ByteLength)
+{
+    UINT8                   *Buffer;
+    UINT32                  Length;
+    UINT32                  i;
+
+
+    Buffer = ((UINT8 *) Table) + BufferOffset;
+    Length = ByteLength - 2; /* Last two bytes are the null terminator */
+
+    /* Ensure all low bytes are entirely printable ASCII */
+
+    for (i = 0; i < Length; i += 2)
+    {
+        if (!isprint (Buffer[i]))
+        {
+            goto DumpRawBuffer;
+        }
+    }
+
+    /* Ensure all high bytes are zero */
+
+    for (i = 1; i < Length; i += 2)
+    {
+        if (Buffer[i])
+        {
+            goto DumpRawBuffer;
+        }
+    }
+
+    /* Dump the buffer as a normal string */
+
+    AcpiOsPrintf ("\"");
+    for (i = 0; i < Length; i += 2)
+    {
+        AcpiOsPrintf ("%c", Buffer[i]);
+    }
+
+    AcpiOsPrintf ("\"\n");
+    return;
+
+DumpRawBuffer:
+    AcpiDmDumpBuffer (Table, BufferOffset, ByteLength,
+        BufferOffset, NULL);
+    AcpiOsPrintf ("\n");
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpRsdp
+ *
+ * PARAMETERS:  Table               - A RSDP
+ *
+ * RETURN:      Length of the table (there is not always a length field,
+ *              use revision or length if available (ACPI 2.0+))
+ *
+ * DESCRIPTION: Format the contents of a RSDP
+ *
+ ******************************************************************************/
+
+UINT32
+AcpiDmDumpRsdp (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_TABLE_RSDP         *Rsdp = ACPI_CAST_PTR (ACPI_TABLE_RSDP, Table);
+    UINT32                  Length = sizeof (ACPI_RSDP_COMMON);
+    UINT8                   Checksum;
+    ACPI_STATUS             Status;
+
+
+    /* Dump the common ACPI 1.0 portion */
+
+    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoRsdp1);
+    if (ACPI_FAILURE (Status))
+    {
+        return (Length);
+    }
+
+    /* Validate the first checksum */
+
+    Checksum = AcpiDmGenerateChecksum (Rsdp, sizeof (ACPI_RSDP_COMMON),
+        Rsdp->Checksum);
+    if (Checksum != Rsdp->Checksum)
+    {
+        AcpiOsPrintf ("/* Incorrect Checksum above, should be 0x%2.2X */\n",
+            Checksum);
+    }
+
+    /* The RSDP for ACPI 2.0+ contains more data and has a Length field */
+
+    if (Rsdp->Revision > 0)
+    {
+        Length = Rsdp->Length;
+        Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoRsdp2);
+        if (ACPI_FAILURE (Status))
+        {
+            return (Length);
+        }
+
+        /* Validate the extended checksum over entire RSDP */
+
+        Checksum = AcpiDmGenerateChecksum (Rsdp, sizeof (ACPI_TABLE_RSDP),
+            Rsdp->ExtendedChecksum);
+        if (Checksum != Rsdp->ExtendedChecksum)
+        {
+            AcpiOsPrintf (
+                "/* Incorrect Extended Checksum above, should be 0x%2.2X */\n",
+                Checksum);
+        }
+    }
+
+    return (Length);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpRsdt
+ *
+ * PARAMETERS:  Table               - A RSDT
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a RSDT
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpRsdt (
+    ACPI_TABLE_HEADER       *Table)
+{
+    UINT32                  *Array;
+    UINT32                  Entries;
+    UINT32                  Offset;
+    UINT32                  i;
+
+
+    /* Point to start of table pointer array */
+
+    Array = ACPI_CAST_PTR (ACPI_TABLE_RSDT, Table)->TableOffsetEntry;
+    Offset = sizeof (ACPI_TABLE_HEADER);
+
+    /* RSDT uses 32-bit pointers */
+
+    Entries = (Table->Length - sizeof (ACPI_TABLE_HEADER)) / sizeof (UINT32);
+
+    for (i = 0; i < Entries; i++)
+    {
+        AcpiDmLineHeader2 (Offset, sizeof (UINT32), "ACPI Table Address", i);
+        AcpiOsPrintf ("%8.8X\n", Array[i]);
+        Offset += sizeof (UINT32);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpXsdt
+ *
+ * PARAMETERS:  Table               - A XSDT
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a XSDT
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpXsdt (
+    ACPI_TABLE_HEADER       *Table)
+{
+    UINT64                  *Array;
+    UINT32                  Entries;
+    UINT32                  Offset;
+    UINT32                  i;
+
+
+    /* Point to start of table pointer array */
+
+    Array = ACPI_CAST_PTR (ACPI_TABLE_XSDT, Table)->TableOffsetEntry;
+    Offset = sizeof (ACPI_TABLE_HEADER);
+
+    /* XSDT uses 64-bit pointers */
+
+    Entries = (Table->Length - sizeof (ACPI_TABLE_HEADER)) / sizeof (UINT64);
+
+    for (i = 0; i < Entries; i++)
+    {
+        AcpiDmLineHeader2 (Offset, sizeof (UINT64), "ACPI Table Address", i);
+        AcpiOsPrintf ("%8.8X%8.8X\n", ACPI_FORMAT_UINT64 (Array[i]));
+        Offset += sizeof (UINT64);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpFadt
+ *
+ * PARAMETERS:  Table               - A FADT
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a FADT
+ *
+ * NOTE:        We cannot depend on the FADT version to indicate the actual
+ *              contents of the FADT because of BIOS bugs. The table length
+ *              is the only reliable indicator.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpFadt (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+
+
+    /* Always dump the minimum FADT revision 1 fields (ACPI 1.0) */
+
+    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0,
+        AcpiDmTableInfoFadt1);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Check for FADT revision 2 fields (ACPI 1.0B MS extensions) */
+
+    if ((Table->Length > ACPI_FADT_V1_SIZE) &&
+        (Table->Length <= ACPI_FADT_V2_SIZE))
+    {
+        Status = AcpiDmDumpTable (Table->Length, 0, Table, 0,
+            AcpiDmTableInfoFadt2);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+    }
+
+    /* Check for FADT revision 3/4 fields and up (ACPI 2.0+ extended data) */
+
+    else if (Table->Length > ACPI_FADT_V2_SIZE)
+    {
+        Status = AcpiDmDumpTable (Table->Length, 0, Table, 0,
+            AcpiDmTableInfoFadt3);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Check for FADT revision 5 fields and up (ACPI 5.0+) */
+
+        if (Table->Length > ACPI_FADT_V3_SIZE)
+        {
+            Status = AcpiDmDumpTable (Table->Length, 0, Table, 0,
+                AcpiDmTableInfoFadt5);
+            if (ACPI_FAILURE (Status))
+            {
+                return;
+            }
+        }
+
+        /* Check for FADT revision 6 fields and up (ACPI 6.0+) */
+
+        if (Table->Length > ACPI_FADT_V3_SIZE)
+        {
+            Status = AcpiDmDumpTable (Table->Length, 0, Table, 0,
+                AcpiDmTableInfoFadt6);
+            if (ACPI_FAILURE (Status))
+            {
+                return;
+            }
+        }
+    }
+
+    /* Validate various fields in the FADT, including length */
+
+    AcpiTbCreateLocalFadt (Table, Table->Length);
+
+    /* Validate FADT length against the revision */
+
+    AcpiDmValidateFadtLength (Table->Revision, Table->Length);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmValidateFadtLength
+ *
+ * PARAMETERS:  Revision            - FADT revision (Header->Revision)
+ *              Length              - FADT length (Header->Length
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Check the FADT revision against the expected table length for
+ *              that revision. Issue a warning if the length is not what was
+ *              expected. This seems to be such a common BIOS bug that the
+ *              FADT revision has been rendered virtually meaningless.
+ *
+ ******************************************************************************/
+
+static void
+AcpiDmValidateFadtLength (
+    UINT32                  Revision,
+    UINT32                  Length)
+{
+    UINT32                  ExpectedLength;
+
+
+    switch (Revision)
+    {
+    case 0:
+
+        AcpiOsPrintf ("// ACPI Warning: Invalid FADT revision: 0\n");
+        return;
+
+    case 1:
+
+        ExpectedLength = ACPI_FADT_V1_SIZE;
+        break;
+
+    case 2:
+
+        ExpectedLength = ACPI_FADT_V2_SIZE;
+        break;
+
+    case 3:
+    case 4:
+
+        ExpectedLength = ACPI_FADT_V3_SIZE;
+        break;
+
+    case 5:
+
+        ExpectedLength = ACPI_FADT_V5_SIZE;
+        break;
+
+    default:
+
+        return;
+    }
+
+    if (Length == ExpectedLength)
+    {
+        return;
+    }
+
+    AcpiOsPrintf (
+        "\n// ACPI Warning: FADT revision %X does not match length: "
+        "found %X expected %X\n",
+        Revision, Length, ExpectedLength);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpAsf
+ *
+ * PARAMETERS:  Table               - A ASF table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a ASF table
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpAsf (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    UINT32                  Offset = sizeof (ACPI_TABLE_HEADER);
+    ACPI_ASF_INFO           *SubTable;
+    ACPI_DMTABLE_INFO       *InfoTable;
+    ACPI_DMTABLE_INFO       *DataInfoTable = NULL;
+    UINT8                   *DataTable = NULL;
+    UINT32                  DataCount = 0;
+    UINT32                  DataLength = 0;
+    UINT32                  DataOffset = 0;
+    UINT32                  i;
+    UINT8                   Type;
+
+
+    /* No main table, only subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_ASF_INFO, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        /* Common subtable header */
+
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable,
+            SubTable->Header.Length, AcpiDmTableInfoAsfHdr);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* The actual type is the lower 7 bits of Type */
+
+        Type = (UINT8) (SubTable->Header.Type & 0x7F);
+
+        switch (Type)
+        {
+        case ACPI_ASF_TYPE_INFO:
+
+            InfoTable = AcpiDmTableInfoAsf0;
+            break;
+
+        case ACPI_ASF_TYPE_ALERT:
+
+            InfoTable = AcpiDmTableInfoAsf1;
+            DataInfoTable = AcpiDmTableInfoAsf1a;
+            DataTable = ACPI_ADD_PTR (UINT8, SubTable, sizeof (ACPI_ASF_ALERT));
+            DataCount = ACPI_CAST_PTR (ACPI_ASF_ALERT, SubTable)->Alerts;
+            DataLength = ACPI_CAST_PTR (ACPI_ASF_ALERT, SubTable)->DataLength;
+            DataOffset = Offset + sizeof (ACPI_ASF_ALERT);
+            break;
+
+        case ACPI_ASF_TYPE_CONTROL:
+
+            InfoTable = AcpiDmTableInfoAsf2;
+            DataInfoTable = AcpiDmTableInfoAsf2a;
+            DataTable = ACPI_ADD_PTR (UINT8, SubTable, sizeof (ACPI_ASF_REMOTE));
+            DataCount = ACPI_CAST_PTR (ACPI_ASF_REMOTE, SubTable)->Controls;
+            DataLength = ACPI_CAST_PTR (ACPI_ASF_REMOTE, SubTable)->DataLength;
+            DataOffset = Offset + sizeof (ACPI_ASF_REMOTE);
+            break;
+
+        case ACPI_ASF_TYPE_BOOT:
+
+            InfoTable = AcpiDmTableInfoAsf3;
+            break;
+
+        case ACPI_ASF_TYPE_ADDRESS:
+
+            InfoTable = AcpiDmTableInfoAsf4;
+            DataTable = ACPI_ADD_PTR (UINT8, SubTable, sizeof (ACPI_ASF_ADDRESS));
+            DataLength = ACPI_CAST_PTR (ACPI_ASF_ADDRESS, SubTable)->Devices;
+            DataOffset = Offset + sizeof (ACPI_ASF_ADDRESS);
+            break;
+
+        default:
+
+            AcpiOsPrintf ("\n**** Unknown ASF subtable type 0x%X\n",
+                SubTable->Header.Type);
+            return;
+        }
+
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable,
+            SubTable->Header.Length, InfoTable);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Dump variable-length extra data */
+
+        switch (Type)
+        {
+        case ACPI_ASF_TYPE_ALERT:
+        case ACPI_ASF_TYPE_CONTROL:
+
+            for (i = 0; i < DataCount; i++)
+            {
+                AcpiOsPrintf ("\n");
+                Status = AcpiDmDumpTable (Table->Length, DataOffset,
+                    DataTable, DataLength, DataInfoTable);
+                if (ACPI_FAILURE (Status))
+                {
+                    return;
+                }
+
+                DataTable = ACPI_ADD_PTR (UINT8, DataTable, DataLength);
+                DataOffset += DataLength;
+            }
+            break;
+
+        case ACPI_ASF_TYPE_ADDRESS:
+
+            for (i = 0; i < DataLength; i++)
+            {
+                if (!(i % 16))
+                {
+                    AcpiDmLineHeader (DataOffset, 1, "Addresses");
+                }
+
+                AcpiOsPrintf ("%2.2X ", *DataTable);
+                DataTable++;
+                DataOffset++;
+
+                if (DataOffset > Table->Length)
+                {
+                    AcpiOsPrintf (
+                        "**** ACPI table terminates in the middle of a "
+                        "data structure! (ASF! table)\n");
+                    return;
+                }
+            }
+
+            AcpiOsPrintf ("\n");
+            break;
+
+        default:
+
+            break;
+        }
+
+        AcpiOsPrintf ("\n");
+
+        /* Point to next subtable */
+
+        if (!SubTable->Header.Length)
+        {
+            AcpiOsPrintf ("Invalid zero subtable header length\n");
+            return;
+        }
+
+        Offset += SubTable->Header.Length;
+        SubTable = ACPI_ADD_PTR (ACPI_ASF_INFO, SubTable,
+            SubTable->Header.Length);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpCpep
+ *
+ * PARAMETERS:  Table               - A CPEP table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a CPEP. This table type consists
+ *              of an open-ended number of subtables.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpCpep (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    ACPI_CPEP_POLLING       *SubTable;
+    UINT32                  Length = Table->Length;
+    UINT32                  Offset = sizeof (ACPI_TABLE_CPEP);
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoCpep);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_CPEP_POLLING, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTable->Header.Length, AcpiDmTableInfoCpep0);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Point to next subtable */
+
+        Offset += SubTable->Header.Length;
+        SubTable = ACPI_ADD_PTR (ACPI_CPEP_POLLING, SubTable,
+            SubTable->Header.Length);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpCsrt
+ *
+ * PARAMETERS:  Table               - A CSRT table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a CSRT. This table type consists
+ *              of an open-ended number of subtables.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpCsrt (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    ACPI_CSRT_GROUP         *SubTable;
+    ACPI_CSRT_SHARED_INFO   *SharedInfoTable;
+    ACPI_CSRT_DESCRIPTOR    *SubSubTable;
+    UINT32                  Length = Table->Length;
+    UINT32                  Offset = sizeof (ACPI_TABLE_CSRT);
+    UINT32                  SubOffset;
+    UINT32                  SubSubOffset;
+    UINT32                  InfoLength;
+
+
+    /* The main table only contains the ACPI header, thus already handled */
+
+    /* Subtables (Resource Groups) */
+
+    SubTable = ACPI_ADD_PTR (ACPI_CSRT_GROUP, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        /* Resource group subtable */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTable->Length, AcpiDmTableInfoCsrt0);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Shared info subtable (One per resource group) */
+
+        SubOffset = sizeof (ACPI_CSRT_GROUP);
+        SharedInfoTable = ACPI_ADD_PTR (ACPI_CSRT_SHARED_INFO, Table,
+            Offset + SubOffset);
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Length, Offset + SubOffset, SharedInfoTable,
+            sizeof (ACPI_CSRT_SHARED_INFO), AcpiDmTableInfoCsrt1);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        SubOffset += SubTable->SharedInfoLength;
+
+        /* Sub-Subtables (Resource Descriptors) */
+
+        SubSubTable = ACPI_ADD_PTR (ACPI_CSRT_DESCRIPTOR, Table,
+            Offset + SubOffset);
+
+        while ((SubOffset < SubTable->Length) &&
+              ((Offset + SubOffset) < Table->Length))
+        {
+            AcpiOsPrintf ("\n");
+            Status = AcpiDmDumpTable (Length, Offset + SubOffset, SubSubTable,
+                SubSubTable->Length, AcpiDmTableInfoCsrt2);
+            if (ACPI_FAILURE (Status))
+            {
+                return;
+            }
+
+            SubSubOffset = sizeof (ACPI_CSRT_DESCRIPTOR);
+
+            /* Resource-specific info buffer */
+
+            InfoLength = SubSubTable->Length - SubSubOffset;
+            if (InfoLength)
+            {
+                Status = AcpiDmDumpTable (Length,
+                    Offset + SubOffset + SubSubOffset, Table,
+                    InfoLength, AcpiDmTableInfoCsrt2a);
+                if (ACPI_FAILURE (Status))
+                {
+                    return;
+                }
+                SubSubOffset += InfoLength;
+            }
+
+            /* Point to next sub-subtable */
+
+            SubOffset += SubSubTable->Length;
+            SubSubTable = ACPI_ADD_PTR (ACPI_CSRT_DESCRIPTOR, SubSubTable,
+                SubSubTable->Length);
+        }
+
+        /* Point to next subtable */
+
+        Offset += SubTable->Length;
+        SubTable = ACPI_ADD_PTR (ACPI_CSRT_GROUP, SubTable,
+            SubTable->Length);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpDbg2
+ *
+ * PARAMETERS:  Table               - A DBG2 table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a DBG2. This table type consists
+ *              of an open-ended number of subtables.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpDbg2 (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    ACPI_DBG2_DEVICE        *SubTable;
+    UINT32                  Length = Table->Length;
+    UINT32                  Offset = sizeof (ACPI_TABLE_DBG2);
+    UINT32                  i;
+    UINT32                  ArrayOffset;
+    UINT32                  AbsoluteOffset;
+    UINT8                   *Array;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoDbg2);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_DBG2_DEVICE, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTable->Length, AcpiDmTableInfoDbg2Device);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Dump the BaseAddress array */
+
+        for (i = 0; i < SubTable->RegisterCount; i++)
+        {
+            ArrayOffset = SubTable->BaseAddressOffset +
+                (sizeof (ACPI_GENERIC_ADDRESS) * i);
+            AbsoluteOffset = Offset + ArrayOffset;
+            Array = (UINT8 *) SubTable + ArrayOffset;
+
+            Status = AcpiDmDumpTable (Length, AbsoluteOffset, Array,
+                SubTable->Length, AcpiDmTableInfoDbg2Addr);
+            if (ACPI_FAILURE (Status))
+            {
+                return;
+            }
+        }
+
+        /* Dump the AddressSize array */
+
+        for (i = 0; i < SubTable->RegisterCount; i++)
+        {
+            ArrayOffset = SubTable->AddressSizeOffset +
+                (sizeof (UINT32) * i);
+            AbsoluteOffset = Offset + ArrayOffset;
+            Array = (UINT8 *) SubTable + ArrayOffset;
+
+            Status = AcpiDmDumpTable (Length, AbsoluteOffset, Array,
+                SubTable->Length, AcpiDmTableInfoDbg2Size);
+            if (ACPI_FAILURE (Status))
+            {
+                return;
+            }
+        }
+
+        /* Dump the Namestring (required) */
+
+        AcpiOsPrintf ("\n");
+        ArrayOffset = SubTable->NamepathOffset;
+        AbsoluteOffset = Offset + ArrayOffset;
+        Array = (UINT8 *) SubTable + ArrayOffset;
+
+        Status = AcpiDmDumpTable (Length, AbsoluteOffset, Array,
+            SubTable->Length, AcpiDmTableInfoDbg2Name);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Dump the OemData (optional) */
+
+        if (SubTable->OemDataOffset)
+        {
+            Status = AcpiDmDumpTable (Length, Offset + SubTable->OemDataOffset,
+                Table, SubTable->OemDataLength,
+                AcpiDmTableInfoDbg2OemData);
+            if (ACPI_FAILURE (Status))
+            {
+                return;
+            }
+        }
+
+        /* Point to next subtable */
+
+        Offset += SubTable->Length;
+        SubTable = ACPI_ADD_PTR (ACPI_DBG2_DEVICE, SubTable,
+            SubTable->Length);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpDmar
+ *
+ * PARAMETERS:  Table               - A DMAR table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a DMAR. This table type consists
+ *              of an open-ended number of subtables.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpDmar (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    ACPI_DMAR_HEADER        *SubTable;
+    UINT32                  Length = Table->Length;
+    UINT32                  Offset = sizeof (ACPI_TABLE_DMAR);
+    ACPI_DMTABLE_INFO       *InfoTable;
+    ACPI_DMAR_DEVICE_SCOPE  *ScopeTable;
+    UINT32                  ScopeOffset;
+    UINT8                   *PciPath;
+    UINT32                  PathOffset;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoDmar);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_DMAR_HEADER, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        /* Common subtable header */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTable->Length, AcpiDmTableInfoDmarHdr);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        AcpiOsPrintf ("\n");
+
+        switch (SubTable->Type)
+        {
+        case ACPI_DMAR_TYPE_HARDWARE_UNIT:
+
+            InfoTable = AcpiDmTableInfoDmar0;
+            ScopeOffset = sizeof (ACPI_DMAR_HARDWARE_UNIT);
+            break;
+
+        case ACPI_DMAR_TYPE_RESERVED_MEMORY:
+
+            InfoTable = AcpiDmTableInfoDmar1;
+            ScopeOffset = sizeof (ACPI_DMAR_RESERVED_MEMORY);
+            break;
+
+        case ACPI_DMAR_TYPE_ROOT_ATS:
+
+            InfoTable = AcpiDmTableInfoDmar2;
+            ScopeOffset = sizeof (ACPI_DMAR_ATSR);
+            break;
+
+        case ACPI_DMAR_TYPE_HARDWARE_AFFINITY:
+
+            InfoTable = AcpiDmTableInfoDmar3;
+            ScopeOffset = sizeof (ACPI_DMAR_RHSA);
+            break;
+
+        case ACPI_DMAR_TYPE_NAMESPACE:
+
+            InfoTable = AcpiDmTableInfoDmar4;
+            ScopeOffset = sizeof (ACPI_DMAR_ANDD);
+            break;
+
+        default:
+
+            AcpiOsPrintf ("\n**** Unknown DMAR subtable type 0x%X\n\n",
+                SubTable->Type);
+            return;
+        }
+
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTable->Length, InfoTable);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /*
+         * Dump the optional device scope entries
+         */
+        if ((SubTable->Type == ACPI_DMAR_TYPE_HARDWARE_AFFINITY) ||
+            (SubTable->Type == ACPI_DMAR_TYPE_NAMESPACE))
+        {
+            /* These types do not support device scopes */
+
+            goto NextSubtable;
+        }
+
+        ScopeTable = ACPI_ADD_PTR (ACPI_DMAR_DEVICE_SCOPE, SubTable, ScopeOffset);
+        while (ScopeOffset < SubTable->Length)
+        {
+            AcpiOsPrintf ("\n");
+            Status = AcpiDmDumpTable (Length, Offset + ScopeOffset, ScopeTable,
+                ScopeTable->Length, AcpiDmTableInfoDmarScope);
+            if (ACPI_FAILURE (Status))
+            {
+                return;
+            }
+            AcpiOsPrintf ("\n");
+
+            /* Dump the PCI Path entries for this device scope */
+
+            PathOffset = sizeof (ACPI_DMAR_DEVICE_SCOPE); /* Path entries start at this offset */
+
+            PciPath = ACPI_ADD_PTR (UINT8, ScopeTable,
+                sizeof (ACPI_DMAR_DEVICE_SCOPE));
+
+            while (PathOffset < ScopeTable->Length)
+            {
+                AcpiDmLineHeader ((PathOffset + ScopeOffset + Offset), 2,
+                    "PCI Path");
+                AcpiOsPrintf ("%2.2X,%2.2X\n", PciPath[0], PciPath[1]);
+
+                /* Point to next PCI Path entry */
+
+                PathOffset += 2;
+                PciPath += 2;
+                AcpiOsPrintf ("\n");
+            }
+
+            /* Point to next device scope entry */
+
+            ScopeOffset += ScopeTable->Length;
+            ScopeTable = ACPI_ADD_PTR (ACPI_DMAR_DEVICE_SCOPE,
+                ScopeTable, ScopeTable->Length);
+        }
+
+NextSubtable:
+        /* Point to next subtable */
+
+        Offset += SubTable->Length;
+        SubTable = ACPI_ADD_PTR (ACPI_DMAR_HEADER, SubTable,
+            SubTable->Length);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpDrtm
+ *
+ * PARAMETERS:  Table               - A DRTM table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a DRTM.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpDrtm (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    UINT32                  Offset;
+    ACPI_DRTM_VTABLE_LIST   *DrtmVtl;
+    ACPI_DRTM_RESOURCE_LIST *DrtmRl;
+    ACPI_DRTM_DPS_ID        *DrtmDps;
+    UINT32                  Count;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0,
+        AcpiDmTableInfoDrtm);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    Offset = sizeof (ACPI_TABLE_DRTM);
+
+    /* Sub-tables */
+
+    /* Dump ValidatedTable length */
+
+    DrtmVtl = ACPI_ADD_PTR (ACPI_DRTM_VTABLE_LIST, Table, Offset);
+    AcpiOsPrintf ("\n");
+    Status = AcpiDmDumpTable (Table->Length, Offset,
+        DrtmVtl, ACPI_OFFSET (ACPI_DRTM_VTABLE_LIST, ValidatedTables),
+        AcpiDmTableInfoDrtm0);
+    if (ACPI_FAILURE (Status))
+    {
+            return;
+    }
+
+    Offset += ACPI_OFFSET (ACPI_DRTM_VTABLE_LIST, ValidatedTables);
+
+    /* Dump Validated table addresses */
+
+    Count = 0;
+    while ((Offset < Table->Length) &&
+            (DrtmVtl->ValidatedTableCount > Count))
+    {
+        Status = AcpiDmDumpTable (Table->Length, Offset,
+            ACPI_ADD_PTR (void, Table, Offset), sizeof (UINT64),
+            AcpiDmTableInfoDrtm0a);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        Offset += sizeof (UINT64);
+        Count++;
+    }
+
+    /* Dump ResourceList length */
+
+    DrtmRl = ACPI_ADD_PTR (ACPI_DRTM_RESOURCE_LIST, Table, Offset);
+    AcpiOsPrintf ("\n");
+    Status = AcpiDmDumpTable (Table->Length, Offset,
+        DrtmRl, ACPI_OFFSET (ACPI_DRTM_RESOURCE_LIST, Resources),
+        AcpiDmTableInfoDrtm1);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    Offset += ACPI_OFFSET (ACPI_DRTM_RESOURCE_LIST, Resources);
+
+    /* Dump the Resource List */
+
+    Count = 0;
+    while ((Offset < Table->Length) &&
+           (DrtmRl->ResourceCount > Count))
+    {
+        Status = AcpiDmDumpTable (Table->Length, Offset,
+            ACPI_ADD_PTR (void, Table, Offset),
+            sizeof (ACPI_DRTM_RESOURCE), AcpiDmTableInfoDrtm1a);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        Offset += sizeof (ACPI_DRTM_RESOURCE);
+        Count++;
+    }
+
+    /* Dump DPS */
+
+    DrtmDps = ACPI_ADD_PTR (ACPI_DRTM_DPS_ID, Table, Offset);
+    AcpiOsPrintf ("\n");
+    (void) AcpiDmDumpTable (Table->Length, Offset,
+        DrtmDps, sizeof (ACPI_DRTM_DPS_ID), AcpiDmTableInfoDrtm2);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpEinj
+ *
+ * PARAMETERS:  Table               - A EINJ table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a EINJ. This table type consists
+ *              of an open-ended number of subtables.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpEinj (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    ACPI_WHEA_HEADER        *SubTable;
+    UINT32                  Length = Table->Length;
+    UINT32                  Offset = sizeof (ACPI_TABLE_EINJ);
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoEinj);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_WHEA_HEADER, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            sizeof (ACPI_WHEA_HEADER), AcpiDmTableInfoEinj0);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Point to next subtable (each subtable is of fixed length) */
+
+        Offset += sizeof (ACPI_WHEA_HEADER);
+        SubTable = ACPI_ADD_PTR (ACPI_WHEA_HEADER, SubTable,
+            sizeof (ACPI_WHEA_HEADER));
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpErst
+ *
+ * PARAMETERS:  Table               - A ERST table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a ERST. This table type consists
+ *              of an open-ended number of subtables.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpErst (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    ACPI_WHEA_HEADER        *SubTable;
+    UINT32                  Length = Table->Length;
+    UINT32                  Offset = sizeof (ACPI_TABLE_ERST);
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoErst);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_WHEA_HEADER, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            sizeof (ACPI_WHEA_HEADER), AcpiDmTableInfoErst0);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Point to next subtable (each subtable is of fixed length) */
+
+        Offset += sizeof (ACPI_WHEA_HEADER);
+        SubTable = ACPI_ADD_PTR (ACPI_WHEA_HEADER, SubTable,
+            sizeof (ACPI_WHEA_HEADER));
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpFpdt
+ *
+ * PARAMETERS:  Table               - A FPDT table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a FPDT. This table type consists
+ *              of an open-ended number of subtables.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpFpdt (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    ACPI_FPDT_HEADER        *SubTable;
+    UINT32                  Length = Table->Length;
+    UINT32                  Offset = sizeof (ACPI_TABLE_FPDT);
+    ACPI_DMTABLE_INFO       *InfoTable;
+
+
+    /* There is no main table (other than the standard ACPI header) */
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_FPDT_HEADER, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        /* Common subtable header */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTable->Length, AcpiDmTableInfoFpdtHdr);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        switch (SubTable->Type)
+        {
+        case ACPI_FPDT_TYPE_BOOT:
+
+            InfoTable = AcpiDmTableInfoFpdt0;
+            break;
+
+        case ACPI_FPDT_TYPE_S3PERF:
+
+            InfoTable = AcpiDmTableInfoFpdt1;
+            break;
+
+        default:
+
+            AcpiOsPrintf ("\n**** Unknown FPDT subtable type 0x%X\n\n",
+                SubTable->Type);
+
+            /* Attempt to continue */
+
+            if (!SubTable->Length)
+            {
+                AcpiOsPrintf ("Invalid zero length subtable\n");
+                return;
+            }
+            goto NextSubTable;
+        }
+
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTable->Length, InfoTable);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+NextSubTable:
+        /* Point to next subtable */
+
+        Offset += SubTable->Length;
+        SubTable = ACPI_ADD_PTR (ACPI_FPDT_HEADER, SubTable,
+            SubTable->Length);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpGtdt
+ *
+ * PARAMETERS:  Table               - A GTDT table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a GTDT. This table type consists
+ *              of an open-ended number of subtables.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpGtdt (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    ACPI_GTDT_HEADER        *SubTable;
+    UINT32                  Length = Table->Length;
+    UINT32                  Offset = sizeof (ACPI_TABLE_GTDT);
+    ACPI_DMTABLE_INFO       *InfoTable;
+    UINT32                  SubTableLength;
+    UINT32                  GtCount;
+    ACPI_GTDT_TIMER_ENTRY   *GtxTable;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoGtdt);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_GTDT_HEADER, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        /* Common subtable header */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTable->Length, AcpiDmTableInfoGtdtHdr);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        GtCount = 0;
+        switch (SubTable->Type)
+        {
+        case ACPI_GTDT_TYPE_TIMER_BLOCK:
+
+            SubTableLength = sizeof (ACPI_GTDT_TIMER_BLOCK);
+            GtCount = (ACPI_CAST_PTR (ACPI_GTDT_TIMER_BLOCK,
+                SubTable))->TimerCount;
+
+            InfoTable = AcpiDmTableInfoGtdt0;
+            break;
+
+        case ACPI_GTDT_TYPE_WATCHDOG:
+
+            SubTableLength = sizeof (ACPI_GTDT_WATCHDOG);
+
+            InfoTable = AcpiDmTableInfoGtdt1;
+            break;
+
+        default:
+
+            /* Cannot continue on unknown type - no length */
+
+            AcpiOsPrintf ("\n**** Unknown GTDT subtable type 0x%X\n",
+                SubTable->Type);
+            return;
+        }
+
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTable->Length, InfoTable);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Point to end of current subtable (each subtable above is of fixed length) */
+
+        Offset += SubTableLength;
+
+        /* If there are any Gt Timer Blocks from above, dump them now */
+
+        if (GtCount)
+        {
+            GtxTable = ACPI_ADD_PTR (
+                ACPI_GTDT_TIMER_ENTRY, SubTable, SubTableLength);
+            SubTableLength += GtCount * sizeof (ACPI_GTDT_TIMER_ENTRY);
+
+            while (GtCount)
+            {
+                AcpiOsPrintf ("\n");
+                Status = AcpiDmDumpTable (Length, Offset, GtxTable,
+                    sizeof (ACPI_GTDT_TIMER_ENTRY), AcpiDmTableInfoGtdt0a);
+                if (ACPI_FAILURE (Status))
+                {
+                    return;
+                }
+                Offset += sizeof (ACPI_GTDT_TIMER_ENTRY);
+                GtxTable++;
+                GtCount--;
+            }
+        }
+
+        /* Point to next subtable */
+
+        SubTable = ACPI_ADD_PTR (ACPI_GTDT_HEADER, SubTable, SubTableLength);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpHest
+ *
+ * PARAMETERS:  Table               - A HEST table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a HEST. This table type consists
+ *              of an open-ended number of subtables.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpHest (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    ACPI_HEST_HEADER        *SubTable;
+    UINT32                  Length = Table->Length;
+    UINT32                  Offset = sizeof (ACPI_TABLE_HEST);
+    ACPI_DMTABLE_INFO       *InfoTable;
+    UINT32                  SubTableLength;
+    UINT32                  BankCount;
+    ACPI_HEST_IA_ERROR_BANK *BankTable;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoHest);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_HEST_HEADER, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        BankCount = 0;
+        switch (SubTable->Type)
+        {
+        case ACPI_HEST_TYPE_IA32_CHECK:
+
+            InfoTable = AcpiDmTableInfoHest0;
+            SubTableLength = sizeof (ACPI_HEST_IA_MACHINE_CHECK);
+            BankCount = (ACPI_CAST_PTR (ACPI_HEST_IA_MACHINE_CHECK,
+                SubTable))->NumHardwareBanks;
+            break;
+
+        case ACPI_HEST_TYPE_IA32_CORRECTED_CHECK:
+
+            InfoTable = AcpiDmTableInfoHest1;
+            SubTableLength = sizeof (ACPI_HEST_IA_CORRECTED);
+            BankCount = (ACPI_CAST_PTR (ACPI_HEST_IA_CORRECTED,
+                SubTable))->NumHardwareBanks;
+            break;
+
+        case ACPI_HEST_TYPE_IA32_NMI:
+
+            InfoTable = AcpiDmTableInfoHest2;
+            SubTableLength = sizeof (ACPI_HEST_IA_NMI);
+            break;
+
+        case ACPI_HEST_TYPE_AER_ROOT_PORT:
+
+            InfoTable = AcpiDmTableInfoHest6;
+            SubTableLength = sizeof (ACPI_HEST_AER_ROOT);
+            break;
+
+        case ACPI_HEST_TYPE_AER_ENDPOINT:
+
+            InfoTable = AcpiDmTableInfoHest7;
+            SubTableLength = sizeof (ACPI_HEST_AER);
+            break;
+
+        case ACPI_HEST_TYPE_AER_BRIDGE:
+
+            InfoTable = AcpiDmTableInfoHest8;
+            SubTableLength = sizeof (ACPI_HEST_AER_BRIDGE);
+            break;
+
+        case ACPI_HEST_TYPE_GENERIC_ERROR:
+
+            InfoTable = AcpiDmTableInfoHest9;
+            SubTableLength = sizeof (ACPI_HEST_GENERIC);
+            break;
+
+        case ACPI_HEST_TYPE_GENERIC_ERROR_V2:
+
+            InfoTable = AcpiDmTableInfoHest10;
+            SubTableLength = sizeof (ACPI_HEST_GENERIC_V2);
+            break;
+
+        default:
+
+            /* Cannot continue on unknown type - no length */
+
+            AcpiOsPrintf ("\n**** Unknown HEST subtable type 0x%X\n",
+                SubTable->Type);
+            return;
+        }
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTableLength, InfoTable);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Point to end of current subtable (each subtable above is of fixed length) */
+
+        Offset += SubTableLength;
+
+        /* If there are any (fixed-length) Error Banks from above, dump them now */
+
+        if (BankCount)
+        {
+            BankTable = ACPI_ADD_PTR (ACPI_HEST_IA_ERROR_BANK, SubTable,
+                SubTableLength);
+            SubTableLength += BankCount * sizeof (ACPI_HEST_IA_ERROR_BANK);
+
+            while (BankCount)
+            {
+                AcpiOsPrintf ("\n");
+                Status = AcpiDmDumpTable (Length, Offset, BankTable,
+                    sizeof (ACPI_HEST_IA_ERROR_BANK), AcpiDmTableInfoHestBank);
+                if (ACPI_FAILURE (Status))
+                {
+                    return;
+                }
+
+                Offset += sizeof (ACPI_HEST_IA_ERROR_BANK);
+                BankTable++;
+                BankCount--;
+            }
+        }
+
+        /* Point to next subtable */
+
+        SubTable = ACPI_ADD_PTR (ACPI_HEST_HEADER, SubTable, SubTableLength);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpIort
+ *
+ * PARAMETERS:  Table               - A IORT table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a IORT
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpIort (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    ACPI_TABLE_IORT         *Iort;
+    ACPI_IORT_NODE          *IortNode;
+    ACPI_IORT_ITS_GROUP     *IortItsGroup = NULL;
+    ACPI_IORT_SMMU          *IortSmmu = NULL;
+    UINT32                  Offset;
+    UINT32                  NodeOffset;
+    UINT32                  Length;
+    ACPI_DMTABLE_INFO       *InfoTable;
+    char                    *String;
+    UINT32                  i;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoIort);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    Iort = ACPI_CAST_PTR (ACPI_TABLE_IORT, Table);
+    Offset = sizeof (ACPI_TABLE_IORT);
+
+    /* Dump the OptionalPadding (optional) */
+
+    if (Iort->NodeOffset > Offset)
+    {
+        Status = AcpiDmDumpTable (Table->Length, Offset, Table,
+            Iort->NodeOffset - Offset, AcpiDmTableInfoIortPad);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+    }
+
+    Offset = Iort->NodeOffset;
+    while (Offset < Table->Length)
+    {
+        /* Common subtable header */
+
+        IortNode = ACPI_ADD_PTR (ACPI_IORT_NODE, Table, Offset);
+        AcpiOsPrintf ("\n");
+        Length = ACPI_OFFSET (ACPI_IORT_NODE, NodeData);
+        Status = AcpiDmDumpTable (Table->Length, Offset,
+            IortNode, Length, AcpiDmTableInfoIortHdr);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        NodeOffset = Length;
+
+        switch (IortNode->Type)
+        {
+        case ACPI_IORT_NODE_ITS_GROUP:
+
+            InfoTable = AcpiDmTableInfoIort0;
+            Length = ACPI_OFFSET (ACPI_IORT_ITS_GROUP, Identifiers);
+            IortItsGroup = ACPI_ADD_PTR (ACPI_IORT_ITS_GROUP, IortNode, NodeOffset);
+            break;
+
+        case ACPI_IORT_NODE_NAMED_COMPONENT:
+
+            InfoTable = AcpiDmTableInfoIort1;
+            Length = ACPI_OFFSET (ACPI_IORT_NAMED_COMPONENT, DeviceName);
+            String = ACPI_ADD_PTR (char, IortNode, NodeOffset + Length);
+            Length += strlen (String) + 1;
+            break;
+
+        case ACPI_IORT_NODE_PCI_ROOT_COMPLEX:
+
+            InfoTable = AcpiDmTableInfoIort2;
+            Length = IortNode->Length - NodeOffset;
+            break;
+
+        case ACPI_IORT_NODE_SMMU:
+
+            InfoTable = AcpiDmTableInfoIort3;
+            Length = ACPI_OFFSET (ACPI_IORT_SMMU, Interrupts);
+            IortSmmu = ACPI_ADD_PTR (ACPI_IORT_SMMU, IortNode, NodeOffset);
+            break;
+
+        case ACPI_IORT_NODE_SMMU_V3:
+
+            InfoTable = AcpiDmTableInfoIort4;
+            Length = IortNode->Length - NodeOffset;
+            break;
+
+        default:
+
+            AcpiOsPrintf ("\n**** Unknown IORT node type 0x%X\n",
+                IortNode->Type);
+
+            /* Attempt to continue */
+
+            if (!IortNode->Length)
+            {
+                AcpiOsPrintf ("Invalid zero length IORT node\n");
+                return;
+            }
+            goto NextSubTable;
+        }
+
+        /* Dump the node subtable header */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Table->Length, Offset + NodeOffset,
+            ACPI_ADD_PTR (ACPI_IORT_NODE, IortNode, NodeOffset),
+            Length, InfoTable);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        NodeOffset += Length;
+
+        /* Dump the node specific data */
+
+        switch (IortNode->Type)
+        {
+        case ACPI_IORT_NODE_ITS_GROUP:
+
+            /* Validate IortItsGroup to avoid compiler warnings */
+
+            if (IortItsGroup)
+            {
+                for (i = 0; i < IortItsGroup->ItsCount; i++)
+                {
+                    Status = AcpiDmDumpTable (Table->Length, Offset + NodeOffset,
+                        ACPI_ADD_PTR (ACPI_IORT_NODE, IortNode, NodeOffset),
+                        4, AcpiDmTableInfoIort0a);
+                    NodeOffset += 4;
+                }
+            }
+            break;
+
+        case ACPI_IORT_NODE_NAMED_COMPONENT:
+
+            /* Dump the Padding (optional) */
+
+            if (IortNode->Length > NodeOffset)
+            {
+                Status = AcpiDmDumpTable (Table->Length, Offset + NodeOffset,
+                    Table, IortNode->Length - NodeOffset,
+                    AcpiDmTableInfoIort1a);
+                if (ACPI_FAILURE (Status))
+                {
+                    return;
+                }
+            }
+            break;
+
+        case ACPI_IORT_NODE_SMMU:
+
+            AcpiOsPrintf ("\n");
+
+            /* Validate IortSmmu to avoid compiler warnings */
+
+            if (IortSmmu)
+            {
+                Length = 2 * sizeof (UINT64);
+                NodeOffset = IortSmmu->GlobalInterruptOffset;
+                Status = AcpiDmDumpTable (Table->Length, Offset + NodeOffset,
+                    ACPI_ADD_PTR (ACPI_IORT_NODE, IortNode, NodeOffset),
+                    Length, AcpiDmTableInfoIort3a);
+                if (ACPI_FAILURE (Status))
+                {
+                    return;
+                }
+
+                NodeOffset = IortSmmu->ContextInterruptOffset;
+                for (i = 0; i < IortSmmu->ContextInterruptCount; i++)
+                {
+                    Status = AcpiDmDumpTable (Table->Length, Offset + NodeOffset,
+                        ACPI_ADD_PTR (ACPI_IORT_NODE, IortNode, NodeOffset),
+                        8, AcpiDmTableInfoIort3b);
+                    if (ACPI_FAILURE (Status))
+                    {
+                        return;
+                    }
+
+                    NodeOffset += 8;
+                }
+
+                NodeOffset = IortSmmu->PmuInterruptOffset;
+                for (i = 0; i < IortSmmu->PmuInterruptCount; i++)
+                {
+                    Status = AcpiDmDumpTable (Table->Length, Offset + NodeOffset,
+                        ACPI_ADD_PTR (ACPI_IORT_NODE, IortNode, NodeOffset),
+                        8, AcpiDmTableInfoIort3c);
+                    if (ACPI_FAILURE (Status))
+                    {
+                        return;
+                    }
+
+                    NodeOffset += 8;
+                }
+            }
+            break;
+
+        default:
+
+            break;
+        }
+
+        /* Dump the ID mappings */
+
+        NodeOffset = IortNode->MappingOffset;
+        for (i = 0; i < IortNode->MappingCount; i++)
+        {
+            AcpiOsPrintf ("\n");
+            Length = sizeof (ACPI_IORT_ID_MAPPING);
+            Status = AcpiDmDumpTable (Table->Length, Offset + NodeOffset,
+                ACPI_ADD_PTR (ACPI_IORT_NODE, IortNode, NodeOffset),
+                Length, AcpiDmTableInfoIortMap);
+            if (ACPI_FAILURE (Status))
+            {
+                return;
+            }
+
+            NodeOffset += Length;
+        }
+
+NextSubTable:
+        /* Point to next node subtable */
+
+        Offset += IortNode->Length;
+        IortNode = ACPI_ADD_PTR (ACPI_IORT_NODE, IortNode, IortNode->Length);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpIvrs
+ *
+ * PARAMETERS:  Table               - A IVRS table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a IVRS
+ *
+ ******************************************************************************/
+
+static UINT8 EntrySizes[] = {4,8,16,32};
+
+void
+AcpiDmDumpIvrs (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    UINT32                  Offset = sizeof (ACPI_TABLE_IVRS);
+    UINT32                  EntryOffset;
+    UINT32                  EntryLength;
+    UINT32                  EntryType;
+    ACPI_IVRS_DE_HEADER     *DeviceEntry;
+    ACPI_IVRS_HEADER        *SubTable;
+    ACPI_DMTABLE_INFO       *InfoTable;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoIvrs);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_IVRS_HEADER, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        /* Common subtable header */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable,
+            SubTable->Length, AcpiDmTableInfoIvrsHdr);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        switch (SubTable->Type)
+        {
+        case ACPI_IVRS_TYPE_HARDWARE:
+
+            InfoTable = AcpiDmTableInfoIvrs0;
+            break;
+
+        case ACPI_IVRS_TYPE_MEMORY1:
+        case ACPI_IVRS_TYPE_MEMORY2:
+        case ACPI_IVRS_TYPE_MEMORY3:
+
+            InfoTable = AcpiDmTableInfoIvrs1;
+            break;
+
+        default:
+
+            AcpiOsPrintf ("\n**** Unknown IVRS subtable type 0x%X\n",
+                SubTable->Type);
+
+            /* Attempt to continue */
+
+            if (!SubTable->Length)
+            {
+                AcpiOsPrintf ("Invalid zero length subtable\n");
+                return;
+            }
+            goto NextSubTable;
+        }
+
+        /* Dump the subtable */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable,
+            SubTable->Length, InfoTable);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* The hardware subtable can contain multiple device entries */
+
+        if (SubTable->Type == ACPI_IVRS_TYPE_HARDWARE)
+        {
+            EntryOffset = Offset + sizeof (ACPI_IVRS_HARDWARE);
+            DeviceEntry = ACPI_ADD_PTR (ACPI_IVRS_DE_HEADER, SubTable,
+                sizeof (ACPI_IVRS_HARDWARE));
+
+            while (EntryOffset < (Offset + SubTable->Length))
+            {
+                AcpiOsPrintf ("\n");
+                /*
+                 * Upper 2 bits of Type encode the length of the device entry
+                 *
+                 * 00 = 4 byte
+                 * 01 = 8 byte
+                 * 10 = 16 byte - currently no entries defined
+                 * 11 = 32 byte - currently no entries defined
+                 */
+                EntryType = DeviceEntry->Type;
+                EntryLength = EntrySizes [EntryType >> 6];
+
+                switch (EntryType)
+                {
+                /* 4-byte device entries */
+
+                case ACPI_IVRS_TYPE_PAD4:
+                case ACPI_IVRS_TYPE_ALL:
+                case ACPI_IVRS_TYPE_SELECT:
+                case ACPI_IVRS_TYPE_START:
+                case ACPI_IVRS_TYPE_END:
+
+                    InfoTable = AcpiDmTableInfoIvrs4;
+                    break;
+
+                /* 8-byte entries, type A */
+
+                case ACPI_IVRS_TYPE_ALIAS_SELECT:
+                case ACPI_IVRS_TYPE_ALIAS_START:
+
+                    InfoTable = AcpiDmTableInfoIvrs8a;
+                    break;
+
+                /* 8-byte entries, type B */
+
+                case ACPI_IVRS_TYPE_PAD8:
+                case ACPI_IVRS_TYPE_EXT_SELECT:
+                case ACPI_IVRS_TYPE_EXT_START:
+
+                    InfoTable = AcpiDmTableInfoIvrs8b;
+                    break;
+
+                /* 8-byte entries, type C */
+
+                case ACPI_IVRS_TYPE_SPECIAL:
+
+                    InfoTable = AcpiDmTableInfoIvrs8c;
+                    break;
+
+                default:
+                    InfoTable = AcpiDmTableInfoIvrs4;
+                    AcpiOsPrintf (
+                        "\n**** Unknown IVRS device entry type/length: "
+                        "0x%.2X/0x%X at offset 0x%.4X: (header below)\n",
+                        EntryType, EntryLength, EntryOffset);
+                    break;
+                }
+
+                /* Dump the Device Entry */
+
+                Status = AcpiDmDumpTable (Table->Length, EntryOffset,
+                    DeviceEntry, EntryLength, InfoTable);
+                if (ACPI_FAILURE (Status))
+                {
+                    return;
+                }
+
+                EntryOffset += EntryLength;
+                DeviceEntry = ACPI_ADD_PTR (ACPI_IVRS_DE_HEADER, DeviceEntry,
+                    EntryLength);
+            }
+        }
+
+NextSubTable:
+        /* Point to next subtable */
+
+        Offset += SubTable->Length;
+        SubTable = ACPI_ADD_PTR (ACPI_IVRS_HEADER, SubTable, SubTable->Length);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpLpit
+ *
+ * PARAMETERS:  Table               - A LPIT table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a LPIT. This table type consists
+ *              of an open-ended number of subtables. Note: There are no
+ *              entries in the main table. An LPIT consists of the table
+ *              header and then subtables only.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpLpit (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    ACPI_LPIT_HEADER        *SubTable;
+    UINT32                  Length = Table->Length;
+    UINT32                  Offset = sizeof (ACPI_TABLE_LPIT);
+    ACPI_DMTABLE_INFO       *InfoTable;
+    UINT32                  SubTableLength;
+
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_LPIT_HEADER, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        /* Common subtable header */
+
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            sizeof (ACPI_LPIT_HEADER), AcpiDmTableInfoLpitHdr);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        switch (SubTable->Type)
+        {
+        case ACPI_LPIT_TYPE_NATIVE_CSTATE:
+
+            InfoTable = AcpiDmTableInfoLpit0;
+            SubTableLength = sizeof (ACPI_LPIT_NATIVE);
+            break;
+
+        default:
+
+            /* Cannot continue on unknown type - no length */
+
+            AcpiOsPrintf ("\n**** Unknown LPIT subtable type 0x%X\n",
+                SubTable->Type);
+            return;
+        }
+
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTableLength, InfoTable);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        AcpiOsPrintf ("\n");
+
+        /* Point to next subtable */
+
+        Offset += SubTableLength;
+        SubTable = ACPI_ADD_PTR (ACPI_LPIT_HEADER, SubTable, SubTableLength);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpMadt
+ *
+ * PARAMETERS:  Table               - A MADT table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a MADT. This table type consists
+ *              of an open-ended number of subtables.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpMadt (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    ACPI_SUBTABLE_HEADER    *SubTable;
+    UINT32                  Length = Table->Length;
+    UINT32                  Offset = sizeof (ACPI_TABLE_MADT);
+    ACPI_DMTABLE_INFO       *InfoTable;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoMadt);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_SUBTABLE_HEADER, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        /* Common subtable header */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTable->Length, AcpiDmTableInfoMadtHdr);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        switch (SubTable->Type)
+        {
+        case ACPI_MADT_TYPE_LOCAL_APIC:
+
+            InfoTable = AcpiDmTableInfoMadt0;
+            break;
+
+        case ACPI_MADT_TYPE_IO_APIC:
+
+            InfoTable = AcpiDmTableInfoMadt1;
+            break;
+
+        case ACPI_MADT_TYPE_INTERRUPT_OVERRIDE:
+
+            InfoTable = AcpiDmTableInfoMadt2;
+            break;
+
+        case ACPI_MADT_TYPE_NMI_SOURCE:
+
+            InfoTable = AcpiDmTableInfoMadt3;
+            break;
+
+        case ACPI_MADT_TYPE_LOCAL_APIC_NMI:
+
+            InfoTable = AcpiDmTableInfoMadt4;
+            break;
+
+        case ACPI_MADT_TYPE_LOCAL_APIC_OVERRIDE:
+
+            InfoTable = AcpiDmTableInfoMadt5;
+            break;
+
+        case ACPI_MADT_TYPE_IO_SAPIC:
+
+            InfoTable = AcpiDmTableInfoMadt6;
+            break;
+
+        case ACPI_MADT_TYPE_LOCAL_SAPIC:
+
+            InfoTable = AcpiDmTableInfoMadt7;
+            break;
+
+        case ACPI_MADT_TYPE_INTERRUPT_SOURCE:
+
+            InfoTable = AcpiDmTableInfoMadt8;
+            break;
+
+        case ACPI_MADT_TYPE_LOCAL_X2APIC:
+
+            InfoTable = AcpiDmTableInfoMadt9;
+            break;
+
+        case ACPI_MADT_TYPE_LOCAL_X2APIC_NMI:
+
+            InfoTable = AcpiDmTableInfoMadt10;
+            break;
+
+        case ACPI_MADT_TYPE_GENERIC_INTERRUPT:
+
+            InfoTable = AcpiDmTableInfoMadt11;
+            break;
+
+        case ACPI_MADT_TYPE_GENERIC_DISTRIBUTOR:
+
+            InfoTable = AcpiDmTableInfoMadt12;
+            break;
+
+        case ACPI_MADT_TYPE_GENERIC_MSI_FRAME:
+
+            InfoTable = AcpiDmTableInfoMadt13;
+            break;
+
+        case ACPI_MADT_TYPE_GENERIC_REDISTRIBUTOR:
+
+            InfoTable = AcpiDmTableInfoMadt14;
+            break;
+
+        case ACPI_MADT_TYPE_GENERIC_TRANSLATOR:
+
+            InfoTable = AcpiDmTableInfoMadt15;
+            break;
+
+        default:
+
+            AcpiOsPrintf ("\n**** Unknown MADT subtable type 0x%X\n\n",
+                SubTable->Type);
+
+            /* Attempt to continue */
+
+            if (!SubTable->Length)
+            {
+                AcpiOsPrintf ("Invalid zero length subtable\n");
+                return;
+            }
+
+            goto NextSubTable;
+        }
+
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTable->Length, InfoTable);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+NextSubTable:
+        /* Point to next subtable */
+
+        Offset += SubTable->Length;
+        SubTable = ACPI_ADD_PTR (ACPI_SUBTABLE_HEADER, SubTable,
+            SubTable->Length);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpMcfg
+ *
+ * PARAMETERS:  Table               - A MCFG Table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a MCFG table
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpMcfg (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    UINT32                  Offset = sizeof (ACPI_TABLE_MCFG);
+    ACPI_MCFG_ALLOCATION    *SubTable;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoMcfg);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_MCFG_ALLOCATION, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        if (Offset + sizeof (ACPI_MCFG_ALLOCATION) > Table->Length)
+        {
+            AcpiOsPrintf ("Warning: there are %u invalid trailing bytes\n",
+                sizeof (ACPI_MCFG_ALLOCATION) - (Offset - Table->Length));
+            return;
+        }
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable,
+            sizeof (ACPI_MCFG_ALLOCATION), AcpiDmTableInfoMcfg0);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Point to next subtable (each subtable is of fixed length) */
+
+        Offset += sizeof (ACPI_MCFG_ALLOCATION);
+        SubTable = ACPI_ADD_PTR (ACPI_MCFG_ALLOCATION, SubTable,
+            sizeof (ACPI_MCFG_ALLOCATION));
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpMpst
+ *
+ * PARAMETERS:  Table               - A MPST Table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a MPST table
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpMpst (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    UINT32                  Offset = sizeof (ACPI_TABLE_MPST);
+    ACPI_MPST_POWER_NODE    *SubTable0;
+    ACPI_MPST_POWER_STATE   *SubTable0A;
+    ACPI_MPST_COMPONENT     *SubTable0B;
+    ACPI_MPST_DATA_HDR      *SubTable1;
+    ACPI_MPST_POWER_DATA    *SubTable2;
+    UINT16                  SubtableCount;
+    UINT32                  PowerStateCount;
+    UINT32                  ComponentCount;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoMpst);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtable: Memory Power Node(s) */
+
+    SubtableCount = (ACPI_CAST_PTR (ACPI_TABLE_MPST, Table))->PowerNodeCount;
+    SubTable0 = ACPI_ADD_PTR (ACPI_MPST_POWER_NODE, Table, Offset);
+
+    while ((Offset < Table->Length) && SubtableCount)
+    {
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable0,
+            sizeof (ACPI_MPST_POWER_NODE), AcpiDmTableInfoMpst0);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Extract the sub-subtable counts */
+
+        PowerStateCount = SubTable0->NumPowerStates;
+        ComponentCount = SubTable0->NumPhysicalComponents;
+        Offset += sizeof (ACPI_MPST_POWER_NODE);
+
+        /* Sub-subtables - Memory Power State Structure(s) */
+
+        SubTable0A = ACPI_ADD_PTR (ACPI_MPST_POWER_STATE, SubTable0,
+            sizeof (ACPI_MPST_POWER_NODE));
+
+        while (PowerStateCount)
+        {
+            AcpiOsPrintf ("\n");
+            Status = AcpiDmDumpTable (Table->Length, Offset, SubTable0A,
+                sizeof (ACPI_MPST_POWER_STATE), AcpiDmTableInfoMpst0A);
+            if (ACPI_FAILURE (Status))
+            {
+                return;
+            }
+
+            SubTable0A++;
+            PowerStateCount--;
+            Offset += sizeof (ACPI_MPST_POWER_STATE);
+       }
+
+        /* Sub-subtables - Physical Component ID Structure(s) */
+
+        SubTable0B = ACPI_CAST_PTR (ACPI_MPST_COMPONENT, SubTable0A);
+
+        if (ComponentCount)
+        {
+            AcpiOsPrintf ("\n");
+        }
+
+        while (ComponentCount)
+        {
+            Status = AcpiDmDumpTable (Table->Length, Offset, SubTable0B,
+                sizeof (ACPI_MPST_COMPONENT), AcpiDmTableInfoMpst0B);
+            if (ACPI_FAILURE (Status))
+            {
+                return;
+            }
+
+            SubTable0B++;
+            ComponentCount--;
+            Offset += sizeof (ACPI_MPST_COMPONENT);
+        }
+
+        /* Point to next Memory Power Node subtable */
+
+        SubtableCount--;
+        SubTable0 = ACPI_ADD_PTR (ACPI_MPST_POWER_NODE, SubTable0,
+            sizeof (ACPI_MPST_POWER_NODE) +
+            (sizeof (ACPI_MPST_POWER_STATE) * SubTable0->NumPowerStates) +
+            (sizeof (ACPI_MPST_COMPONENT) * SubTable0->NumPhysicalComponents));
+    }
+
+    /* Subtable: Count of Memory Power State Characteristic structures */
+
+    AcpiOsPrintf ("\n");
+    SubTable1 = ACPI_CAST_PTR (ACPI_MPST_DATA_HDR, SubTable0);
+    Status = AcpiDmDumpTable (Table->Length, Offset, SubTable1,
+        sizeof (ACPI_MPST_DATA_HDR), AcpiDmTableInfoMpst1);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    SubtableCount = SubTable1->CharacteristicsCount;
+    Offset += sizeof (ACPI_MPST_DATA_HDR);
+
+    /* Subtable: Memory Power State Characteristics structure(s) */
+
+    SubTable2 = ACPI_ADD_PTR (ACPI_MPST_POWER_DATA, SubTable1,
+        sizeof (ACPI_MPST_DATA_HDR));
+
+    while ((Offset < Table->Length) && SubtableCount)
+    {
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable2,
+            sizeof (ACPI_MPST_POWER_DATA), AcpiDmTableInfoMpst2);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        SubTable2++;
+        SubtableCount--;
+        Offset += sizeof (ACPI_MPST_POWER_DATA);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpMsct
+ *
+ * PARAMETERS:  Table               - A MSCT table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a MSCT
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpMsct (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    UINT32                  Offset = sizeof (ACPI_TABLE_MSCT);
+    ACPI_MSCT_PROXIMITY     *SubTable;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoMsct);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_MSCT_PROXIMITY, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        /* Common subtable header */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable,
+            sizeof (ACPI_MSCT_PROXIMITY), AcpiDmTableInfoMsct0);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Point to next subtable */
+
+        Offset += sizeof (ACPI_MSCT_PROXIMITY);
+        SubTable = ACPI_ADD_PTR (ACPI_MSCT_PROXIMITY, SubTable,
+            sizeof (ACPI_MSCT_PROXIMITY));
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpMtmr
+ *
+ * PARAMETERS:  Table               - A MTMR table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a MTMR
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpMtmr (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    UINT32                  Offset = sizeof (ACPI_TABLE_MTMR);
+    ACPI_MTMR_ENTRY         *SubTable;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoMtmr);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_MTMR_ENTRY, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        /* Common subtable header */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable,
+            sizeof (ACPI_MTMR_ENTRY), AcpiDmTableInfoMtmr0);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Point to next subtable */
+
+        Offset += sizeof (ACPI_MTMR_ENTRY);
+        SubTable = ACPI_ADD_PTR (ACPI_MTMR_ENTRY, SubTable,
+            sizeof (ACPI_MTMR_ENTRY));
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpNfit
+ *
+ * PARAMETERS:  Table               - A NFIT table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of an NFIT.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpNfit (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    UINT32                  Offset = sizeof (ACPI_TABLE_NFIT);
+    UINT32                  FieldOffset = 0;
+    UINT32                  Length;
+    ACPI_NFIT_HEADER        *SubTable;
+    ACPI_DMTABLE_INFO       *InfoTable;
+    ACPI_NFIT_INTERLEAVE    *Interleave = NULL;
+    ACPI_NFIT_SMBIOS        *SmbiosInfo = NULL;
+    ACPI_NFIT_FLUSH_ADDRESS *Hint = NULL;
+    UINT32                  i;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoNfit);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_NFIT_HEADER, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        /* NFIT subtable header */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable,
+            SubTable->Length, AcpiDmTableInfoNfitHdr);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        switch (SubTable->Type)
+        {
+        case ACPI_NFIT_TYPE_SYSTEM_ADDRESS:
+
+            InfoTable = AcpiDmTableInfoNfit0;
+            break;
+
+        case ACPI_NFIT_TYPE_MEMORY_MAP:
+
+            InfoTable = AcpiDmTableInfoNfit1;
+            break;
+
+        case ACPI_NFIT_TYPE_INTERLEAVE:
+
+            /* Has a variable number of 32-bit values at the end */
+
+            InfoTable = AcpiDmTableInfoNfit2;
+            Interleave = ACPI_CAST_PTR (ACPI_NFIT_INTERLEAVE, SubTable);
+            FieldOffset = sizeof (ACPI_NFIT_INTERLEAVE);
+            break;
+
+        case ACPI_NFIT_TYPE_SMBIOS:
+
+            SmbiosInfo = ACPI_CAST_PTR (ACPI_NFIT_SMBIOS, SubTable);
+            InfoTable = AcpiDmTableInfoNfit3;
+            break;
+
+        case ACPI_NFIT_TYPE_CONTROL_REGION:
+
+            InfoTable = AcpiDmTableInfoNfit4;
+            break;
+
+        case ACPI_NFIT_TYPE_DATA_REGION:
+
+            InfoTable = AcpiDmTableInfoNfit5;
+            break;
+
+        case ACPI_NFIT_TYPE_FLUSH_ADDRESS:
+
+            /* Has a variable number of 64-bit addresses at the end */
+
+            InfoTable = AcpiDmTableInfoNfit6;
+            Hint = ACPI_CAST_PTR (ACPI_NFIT_FLUSH_ADDRESS, SubTable);
+            FieldOffset = sizeof (ACPI_NFIT_FLUSH_ADDRESS) - sizeof (UINT64);
+            break;
+
+        default:
+            AcpiOsPrintf ("\n**** Unknown NFIT subtable type 0x%X\n",
+                SubTable->Type);
+
+            /* Attempt to continue */
+
+            if (!SubTable->Length)
+            {
+                AcpiOsPrintf ("Invalid zero length subtable\n");
+                return;
+            }
+            goto NextSubTable;
+        }
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable,
+            SubTable->Length, InfoTable);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Per-subtable variable-length fields */
+
+        switch (SubTable->Type)
+        {
+        case ACPI_NFIT_TYPE_INTERLEAVE:
+
+            for (i = 0; i < Interleave->LineCount; i++)
+            {
+                Status = AcpiDmDumpTable (Table->Length, Offset + FieldOffset,
+                    &Interleave->LineOffset[i],
+                    sizeof (UINT32), AcpiDmTableInfoNfit2a);
+                if (ACPI_FAILURE (Status))
+                {
+                    return;
+                }
+
+                FieldOffset += sizeof (UINT32);
+            }
+            break;
+
+        case ACPI_NFIT_TYPE_SMBIOS:
+
+            Length = SubTable->Length -
+                sizeof (ACPI_NFIT_SMBIOS) + sizeof (UINT8);
+
+            if (Length)
+            {
+                Status = AcpiDmDumpTable (Table->Length,
+                    sizeof (ACPI_NFIT_SMBIOS) - sizeof (UINT8),
+                    SmbiosInfo,
+                    Length, AcpiDmTableInfoNfit3a);
+                if (ACPI_FAILURE (Status))
+                {
+                    return;
+                }
+            }
+
+            break;
+
+        case ACPI_NFIT_TYPE_FLUSH_ADDRESS:
+
+            for (i = 0; i < Hint->HintCount; i++)
+            {
+                Status = AcpiDmDumpTable (Table->Length, Offset + FieldOffset,
+                    &Hint->HintAddress[i],
+                    sizeof (UINT64), AcpiDmTableInfoNfit6a);
+                if (ACPI_FAILURE (Status))
+                {
+                    return;
+                }
+
+                FieldOffset += sizeof (UINT64);
+            }
+            break;
+
+        default:
+            break;
+        }
+
+NextSubTable:
+        /* Point to next subtable */
+
+        Offset += SubTable->Length;
+        SubTable = ACPI_ADD_PTR (ACPI_NFIT_HEADER, SubTable, SubTable->Length);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpPcct
+ *
+ * PARAMETERS:  Table               - A PCCT table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a PCCT. This table type consists
+ *              of an open-ended number of subtables.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpPcct (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    ACPI_PCCT_SUBSPACE      *SubTable;
+    ACPI_DMTABLE_INFO       *InfoTable;
+    UINT32                  Length = Table->Length;
+    UINT32                  Offset = sizeof (ACPI_TABLE_PCCT);
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoPcct);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_PCCT_SUBSPACE, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        /* Common subtable header */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTable->Header.Length, AcpiDmTableInfoPcctHdr);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        switch (SubTable->Header.Type)
+        {
+        case ACPI_PCCT_TYPE_GENERIC_SUBSPACE:
+
+            InfoTable = AcpiDmTableInfoPcct0;
+            break;
+
+        case ACPI_PCCT_TYPE_HW_REDUCED_SUBSPACE:
+
+            InfoTable = AcpiDmTableInfoPcct1;
+            break;
+
+        case ACPI_PCCT_TYPE_HW_REDUCED_SUBSPACE_TYPE2:
+
+            InfoTable = AcpiDmTableInfoPcct2;
+            break;
+
+        default:
+
+            AcpiOsPrintf (
+                "\n**** Unexpected or unknown PCCT subtable type 0x%X\n\n",
+                SubTable->Header.Type);
+            return;
+        }
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTable->Header.Length, InfoTable);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Point to next subtable */
+
+        Offset += SubTable->Header.Length;
+        SubTable = ACPI_ADD_PTR (ACPI_PCCT_SUBSPACE, SubTable,
+            SubTable->Header.Length);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpPmtt
+ *
+ * PARAMETERS:  Table               - A PMTT table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a PMTT. This table type consists
+ *              of an open-ended number of subtables.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpPmtt (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    ACPI_PMTT_HEADER        *SubTable;
+    ACPI_PMTT_HEADER        *MemSubTable;
+    ACPI_PMTT_HEADER        *DimmSubTable;
+    ACPI_PMTT_DOMAIN        *DomainArray;
+    UINT32                  Length = Table->Length;
+    UINT32                  Offset = sizeof (ACPI_TABLE_PMTT);
+    UINT32                  MemOffset;
+    UINT32                  DimmOffset;
+    UINT32                  DomainOffset;
+    UINT32                  DomainCount;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoPmtt);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_PMTT_HEADER, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        /* Common subtable header */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTable->Length, AcpiDmTableInfoPmttHdr);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Only Socket subtables are expected at this level */
+
+        if (SubTable->Type != ACPI_PMTT_TYPE_SOCKET)
+        {
+            AcpiOsPrintf (
+                "\n**** Unexpected or unknown PMTT subtable type 0x%X\n\n",
+                SubTable->Type);
+            return;
+        }
+
+        /* Dump the fixed-length portion of the subtable */
+
+        Status = AcpiDmDumpTable (Length, Offset, SubTable,
+            SubTable->Length, AcpiDmTableInfoPmtt0);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Walk the memory controller subtables */
+
+        MemOffset = sizeof (ACPI_PMTT_SOCKET);
+        MemSubTable = ACPI_ADD_PTR (ACPI_PMTT_HEADER, SubTable,
+            sizeof (ACPI_PMTT_SOCKET));
+
+        while (((Offset + MemOffset) < Table->Length) &&
+            (MemOffset < SubTable->Length))
+        {
+            /* Common subtable header */
+
+            AcpiOsPrintf ("\n");
+            Status = AcpiDmDumpTable (Length,
+                Offset + MemOffset, MemSubTable,
+                MemSubTable->Length, AcpiDmTableInfoPmttHdr);
+            if (ACPI_FAILURE (Status))
+            {
+                return;
+            }
+
+            /* Only memory controller subtables are expected at this level */
+
+            if (MemSubTable->Type != ACPI_PMTT_TYPE_CONTROLLER)
+            {
+                AcpiOsPrintf (
+                    "\n**** Unexpected or unknown PMTT subtable type 0x%X\n\n",
+                    MemSubTable->Type);
+                return;
+            }
+
+            /* Dump the fixed-length portion of the controller subtable */
+
+            Status = AcpiDmDumpTable (Length,
+                Offset + MemOffset, MemSubTable,
+                MemSubTable->Length, AcpiDmTableInfoPmtt1);
+            if (ACPI_FAILURE (Status))
+            {
+                return;
+            }
+
+            /* Walk the variable count of proximity domains */
+
+            DomainCount = ((ACPI_PMTT_CONTROLLER *) MemSubTable)->DomainCount;
+            DomainOffset = sizeof (ACPI_PMTT_CONTROLLER);
+            DomainArray = ACPI_ADD_PTR (ACPI_PMTT_DOMAIN, MemSubTable,
+                sizeof (ACPI_PMTT_CONTROLLER));
+
+            while (((Offset + MemOffset + DomainOffset) < Table->Length) &&
+                ((MemOffset + DomainOffset) < SubTable->Length) &&
+                DomainCount)
+            {
+                Status = AcpiDmDumpTable (Length,
+                    Offset + MemOffset + DomainOffset, DomainArray,
+                    sizeof (ACPI_PMTT_DOMAIN), AcpiDmTableInfoPmtt1a);
+                if (ACPI_FAILURE (Status))
+                {
+                    return;
+                }
+
+                DomainOffset += sizeof (ACPI_PMTT_DOMAIN);
+                DomainArray++;
+                DomainCount--;
+            }
+
+            if (DomainCount)
+            {
+                AcpiOsPrintf (
+                    "\n**** DomainCount exceeds subtable length\n\n");
+            }
+
+            /* Walk the physical component (DIMM) subtables */
+
+            DimmOffset = DomainOffset;
+            DimmSubTable = ACPI_ADD_PTR (ACPI_PMTT_HEADER, MemSubTable,
+                DomainOffset);
+
+            while (((Offset + MemOffset + DimmOffset) < Table->Length) &&
+                (DimmOffset < MemSubTable->Length))
+            {
+                /* Common subtable header */
+
+                AcpiOsPrintf ("\n");
+                Status = AcpiDmDumpTable (Length,
+                    Offset + MemOffset + DimmOffset, DimmSubTable,
+                    DimmSubTable->Length, AcpiDmTableInfoPmttHdr);
+                if (ACPI_FAILURE (Status))
+                {
+                    return;
+                }
+
+                /* Only DIMM subtables are expected at this level */
+
+                if (DimmSubTable->Type != ACPI_PMTT_TYPE_DIMM)
+                {
+                    AcpiOsPrintf (
+                        "\n**** Unexpected or unknown PMTT subtable type 0x%X\n\n",
+                        DimmSubTable->Type);
+                    return;
+                }
+
+                /* Dump the fixed-length DIMM subtable */
+
+                Status = AcpiDmDumpTable (Length,
+                    Offset + MemOffset + DimmOffset, DimmSubTable,
+                    DimmSubTable->Length, AcpiDmTableInfoPmtt2);
+                if (ACPI_FAILURE (Status))
+                {
+                    return;
+                }
+
+                /* Point to next DIMM subtable */
+
+                DimmOffset += DimmSubTable->Length;
+                DimmSubTable = ACPI_ADD_PTR (ACPI_PMTT_HEADER,
+                    DimmSubTable, DimmSubTable->Length);
+            }
+
+            /* Point to next Controller subtable */
+
+            MemOffset += MemSubTable->Length;
+            MemSubTable = ACPI_ADD_PTR (ACPI_PMTT_HEADER,
+                MemSubTable, MemSubTable->Length);
+        }
+
+        /* Point to next Socket subtable */
+
+        Offset += SubTable->Length;
+        SubTable = ACPI_ADD_PTR (ACPI_PMTT_HEADER,
+            SubTable, SubTable->Length);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpS3pt
+ *
+ * PARAMETERS:  Table               - A S3PT table
+ *
+ * RETURN:      Length of the table
+ *
+ * DESCRIPTION: Format the contents of a S3PT
+ *
+ ******************************************************************************/
+
+UINT32
+AcpiDmDumpS3pt (
+    ACPI_TABLE_HEADER       *Tables)
+{
+    ACPI_STATUS             Status;
+    UINT32                  Offset = sizeof (ACPI_TABLE_S3PT);
+    ACPI_FPDT_HEADER        *SubTable;
+    ACPI_DMTABLE_INFO       *InfoTable;
+    ACPI_TABLE_S3PT         *S3ptTable = ACPI_CAST_PTR (ACPI_TABLE_S3PT, Tables);
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Offset, 0, S3ptTable, 0, AcpiDmTableInfoS3pt);
+    if (ACPI_FAILURE (Status))
+    {
+        return 0;
+    }
+
+    SubTable = ACPI_ADD_PTR (ACPI_FPDT_HEADER, S3ptTable, Offset);
+    while (Offset < S3ptTable->Length)
+    {
+        /* Common subtable header */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (S3ptTable->Length, Offset, SubTable,
+            SubTable->Length, AcpiDmTableInfoS3ptHdr);
+        if (ACPI_FAILURE (Status))
+        {
+            return 0;
+        }
+
+        switch (SubTable->Type)
+        {
+        case ACPI_S3PT_TYPE_RESUME:
+
+            InfoTable = AcpiDmTableInfoS3pt0;
+            break;
+
+        case ACPI_S3PT_TYPE_SUSPEND:
+
+            InfoTable = AcpiDmTableInfoS3pt1;
+            break;
+
+        default:
+
+            AcpiOsPrintf ("\n**** Unknown S3PT subtable type 0x%X\n",
+                SubTable->Type);
+
+            /* Attempt to continue */
+
+            if (!SubTable->Length)
+            {
+                AcpiOsPrintf ("Invalid zero length subtable\n");
+                return 0;
+            }
+            goto NextSubTable;
+        }
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (S3ptTable->Length, Offset, SubTable,
+            SubTable->Length, InfoTable);
+        if (ACPI_FAILURE (Status))
+        {
+            return 0;
+        }
+
+NextSubTable:
+        /* Point to next subtable */
+
+        Offset += SubTable->Length;
+        SubTable = ACPI_ADD_PTR (ACPI_FPDT_HEADER, SubTable, SubTable->Length);
+    }
+
+    return (S3ptTable->Length);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpSlic
+ *
+ * PARAMETERS:  Table               - A SLIC table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a SLIC
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpSlic (
+    ACPI_TABLE_HEADER       *Table)
+{
+
+    (void) AcpiDmDumpTable (Table->Length, sizeof (ACPI_TABLE_HEADER), Table,
+        Table->Length - sizeof (*Table), AcpiDmTableInfoSlic);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpSlit
+ *
+ * PARAMETERS:  Table               - An SLIT
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a SLIT
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpSlit (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    UINT32                  Offset;
+    UINT8                   *Row;
+    UINT32                  Localities;
+    UINT32                  i;
+    UINT32                  j;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoSlit);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Display the Locality NxN Matrix */
+
+    Localities = (UINT32) ACPI_CAST_PTR (ACPI_TABLE_SLIT, Table)->LocalityCount;
+    Offset = ACPI_OFFSET (ACPI_TABLE_SLIT, Entry[0]);
+    Row = (UINT8 *) ACPI_CAST_PTR (ACPI_TABLE_SLIT, Table)->Entry;
+
+    for (i = 0; i < Localities; i++)
+    {
+        /* Display one row of the matrix */
+
+        AcpiDmLineHeader2 (Offset, Localities, "Locality", i);
+        for  (j = 0; j < Localities; j++)
+        {
+            /* Check for beyond EOT */
+
+            if (Offset >= Table->Length)
+            {
+                AcpiOsPrintf (
+                    "\n**** Not enough room in table for all localities\n");
+                return;
+            }
+
+            AcpiOsPrintf ("%2.2X", Row[j]);
+            Offset++;
+
+            /* Display up to 16 bytes per output row */
+
+            if ((j+1) < Localities)
+            {
+                AcpiOsPrintf (" ");
+
+                if (j && (((j+1) % 16) == 0))
+                {
+                    AcpiOsPrintf ("\\\n"); /* With line continuation char */
+                    AcpiDmLineHeader (Offset, 0, NULL);
+                }
+            }
+        }
+
+        /* Point to next row */
+
+        AcpiOsPrintf ("\n");
+        Row += Localities;
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpSrat
+ *
+ * PARAMETERS:  Table               - A SRAT table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a SRAT
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpSrat (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    UINT32                  Offset = sizeof (ACPI_TABLE_SRAT);
+    ACPI_SUBTABLE_HEADER    *SubTable;
+    ACPI_DMTABLE_INFO       *InfoTable;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoSrat);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_SUBTABLE_HEADER, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        /* Common subtable header */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable,
+            SubTable->Length, AcpiDmTableInfoSratHdr);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        switch (SubTable->Type)
+        {
+        case ACPI_SRAT_TYPE_CPU_AFFINITY:
+
+            InfoTable = AcpiDmTableInfoSrat0;
+            break;
+
+        case ACPI_SRAT_TYPE_MEMORY_AFFINITY:
+
+            InfoTable = AcpiDmTableInfoSrat1;
+            break;
+
+        case ACPI_SRAT_TYPE_X2APIC_CPU_AFFINITY:
+
+            InfoTable = AcpiDmTableInfoSrat2;
+            break;
+
+        case ACPI_SRAT_TYPE_GICC_AFFINITY:
+
+            InfoTable = AcpiDmTableInfoSrat3;
+            break;
+
+        default:
+            AcpiOsPrintf ("\n**** Unknown SRAT subtable type 0x%X\n",
+                SubTable->Type);
+
+            /* Attempt to continue */
+
+            if (!SubTable->Length)
+            {
+                AcpiOsPrintf ("Invalid zero length subtable\n");
+                return;
+            }
+            goto NextSubTable;
+        }
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable,
+            SubTable->Length, InfoTable);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+NextSubTable:
+        /* Point to next subtable */
+
+        Offset += SubTable->Length;
+        SubTable = ACPI_ADD_PTR (ACPI_SUBTABLE_HEADER, SubTable,
+            SubTable->Length);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpStao
+ *
+ * PARAMETERS:  Table               - A STAO table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a STAO. This is a variable-length
+ *              table that contains an open-ended number of ASCII strings
+ *              at the end of the table.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpStao (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    char                    *Namepath;
+    UINT32                  Length = Table->Length;
+    UINT32                  StringLength;
+    UINT32                  Offset = sizeof (ACPI_TABLE_STAO);
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoStao);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* The rest of the table consists of Namepath strings */
+
+    while (Offset < Table->Length)
+    {
+        Namepath = ACPI_ADD_PTR (char, Table, Offset);
+        StringLength = strlen (Namepath) + 1;
+
+        AcpiDmLineHeader (Offset, StringLength, "Namestring");
+        AcpiOsPrintf ("\"%s\"\n", Namepath);
+
+        /* Point to next namepath */
+
+        Offset += StringLength;
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpTcpa
+ *
+ * PARAMETERS:  Table               - A TCPA table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a TCPA.
+ *
+ * NOTE:        There are two versions of the table with the same signature:
+ *              the client version and the server version. The common
+ *              PlatformClass field is used to differentiate the two types of
+ *              tables.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpTcpa (
+    ACPI_TABLE_HEADER       *Table)
+{
+    UINT32                  Offset = sizeof (ACPI_TABLE_TCPA_HDR);
+    ACPI_TABLE_TCPA_HDR     *CommonHeader = ACPI_CAST_PTR (
+                                ACPI_TABLE_TCPA_HDR, Table);
+    ACPI_TABLE_TCPA_HDR     *SubTable = ACPI_ADD_PTR (
+                                ACPI_TABLE_TCPA_HDR, Table, Offset);
+    ACPI_STATUS             Status;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Table->Length, 0, Table,
+        0, AcpiDmTableInfoTcpaHdr);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /*
+     * Examine the PlatformClass field to determine the table type.
+     * Either a client or server table. Only one.
+     */
+    switch (CommonHeader->PlatformClass)
+    {
+    case ACPI_TCPA_CLIENT_TABLE:
+
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable,
+            Table->Length - Offset, AcpiDmTableInfoTcpaClient);
+        break;
+
+    case ACPI_TCPA_SERVER_TABLE:
+
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable,
+            Table->Length - Offset, AcpiDmTableInfoTcpaServer);
+        break;
+
+    default:
+
+        AcpiOsPrintf ("\n**** Unknown TCPA Platform Class 0x%X\n",
+            CommonHeader->PlatformClass);
+        Status = AE_ERROR;
+        break;
+    }
+
+    if (ACPI_FAILURE (Status))
+    {
+        AcpiOsPrintf ("\n**** Cannot disassemble TCPA table\n");
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpVrtc
+ *
+ * PARAMETERS:  Table               - A VRTC table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a VRTC
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpVrtc (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    UINT32                  Offset = sizeof (ACPI_TABLE_VRTC);
+    ACPI_VRTC_ENTRY         *SubTable;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoVrtc);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_VRTC_ENTRY, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        /* Common subtable header */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable,
+            sizeof (ACPI_VRTC_ENTRY), AcpiDmTableInfoVrtc0);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Point to next subtable */
+
+        Offset += sizeof (ACPI_VRTC_ENTRY);
+        SubTable = ACPI_ADD_PTR (ACPI_VRTC_ENTRY, SubTable,
+            sizeof (ACPI_VRTC_ENTRY));
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpWdat
+ *
+ * PARAMETERS:  Table               - A WDAT table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a WDAT
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpWdat (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    UINT32                  Offset = sizeof (ACPI_TABLE_WDAT);
+    ACPI_WDAT_ENTRY         *SubTable;
+
+
+    /* Main table */
+
+    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoWdat);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Subtables */
+
+    SubTable = ACPI_ADD_PTR (ACPI_WDAT_ENTRY, Table, Offset);
+    while (Offset < Table->Length)
+    {
+        /* Common subtable header */
+
+        AcpiOsPrintf ("\n");
+        Status = AcpiDmDumpTable (Table->Length, Offset, SubTable,
+            sizeof (ACPI_WDAT_ENTRY), AcpiDmTableInfoWdat0);
+        if (ACPI_FAILURE (Status))
+        {
+            return;
+        }
+
+        /* Point to next subtable */
+
+        Offset += sizeof (ACPI_WDAT_ENTRY);
+        SubTable = ACPI_ADD_PTR (ACPI_WDAT_ENTRY, SubTable,
+            sizeof (ACPI_WDAT_ENTRY));
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmDumpWpbt
+ *
+ * PARAMETERS:  Table               - A WPBT table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Format the contents of a WPBT. This table type consists
+ *              of an open-ended arguments buffer at the end of the table.
+ *
+ ******************************************************************************/
+
+void
+AcpiDmDumpWpbt (
+    ACPI_TABLE_HEADER       *Table)
+{
+    ACPI_STATUS             Status;
+    ACPI_TABLE_WPBT         *SubTable;
+    UINT32                  Length = Table->Length;
+    UINT16                  ArgumentsLength;
+
+
+    /* Dump the main table */
+
+    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoWpbt);
+    if (ACPI_FAILURE (Status))
+    {
+        return;
+    }
+
+    /* Extract the arguments buffer length from the main table */
+
+    SubTable = ACPI_CAST_PTR (ACPI_TABLE_WPBT, Table);
+    ArgumentsLength = SubTable->ArgumentsLength;
+
+    /* Dump the arguments buffer */
+
+    (void) AcpiDmDumpTable (Table->Length, 0, Table, ArgumentsLength,
+        AcpiDmTableInfoWpbt0);
+}

--- a/sys/src/libacpi/acpica/common/dmtbinfo.c
+++ b/sys/src/libacpi/acpica/common/dmtbinfo.c
@@ -1,0 +1,3076 @@
+/******************************************************************************
+ *
+ * Module Name: dmtbinfo - Table info for non-AML tables
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+#include "acdisasm.h"
+
+/* This module used for application-level code only */
+
+#define _COMPONENT          ACPI_CA_DISASSEMBLER
+        ACPI_MODULE_NAME    ("dmtbinfo")
+
+/*
+ * How to add a new table:
+ *
+ * - Add the C table definition to the actbl1.h or actbl2.h header.
+ * - Add ACPI_xxxx_OFFSET macro(s) for the table (and subtables) to list below.
+ * - Define the table in this file (for the disassembler). If any
+ *   new data types are required (ACPI_DMT_*), see below.
+ * - Add an external declaration for the new table definition (AcpiDmTableInfo*)
+ *     in acdisam.h
+ * - Add new table definition to the dispatch table in dmtable.c (AcpiDmTableData)
+ *     If a simple table (with no subtables), no disassembly code is needed.
+ *     Otherwise, create the AcpiDmDump* function for to disassemble the table
+ *     and add it to the dmtbdump.c file.
+ * - Add an external declaration for the new AcpiDmDump* function in acdisasm.h
+ * - Add the new AcpiDmDump* function to the dispatch table in dmtable.c
+ * - Create a template for the new table
+ * - Add data table compiler support
+ *
+ * How to add a new data type (ACPI_DMT_*):
+ *
+ * - Add new type at the end of the ACPI_DMT list in acdisasm.h
+ * - Add length and implementation cases in dmtable.c  (disassembler)
+ * - Add type and length cases in dtutils.c (DT compiler)
+ */
+
+/*
+ * Macros used to generate offsets to specific table fields
+ */
+#define ACPI_FACS_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_FACS,f)
+#define ACPI_GAS_OFFSET(f)              (UINT16) ACPI_OFFSET (ACPI_GENERIC_ADDRESS,f)
+#define ACPI_HDR_OFFSET(f)              (UINT16) ACPI_OFFSET (ACPI_TABLE_HEADER,f)
+#define ACPI_RSDP_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_RSDP,f)
+#define ACPI_BERT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_BERT,f)
+#define ACPI_BGRT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_BGRT,f)
+#define ACPI_BOOT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_BOOT,f)
+#define ACPI_CPEP_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_CPEP,f)
+#define ACPI_DBG2_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_DBG2,f)
+#define ACPI_DBGP_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_DBGP,f)
+#define ACPI_DMAR_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_DMAR,f)
+#define ACPI_DRTM_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_DRTM,f)
+#define ACPI_ECDT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_ECDT,f)
+#define ACPI_EINJ_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_EINJ,f)
+#define ACPI_ERST_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_ERST,f)
+#define ACPI_GTDT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_GTDT,f)
+#define ACPI_HEST_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_HEST,f)
+#define ACPI_HPET_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_HPET,f)
+#define ACPI_IORT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_IORT,f)
+#define ACPI_IVRS_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_IVRS,f)
+#define ACPI_MADT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_MADT,f)
+#define ACPI_MCFG_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_MCFG,f)
+#define ACPI_MCHI_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_MCHI,f)
+#define ACPI_MPST_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_MPST,f)
+#define ACPI_MSCT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_MSCT,f)
+#define ACPI_NFIT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_NFIT,f)
+#define ACPI_PCCT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_PCCT,f)
+#define ACPI_PMTT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_PMTT,f)
+#define ACPI_RASF_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_RASF,f)
+#define ACPI_S3PT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_S3PT,f)
+#define ACPI_SBST_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_SBST,f)
+#define ACPI_SLIT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_SLIT,f)
+#define ACPI_SPCR_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_SPCR,f)
+#define ACPI_SPMI_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_SPMI,f)
+#define ACPI_SRAT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_SRAT,f)
+#define ACPI_STAO_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_STAO,f)
+#define ACPI_TCPA_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_TCPA_HDR,f)
+#define ACPI_TPM2_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_TPM2,f)
+#define ACPI_UEFI_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_UEFI,f)
+#define ACPI_WAET_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_WAET,f)
+#define ACPI_WDAT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_WDAT,f)
+#define ACPI_WDDT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_WDDT,f)
+#define ACPI_WDRT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_WDRT,f)
+#define ACPI_WPBT_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_WPBT,f)
+#define ACPI_XENV_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_XENV,f)
+
+/* Subtables */
+
+#define ACPI_ASF0_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_ASF_INFO,f)
+#define ACPI_ASF1_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_ASF_ALERT,f)
+#define ACPI_ASF1a_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_ASF_ALERT_DATA,f)
+#define ACPI_ASF2_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_ASF_REMOTE,f)
+#define ACPI_ASF2a_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_ASF_CONTROL_DATA,f)
+#define ACPI_ASF3_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_ASF_RMCP,f)
+#define ACPI_ASF4_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_ASF_ADDRESS,f)
+#define ACPI_CPEP0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_CPEP_POLLING,f)
+#define ACPI_CSRT0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_CSRT_GROUP,f)
+#define ACPI_CSRT1_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_CSRT_SHARED_INFO,f)
+#define ACPI_CSRT2_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_CSRT_DESCRIPTOR,f)
+#define ACPI_DBG20_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_DBG2_DEVICE,f)
+#define ACPI_DMARS_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_DMAR_DEVICE_SCOPE,f)
+#define ACPI_DMAR0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_DMAR_HARDWARE_UNIT,f)
+#define ACPI_DMAR1_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_DMAR_RESERVED_MEMORY,f)
+#define ACPI_DMAR2_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_DMAR_ATSR,f)
+#define ACPI_DMAR3_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_DMAR_RHSA,f)
+#define ACPI_DMAR4_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_DMAR_ANDD,f)
+#define ACPI_DRTM0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_DRTM_VTABLE_LIST,f)
+#define ACPI_DRTM1_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_DRTM_RESOURCE_LIST,f)
+#define ACPI_DRTM1a_OFFSET(f)           (UINT16) ACPI_OFFSET (ACPI_DRTM_RESOURCE,f)
+#define ACPI_DRTM2_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_DRTM_DPS_ID,f)
+#define ACPI_EINJ0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_WHEA_HEADER,f)
+#define ACPI_ERST0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_WHEA_HEADER,f)
+#define ACPI_FPDTH_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_FPDT_HEADER,f)
+#define ACPI_FPDT0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_FPDT_BOOT_POINTER,f)
+#define ACPI_FPDT1_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_FPDT_S3PT_POINTER,f)
+#define ACPI_GTDT0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_GTDT_TIMER_BLOCK,f)
+#define ACPI_GTDT0a_OFFSET(f)           (UINT16) ACPI_OFFSET (ACPI_GTDT_TIMER_ENTRY,f)
+#define ACPI_GTDT1_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_GTDT_WATCHDOG,f)
+#define ACPI_GTDTH_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_GTDT_HEADER,f)
+#define ACPI_HEST0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_HEST_IA_MACHINE_CHECK,f)
+#define ACPI_HEST1_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_HEST_IA_CORRECTED,f)
+#define ACPI_HEST2_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_HEST_IA_NMI,f)
+#define ACPI_HEST6_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_HEST_AER_ROOT,f)
+#define ACPI_HEST7_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_HEST_AER,f)
+#define ACPI_HEST8_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_HEST_AER_BRIDGE,f)
+#define ACPI_HEST9_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_HEST_GENERIC,f)
+#define ACPI_HEST10_OFFSET(f)           (UINT16) ACPI_OFFSET (ACPI_HEST_GENERIC_V2,f)
+#define ACPI_HESTN_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_HEST_NOTIFY,f)
+#define ACPI_HESTB_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_HEST_IA_ERROR_BANK,f)
+#define ACPI_IORT0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_IORT_ITS_GROUP,f)
+#define ACPI_IORT1_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_IORT_NAMED_COMPONENT,f)
+#define ACPI_IORT2_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_IORT_ROOT_COMPLEX,f)
+#define ACPI_IORT3_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_IORT_SMMU,f)
+#define ACPI_IORT4_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_IORT_SMMU_V3,f)
+#define ACPI_IORTA_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_IORT_MEMORY_ACCESS,f)
+#define ACPI_IORTH_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_IORT_NODE,f)
+#define ACPI_IORTM_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_IORT_ID_MAPPING,f)
+#define ACPI_IVRSH_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_IVRS_HEADER,f)
+#define ACPI_IVRS0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_IVRS_HARDWARE,f)
+#define ACPI_IVRS1_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_IVRS_MEMORY,f)
+#define ACPI_IVRSD_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_IVRS_DE_HEADER,f)
+#define ACPI_IVRS8A_OFFSET(f)           (UINT16) ACPI_OFFSET (ACPI_IVRS_DEVICE8A,f)
+#define ACPI_IVRS8B_OFFSET(f)           (UINT16) ACPI_OFFSET (ACPI_IVRS_DEVICE8B,f)
+#define ACPI_IVRS8C_OFFSET(f)           (UINT16) ACPI_OFFSET (ACPI_IVRS_DEVICE8C,f)
+#define ACPI_LPITH_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_LPIT_HEADER,f)
+#define ACPI_LPIT0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_LPIT_NATIVE,f)
+#define ACPI_MADT0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_MADT_LOCAL_APIC,f)
+#define ACPI_MADT1_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_MADT_IO_APIC,f)
+#define ACPI_MADT2_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_MADT_INTERRUPT_OVERRIDE,f)
+#define ACPI_MADT3_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_MADT_NMI_SOURCE,f)
+#define ACPI_MADT4_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_MADT_LOCAL_APIC_NMI,f)
+#define ACPI_MADT5_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_MADT_LOCAL_APIC_OVERRIDE,f)
+#define ACPI_MADT6_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_MADT_IO_SAPIC,f)
+#define ACPI_MADT7_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_MADT_LOCAL_SAPIC,f)
+#define ACPI_MADT8_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_MADT_INTERRUPT_SOURCE,f)
+#define ACPI_MADT9_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_MADT_LOCAL_X2APIC,f)
+#define ACPI_MADT10_OFFSET(f)           (UINT16) ACPI_OFFSET (ACPI_MADT_LOCAL_X2APIC_NMI,f)
+#define ACPI_MADT11_OFFSET(f)           (UINT16) ACPI_OFFSET (ACPI_MADT_GENERIC_INTERRUPT,f)
+#define ACPI_MADT12_OFFSET(f)           (UINT16) ACPI_OFFSET (ACPI_MADT_GENERIC_DISTRIBUTOR,f)
+#define ACPI_MADT13_OFFSET(f)           (UINT16) ACPI_OFFSET (ACPI_MADT_GENERIC_MSI_FRAME,f)
+#define ACPI_MADT14_OFFSET(f)           (UINT16) ACPI_OFFSET (ACPI_MADT_GENERIC_REDISTRIBUTOR,f)
+#define ACPI_MADT15_OFFSET(f)           (UINT16) ACPI_OFFSET (ACPI_MADT_GENERIC_TRANSLATOR,f)
+#define ACPI_MADTH_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_SUBTABLE_HEADER,f)
+#define ACPI_MCFG0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_MCFG_ALLOCATION,f)
+#define ACPI_MPST0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_MPST_POWER_NODE,f)
+#define ACPI_MPST0A_OFFSET(f)           (UINT16) ACPI_OFFSET (ACPI_MPST_POWER_STATE,f)
+#define ACPI_MPST0B_OFFSET(f)           (UINT16) ACPI_OFFSET (ACPI_MPST_COMPONENT,f)
+#define ACPI_MPST1_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_MPST_DATA_HDR,f)
+#define ACPI_MPST2_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_MPST_POWER_DATA,f)
+#define ACPI_MSCT0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_MSCT_PROXIMITY,f)
+#define ACPI_MTMR0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_MTMR_ENTRY,f)
+#define ACPI_NFITH_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_NFIT_HEADER,f)
+#define ACPI_NFIT0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_NFIT_SYSTEM_ADDRESS,f)
+#define ACPI_NFIT1_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_NFIT_MEMORY_MAP,f)
+#define ACPI_NFIT2_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_NFIT_INTERLEAVE,f)
+#define ACPI_NFIT3_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_NFIT_SMBIOS,f)
+#define ACPI_NFIT4_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_NFIT_CONTROL_REGION,f)
+#define ACPI_NFIT5_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_NFIT_DATA_REGION,f)
+#define ACPI_NFIT6_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_NFIT_FLUSH_ADDRESS,f)
+#define ACPI_PCCT0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_PCCT_SUBSPACE,f)
+#define ACPI_PCCT1_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_PCCT_HW_REDUCED,f)
+#define ACPI_PCCT2_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_PCCT_HW_REDUCED_TYPE2,f)
+#define ACPI_PMTT0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_PMTT_SOCKET,f)
+#define ACPI_PMTT1_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_PMTT_CONTROLLER,f)
+#define ACPI_PMTT1A_OFFSET(f)           (UINT16) ACPI_OFFSET (ACPI_PMTT_DOMAIN,f)
+#define ACPI_PMTT2_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_PMTT_PHYSICAL_COMPONENT,f)
+#define ACPI_PMTTH_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_PMTT_HEADER,f)
+#define ACPI_S3PTH_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_FPDT_HEADER,f)
+#define ACPI_S3PT0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_S3PT_RESUME,f)
+#define ACPI_S3PT1_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_S3PT_SUSPEND,f)
+#define ACPI_SLIC_OFFSET(f)             (UINT16) ACPI_OFFSET (ACPI_TABLE_SLIC,f)
+#define ACPI_SRATH_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_SUBTABLE_HEADER,f)
+#define ACPI_SRAT0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_SRAT_CPU_AFFINITY,f)
+#define ACPI_SRAT1_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_SRAT_MEM_AFFINITY,f)
+#define ACPI_SRAT2_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_SRAT_X2APIC_CPU_AFFINITY,f)
+#define ACPI_SRAT3_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_SRAT_GICC_AFFINITY,f)
+#define ACPI_TCPA_CLIENT_OFFSET(f)      (UINT16) ACPI_OFFSET (ACPI_TABLE_TCPA_CLIENT,f)
+#define ACPI_TCPA_SERVER_OFFSET(f)      (UINT16) ACPI_OFFSET (ACPI_TABLE_TCPA_SERVER,f)
+#define ACPI_VRTC0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_VRTC_ENTRY,f)
+#define ACPI_WDAT0_OFFSET(f)            (UINT16) ACPI_OFFSET (ACPI_WDAT_ENTRY,f)
+
+/*
+ * Simplify access to flag fields by breaking them up into bytes
+ */
+#define ACPI_FLAG_OFFSET(d,f,o)         (UINT16) (ACPI_OFFSET (d,f) + o)
+
+/* Flags */
+
+#define ACPI_DRTM_FLAG_OFFSET(f,o)      ACPI_FLAG_OFFSET (ACPI_TABLE_DRTM,f,o)
+#define ACPI_DRTM1a_FLAG_OFFSET(f,o)    ACPI_FLAG_OFFSET (ACPI_DRTM_RESOURCE,f,o)
+#define ACPI_FADT_FLAG_OFFSET(f,o)      ACPI_FLAG_OFFSET (ACPI_TABLE_FADT,f,o)
+#define ACPI_FACS_FLAG_OFFSET(f,o)      ACPI_FLAG_OFFSET (ACPI_TABLE_FACS,f,o)
+#define ACPI_HPET_FLAG_OFFSET(f,o)      ACPI_FLAG_OFFSET (ACPI_TABLE_HPET,f,o)
+#define ACPI_SRAT0_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_SRAT_CPU_AFFINITY,f,o)
+#define ACPI_SRAT1_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_SRAT_MEM_AFFINITY,f,o)
+#define ACPI_SRAT2_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_SRAT_X2APIC_CPU_AFFINITY,f,o)
+#define ACPI_SRAT3_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_SRAT_GICC_AFFINITY,f,o)
+#define ACPI_GTDT_FLAG_OFFSET(f,o)      ACPI_FLAG_OFFSET (ACPI_TABLE_GTDT,f,o)
+#define ACPI_GTDT0a_FLAG_OFFSET(f,o)    ACPI_FLAG_OFFSET (ACPI_GTDT_TIMER_ENTRY,f,o)
+#define ACPI_GTDT1_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_GTDT_WATCHDOG,f,o)
+#define ACPI_IORT3_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_IORT_SMMU,f,o)
+#define ACPI_IORT4_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_IORT_SMMU_V3,f,o)
+#define ACPI_IORTA_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_IORT_MEMORY_ACCESS,f,o)
+#define ACPI_IORTM_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_IORT_ID_MAPPING,f,o)
+#define ACPI_LPITH_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_LPIT_HEADER,f,o)
+#define ACPI_MADT_FLAG_OFFSET(f,o)      ACPI_FLAG_OFFSET (ACPI_TABLE_MADT,f,o)
+#define ACPI_MADT0_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_MADT_LOCAL_APIC,f,o)
+#define ACPI_MADT2_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_MADT_INTERRUPT_OVERRIDE,f,o)
+#define ACPI_MADT3_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_MADT_NMI_SOURCE,f,o)
+#define ACPI_MADT4_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_MADT_LOCAL_APIC_NMI,f,o)
+#define ACPI_MADT7_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_MADT_LOCAL_SAPIC,f,o)
+#define ACPI_MADT8_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_MADT_INTERRUPT_SOURCE,f,o)
+#define ACPI_MADT9_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_MADT_LOCAL_X2APIC,f,o)
+#define ACPI_MADT10_FLAG_OFFSET(f,o)    ACPI_FLAG_OFFSET (ACPI_MADT_LOCAL_X2APIC_NMI,f,o)
+#define ACPI_MADT11_FLAG_OFFSET(f,o)    ACPI_FLAG_OFFSET (ACPI_MADT_GENERIC_INTERRUPT,f,o)
+#define ACPI_MADT13_FLAG_OFFSET(f,o)    ACPI_FLAG_OFFSET (ACPI_MADT_GENERIC_MSI_FRAME,f,o)
+#define ACPI_MPST0_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_MPST_POWER_NODE,f,o)
+#define ACPI_MPST2_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_MPST_POWER_DATA,f,o)
+#define ACPI_NFIT0_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_NFIT_SYSTEM_ADDRESS,f,o)
+#define ACPI_NFIT1_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_NFIT_MEMORY_MAP,f,o)
+#define ACPI_NFIT4_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_NFIT_CONTROL_REGION,f,o)
+#define ACPI_PCCT_FLAG_OFFSET(f,o)      ACPI_FLAG_OFFSET (ACPI_TABLE_PCCT,f,o)
+#define ACPI_PCCT1_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_PCCT_HW_REDUCED,f,o)
+#define ACPI_PCCT2_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_PCCT_HW_REDUCED_TYPE2,f,o)
+#define ACPI_PMTTH_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_PMTT_HEADER,f,o)
+#define ACPI_WDDT_FLAG_OFFSET(f,o)      ACPI_FLAG_OFFSET (ACPI_TABLE_WDDT,f,o)
+#define ACPI_EINJ0_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_WHEA_HEADER,f,o)
+#define ACPI_ERST0_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_WHEA_HEADER,f,o)
+#define ACPI_HEST0_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_HEST_IA_MACHINE_CHECK,f,o)
+#define ACPI_HEST1_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_HEST_IA_CORRECTED,f,o)
+#define ACPI_HEST6_FLAG_OFFSET(f,o)     ACPI_FLAG_OFFSET (ACPI_HEST_AER_ROOT,f,o)
+
+/*
+ * Required terminator for all tables below
+ */
+#define ACPI_DMT_TERMINATOR             {ACPI_DMT_EXIT, 0, NULL, 0}
+#define ACPI_DMT_NEW_LINE               {ACPI_DMT_EXTRA_TEXT, 0, "\n", 0}
+
+
+/*
+ * ACPI Table Information, used to dump formatted ACPI tables
+ *
+ * Each entry is of the form:  <Field Type, Field Offset, Field Name>
+ */
+
+/*******************************************************************************
+ *
+ * Common ACPI table header
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoHeader[] =
+{
+    {ACPI_DMT_SIG,      ACPI_HDR_OFFSET (Signature[0]),             "Signature", 0},
+    {ACPI_DMT_UINT32,   ACPI_HDR_OFFSET (Length),                   "Table Length", DT_LENGTH},
+    {ACPI_DMT_UINT8,    ACPI_HDR_OFFSET (Revision),                 "Revision", 0},
+    {ACPI_DMT_CHKSUM,   ACPI_HDR_OFFSET (Checksum),                 "Checksum", 0},
+    {ACPI_DMT_NAME6,    ACPI_HDR_OFFSET (OemId[0]),                 "Oem ID", 0},
+    {ACPI_DMT_NAME8,    ACPI_HDR_OFFSET (OemTableId[0]),            "Oem Table ID", 0},
+    {ACPI_DMT_UINT32,   ACPI_HDR_OFFSET (OemRevision),              "Oem Revision", 0},
+    {ACPI_DMT_NAME4,    ACPI_HDR_OFFSET (AslCompilerId[0]),         "Asl Compiler ID", 0},
+    {ACPI_DMT_UINT32,   ACPI_HDR_OFFSET (AslCompilerRevision),      "Asl Compiler Revision", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * GAS - Generic Address Structure
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoGas[] =
+{
+    {ACPI_DMT_SPACEID,  ACPI_GAS_OFFSET (SpaceId),                  "Space ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_GAS_OFFSET (BitWidth),                 "Bit Width", 0},
+    {ACPI_DMT_UINT8,    ACPI_GAS_OFFSET (BitOffset),                "Bit Offset", 0},
+    {ACPI_DMT_ACCWIDTH, ACPI_GAS_OFFSET (AccessWidth),              "Encoded Access Width", 0},
+    {ACPI_DMT_UINT64,   ACPI_GAS_OFFSET (Address),                  "Address", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * RSDP - Root System Description Pointer (Signature is "RSD PTR ")
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoRsdp1[] =
+{
+    {ACPI_DMT_NAME8,    ACPI_RSDP_OFFSET (Signature[0]),            "Signature", 0},
+    {ACPI_DMT_UINT8,    ACPI_RSDP_OFFSET (Checksum),                "Checksum", 0},
+    {ACPI_DMT_NAME6,    ACPI_RSDP_OFFSET (OemId[0]),                "Oem ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_RSDP_OFFSET (Revision),                "Revision", 0},
+    {ACPI_DMT_UINT32,   ACPI_RSDP_OFFSET (RsdtPhysicalAddress),     "RSDT Address", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* ACPI 2.0+ Extensions */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoRsdp2[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_RSDP_OFFSET (Length),                  "Length", DT_LENGTH},
+    {ACPI_DMT_UINT64,   ACPI_RSDP_OFFSET (XsdtPhysicalAddress),     "XSDT Address", 0},
+    {ACPI_DMT_UINT8,    ACPI_RSDP_OFFSET (ExtendedChecksum),        "Extended Checksum", 0},
+    {ACPI_DMT_UINT24,   ACPI_RSDP_OFFSET (Reserved[0]),             "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * FACS - Firmware ACPI Control Structure
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoFacs[] =
+{
+    {ACPI_DMT_NAME4,    ACPI_FACS_OFFSET (Signature[0]),            "Signature", 0},
+    {ACPI_DMT_UINT32,   ACPI_FACS_OFFSET (Length),                  "Length", DT_LENGTH},
+    {ACPI_DMT_UINT32,   ACPI_FACS_OFFSET (HardwareSignature),       "Hardware Signature", 0},
+    {ACPI_DMT_UINT32,   ACPI_FACS_OFFSET (FirmwareWakingVector),    "32 Firmware Waking Vector", 0},
+    {ACPI_DMT_UINT32,   ACPI_FACS_OFFSET (GlobalLock),              "Global Lock", 0},
+    {ACPI_DMT_UINT32,   ACPI_FACS_OFFSET (Flags),                   "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_FACS_FLAG_OFFSET (Flags,0),            "S4BIOS Support Present", 0},
+    {ACPI_DMT_FLAG1,    ACPI_FACS_FLAG_OFFSET (Flags,0),            "64-bit Wake Supported (V2)", 0},
+    {ACPI_DMT_UINT64,   ACPI_FACS_OFFSET (XFirmwareWakingVector),   "64 Firmware Waking Vector", 0},
+    {ACPI_DMT_UINT8,    ACPI_FACS_OFFSET (Version),                 "Version", 0},
+    {ACPI_DMT_UINT24,   ACPI_FACS_OFFSET (Reserved[0]),             "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_FACS_OFFSET (OspmFlags),               "OspmFlags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_FACS_FLAG_OFFSET (OspmFlags,0),        "64-bit Wake Env Required (V2)", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * FADT - Fixed ACPI Description Table (Signature is FACP)
+ *
+ ******************************************************************************/
+
+/* ACPI 1.0 FADT (Version 1) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoFadt1[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_FADT_OFFSET (Facs),                    "FACS Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_FADT_OFFSET (Dsdt),                    "DSDT Address", DT_NON_ZERO},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (Model),                   "Model", 0},
+    {ACPI_DMT_FADTPM,   ACPI_FADT_OFFSET (PreferredProfile),        "PM Profile", 0},
+    {ACPI_DMT_UINT16,   ACPI_FADT_OFFSET (SciInterrupt),            "SCI Interrupt", 0},
+    {ACPI_DMT_UINT32,   ACPI_FADT_OFFSET (SmiCommand),              "SMI Command Port", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (AcpiEnable),              "ACPI Enable Value", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (AcpiDisable),             "ACPI Disable Value", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (S4BiosRequest),           "S4BIOS Command", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (PstateControl),           "P-State Control", 0},
+    {ACPI_DMT_UINT32,   ACPI_FADT_OFFSET (Pm1aEventBlock),          "PM1A Event Block Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_FADT_OFFSET (Pm1bEventBlock),          "PM1B Event Block Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_FADT_OFFSET (Pm1aControlBlock),        "PM1A Control Block Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_FADT_OFFSET (Pm1bControlBlock),        "PM1B Control Block Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_FADT_OFFSET (Pm2ControlBlock),         "PM2 Control Block Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_FADT_OFFSET (PmTimerBlock),            "PM Timer Block Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_FADT_OFFSET (Gpe0Block),               "GPE0 Block Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_FADT_OFFSET (Gpe1Block),               "GPE1 Block Address", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (Pm1EventLength),          "PM1 Event Block Length", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (Pm1ControlLength),        "PM1 Control Block Length", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (Pm2ControlLength),        "PM2 Control Block Length", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (PmTimerLength),           "PM Timer Block Length", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (Gpe0BlockLength),         "GPE0 Block Length", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (Gpe1BlockLength),         "GPE1 Block Length", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (Gpe1Base),                "GPE1 Base Offset", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (CstControl),              "_CST Support", 0},
+    {ACPI_DMT_UINT16,   ACPI_FADT_OFFSET (C2Latency),               "C2 Latency", 0},
+    {ACPI_DMT_UINT16,   ACPI_FADT_OFFSET (C3Latency),               "C3 Latency", 0},
+    {ACPI_DMT_UINT16,   ACPI_FADT_OFFSET (FlushSize),               "CPU Cache Size", 0},
+    {ACPI_DMT_UINT16,   ACPI_FADT_OFFSET (FlushStride),             "Cache Flush Stride", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (DutyOffset),              "Duty Cycle Offset", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (DutyWidth),               "Duty Cycle Width", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (DayAlarm),                "RTC Day Alarm Index", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (MonthAlarm),              "RTC Month Alarm Index", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (Century),                 "RTC Century Index", 0},
+    {ACPI_DMT_UINT16,   ACPI_FADT_OFFSET (BootFlags),               "Boot Flags (decoded below)", DT_FLAG},
+
+    /* Boot Architecture Flags byte 0 */
+
+    {ACPI_DMT_FLAG0,    ACPI_FADT_FLAG_OFFSET (BootFlags,0),        "Legacy Devices Supported (V2)", 0},
+    {ACPI_DMT_FLAG1,    ACPI_FADT_FLAG_OFFSET (BootFlags,0),        "8042 Present on ports 60/64 (V2)", 0},
+    {ACPI_DMT_FLAG2,    ACPI_FADT_FLAG_OFFSET (BootFlags,0),        "VGA Not Present (V4)", 0},
+    {ACPI_DMT_FLAG3,    ACPI_FADT_FLAG_OFFSET (BootFlags,0),        "MSI Not Supported (V4)", 0},
+    {ACPI_DMT_FLAG4,    ACPI_FADT_FLAG_OFFSET (BootFlags,0),        "PCIe ASPM Not Supported (V4)", 0},
+    {ACPI_DMT_FLAG5,    ACPI_FADT_FLAG_OFFSET (BootFlags,0),        "CMOS RTC Not Present (V5)", 0},
+
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (Reserved),                "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_FADT_OFFSET (Flags),                   "Flags (decoded below)", DT_FLAG},
+
+    /* Flags byte 0 */
+
+    {ACPI_DMT_FLAG0,    ACPI_FADT_FLAG_OFFSET (Flags,0),            "WBINVD instruction is operational (V1)", 0},
+    {ACPI_DMT_FLAG1,    ACPI_FADT_FLAG_OFFSET (Flags,0),            "WBINVD flushes all caches (V1)", 0},
+    {ACPI_DMT_FLAG2,    ACPI_FADT_FLAG_OFFSET (Flags,0),            "All CPUs support C1 (V1)", 0},
+    {ACPI_DMT_FLAG3,    ACPI_FADT_FLAG_OFFSET (Flags,0),            "C2 works on MP system (V1)", 0},
+    {ACPI_DMT_FLAG4,    ACPI_FADT_FLAG_OFFSET (Flags,0),            "Control Method Power Button (V1)", 0},
+    {ACPI_DMT_FLAG5,    ACPI_FADT_FLAG_OFFSET (Flags,0),            "Control Method Sleep Button (V1)", 0},
+    {ACPI_DMT_FLAG6,    ACPI_FADT_FLAG_OFFSET (Flags,0),            "RTC wake not in fixed reg space (V1)", 0},
+    {ACPI_DMT_FLAG7,    ACPI_FADT_FLAG_OFFSET (Flags,0),            "RTC can wake system from S4 (V1)", 0},
+
+    /* Flags byte 1 */
+
+    {ACPI_DMT_FLAG0,    ACPI_FADT_FLAG_OFFSET (Flags,1),            "32-bit PM Timer (V1)", 0},
+    {ACPI_DMT_FLAG1,    ACPI_FADT_FLAG_OFFSET (Flags,1),            "Docking Supported (V1)", 0},
+    {ACPI_DMT_FLAG2,    ACPI_FADT_FLAG_OFFSET (Flags,1),            "Reset Register Supported (V2)", 0},
+    {ACPI_DMT_FLAG3,    ACPI_FADT_FLAG_OFFSET (Flags,1),            "Sealed Case (V3)", 0},
+    {ACPI_DMT_FLAG4,    ACPI_FADT_FLAG_OFFSET (Flags,1),            "Headless - No Video (V3)", 0},
+    {ACPI_DMT_FLAG5,    ACPI_FADT_FLAG_OFFSET (Flags,1),            "Use native instr after SLP_TYPx (V3)", 0},
+    {ACPI_DMT_FLAG6,    ACPI_FADT_FLAG_OFFSET (Flags,1),            "PCIEXP_WAK Bits Supported (V4)", 0},
+    {ACPI_DMT_FLAG7,    ACPI_FADT_FLAG_OFFSET (Flags,1),            "Use Platform Timer (V4)", 0},
+
+    /* Flags byte 2 */
+
+    {ACPI_DMT_FLAG0,    ACPI_FADT_FLAG_OFFSET (Flags,2),            "RTC_STS valid on S4 wake (V4)", 0},
+    {ACPI_DMT_FLAG1,    ACPI_FADT_FLAG_OFFSET (Flags,2),            "Remote Power-on capable (V4)", 0},
+    {ACPI_DMT_FLAG2,    ACPI_FADT_FLAG_OFFSET (Flags,2),            "Use APIC Cluster Model (V4)", 0},
+    {ACPI_DMT_FLAG3,    ACPI_FADT_FLAG_OFFSET (Flags,2),            "Use APIC Physical Destination Mode (V4)", 0},
+    {ACPI_DMT_FLAG4,    ACPI_FADT_FLAG_OFFSET (Flags,2),            "Hardware Reduced (V5)", 0},
+    {ACPI_DMT_FLAG5,    ACPI_FADT_FLAG_OFFSET (Flags,2),            "Low Power S0 Idle (V5)", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* ACPI 1.0 MS Extensions (FADT version 2) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoFadt2[] =
+{
+    {ACPI_DMT_GAS,      ACPI_FADT_OFFSET (ResetRegister),           "Reset Register", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (ResetValue),              "Value to cause reset", 0},
+    {ACPI_DMT_UINT16,   ACPI_FADT_OFFSET (ArmBootFlags),            "Reserved", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (MinorRevision),           "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* ACPI 2.0+ Extensions (FADT version 3, 4, and 5) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoFadt3[] =
+{
+    {ACPI_DMT_GAS,      ACPI_FADT_OFFSET (ResetRegister),           "Reset Register", 0},
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (ResetValue),              "Value to cause reset", 0},
+    {ACPI_DMT_UINT16,   ACPI_FADT_OFFSET (ArmBootFlags),            "ARM Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_FADT_FLAG_OFFSET(ArmBootFlags,0),      "PSCI Compliant", 0},
+    {ACPI_DMT_FLAG1,    ACPI_FADT_FLAG_OFFSET(ArmBootFlags,0),      "Must use HVC for PSCI", 0},
+    ACPI_DMT_NEW_LINE,
+    {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (MinorRevision),           "FADT Minor Revision", 0},
+    {ACPI_DMT_UINT64,   ACPI_FADT_OFFSET (XFacs),                   "FACS Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_FADT_OFFSET (XDsdt),                   "DSDT Address", 0},
+    {ACPI_DMT_GAS,      ACPI_FADT_OFFSET (XPm1aEventBlock),         "PM1A Event Block", 0},
+    {ACPI_DMT_GAS,      ACPI_FADT_OFFSET (XPm1bEventBlock),         "PM1B Event Block", 0},
+    {ACPI_DMT_GAS,      ACPI_FADT_OFFSET (XPm1aControlBlock),       "PM1A Control Block", 0},
+    {ACPI_DMT_GAS,      ACPI_FADT_OFFSET (XPm1bControlBlock),       "PM1B Control Block", 0},
+    {ACPI_DMT_GAS,      ACPI_FADT_OFFSET (XPm2ControlBlock),        "PM2 Control Block", 0},
+    {ACPI_DMT_GAS,      ACPI_FADT_OFFSET (XPmTimerBlock),           "PM Timer Block", 0},
+    {ACPI_DMT_GAS,      ACPI_FADT_OFFSET (XGpe0Block),              "GPE0 Block", 0},
+    {ACPI_DMT_GAS,      ACPI_FADT_OFFSET (XGpe1Block),              "GPE1 Block", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* ACPI 5.0 Extensions (FADT version 5) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoFadt5[] =
+{
+    {ACPI_DMT_GAS,      ACPI_FADT_OFFSET (SleepControl),            "Sleep Control Register", 0},
+    {ACPI_DMT_GAS,      ACPI_FADT_OFFSET (SleepStatus),             "Sleep Status Register", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* ACPI 6.0 Extensions (FADT version 6) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoFadt6[] =
+{
+    {ACPI_DMT_UINT64,   ACPI_FADT_OFFSET (HypervisorId),            "Hypervisor ID", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*
+ * Remaining tables are not consumed directly by the ACPICA subsystem
+ */
+
+/*******************************************************************************
+ *
+ * ASF - Alert Standard Format table (Signature "ASF!")
+ *
+ ******************************************************************************/
+
+/* Common Subtable header (one per Subtable) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoAsfHdr[] =
+{
+    {ACPI_DMT_ASF,      ACPI_ASF0_OFFSET (Header.Type),             "Subtable Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF0_OFFSET (Header.Reserved),         "Reserved", 0},
+    {ACPI_DMT_UINT16,   ACPI_ASF0_OFFSET (Header.Length),           "Length", DT_LENGTH},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 0: ASF Information */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoAsf0[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_ASF0_OFFSET (MinResetValue),           "Minimum Reset Value", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF0_OFFSET (MinPollInterval),         "Minimum Polling Interval", 0},
+    {ACPI_DMT_UINT16,   ACPI_ASF0_OFFSET (SystemId),                "System ID", 0},
+    {ACPI_DMT_UINT32,   ACPI_ASF0_OFFSET (MfgId),                   "Manufacturer ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF0_OFFSET (Flags),                   "Flags", 0},
+    {ACPI_DMT_UINT24,   ACPI_ASF0_OFFSET (Reserved2[0]),            "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 1: ASF Alerts */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoAsf1[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_ASF1_OFFSET (AssertMask),              "AssertMask", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF1_OFFSET (DeassertMask),            "DeassertMask", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF1_OFFSET (Alerts),                  "Alert Count", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF1_OFFSET (DataLength),              "Alert Data Length", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 1a: ASF Alert data */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoAsf1a[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_ASF1a_OFFSET (Address),                "Address", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF1a_OFFSET (Command),                "Command", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF1a_OFFSET (Mask),                   "Mask", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF1a_OFFSET (Value),                  "Value", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF1a_OFFSET (SensorType),             "SensorType", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF1a_OFFSET (Type),                   "Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF1a_OFFSET (Offset),                 "Offset", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF1a_OFFSET (SourceType),             "SourceType", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF1a_OFFSET (Severity),               "Severity", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF1a_OFFSET (SensorNumber),           "SensorNumber", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF1a_OFFSET (Entity),                 "Entity", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF1a_OFFSET (Instance),               "Instance", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 2: ASF Remote Control */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoAsf2[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_ASF2_OFFSET (Controls),                "Control Count", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF2_OFFSET (DataLength),              "Control Data Length", 0},
+    {ACPI_DMT_UINT16,   ACPI_ASF2_OFFSET (Reserved2),               "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 2a: ASF Control data */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoAsf2a[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_ASF2a_OFFSET (Function),               "Function", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF2a_OFFSET (Address),                "Address", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF2a_OFFSET (Command),                "Command", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF2a_OFFSET (Value),                  "Value", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 3: ASF RMCP Boot Options */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoAsf3[] =
+{
+    {ACPI_DMT_BUF7,     ACPI_ASF3_OFFSET (Capabilities[0]),         "Capabilities", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF3_OFFSET (CompletionCode),          "Completion Code", 0},
+    {ACPI_DMT_UINT32,   ACPI_ASF3_OFFSET (EnterpriseId),            "Enterprise ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF3_OFFSET (Command),                 "Command", 0},
+    {ACPI_DMT_UINT16,   ACPI_ASF3_OFFSET (Parameter),               "Parameter", 0},
+    {ACPI_DMT_UINT16,   ACPI_ASF3_OFFSET (BootOptions),             "Boot Options", 0},
+    {ACPI_DMT_UINT16,   ACPI_ASF3_OFFSET (OemParameters),           "Oem Parameters", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 4: ASF Address */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoAsf4[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_ASF4_OFFSET (EpromAddress),            "Eprom Address", 0},
+    {ACPI_DMT_UINT8,    ACPI_ASF4_OFFSET (Devices),                 "Device Count", DT_COUNT},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * BERT -  Boot Error Record table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoBert[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_BERT_OFFSET (RegionLength),            "Boot Error Region Length", 0},
+    {ACPI_DMT_UINT64,   ACPI_BERT_OFFSET (Address),                 "Boot Error Region Address", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * BGRT -  Boot Graphics Resource Table (ACPI 5.0)
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoBgrt[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_BGRT_OFFSET (Version),                 "Version", 0},
+    {ACPI_DMT_UINT8,    ACPI_BGRT_OFFSET (Status),                  "Status", 0},
+    {ACPI_DMT_UINT8,    ACPI_BGRT_OFFSET (ImageType),               "Image Type", 0},
+    {ACPI_DMT_UINT64,   ACPI_BGRT_OFFSET (ImageAddress),            "Image Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_BGRT_OFFSET (ImageOffsetX),            "Image OffsetX", 0},
+    {ACPI_DMT_UINT32,   ACPI_BGRT_OFFSET (ImageOffsetY),            "Image OffsetY", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * BOOT - Simple Boot Flag Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoBoot[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_BOOT_OFFSET (CmosIndex),               "Boot Register Index", 0},
+    {ACPI_DMT_UINT24,   ACPI_BOOT_OFFSET (Reserved[0]),             "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * CPEP - Corrected Platform Error Polling table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoCpep[] =
+{
+    {ACPI_DMT_UINT64,   ACPI_CPEP_OFFSET (Reserved),                "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoCpep0[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_CPEP0_OFFSET (Header.Type),            "Subtable Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_CPEP0_OFFSET (Header.Length),          "Length", DT_LENGTH},
+    {ACPI_DMT_UINT8,    ACPI_CPEP0_OFFSET (Id),                     "Processor ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_CPEP0_OFFSET (Eid),                    "Processor EID", 0},
+    {ACPI_DMT_UINT32,   ACPI_CPEP0_OFFSET (Interval),               "Polling Interval", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * CSRT - Core System Resource Table
+ *
+ ******************************************************************************/
+
+/* Main table consists only of the standard ACPI table header */
+
+/* Resource Group subtable */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoCsrt0[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_CSRT0_OFFSET (Length),                 "Length", DT_LENGTH},
+    {ACPI_DMT_UINT32,   ACPI_CSRT0_OFFSET (VendorId),               "Vendor ID", 0},
+    {ACPI_DMT_UINT32,   ACPI_CSRT0_OFFSET (SubvendorId),            "Subvendor ID", 0},
+    {ACPI_DMT_UINT16,   ACPI_CSRT0_OFFSET (DeviceId),               "Device ID", 0},
+    {ACPI_DMT_UINT16,   ACPI_CSRT0_OFFSET (SubdeviceId),            "Subdevice ID", 0},
+    {ACPI_DMT_UINT16,   ACPI_CSRT0_OFFSET (Revision),               "Revision", 0},
+    {ACPI_DMT_UINT16,   ACPI_CSRT0_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_CSRT0_OFFSET (SharedInfoLength),       "Shared Info Length", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* Shared Info subtable */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoCsrt1[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_CSRT1_OFFSET (MajorVersion),           "Major Version", 0},
+    {ACPI_DMT_UINT16,   ACPI_CSRT1_OFFSET (MinorVersion),           "Minor Version", 0},
+    {ACPI_DMT_UINT32,   ACPI_CSRT1_OFFSET (MmioBaseLow),            "MMIO Base Address Low", 0},
+    {ACPI_DMT_UINT32,   ACPI_CSRT1_OFFSET (MmioBaseHigh),           "MMIO Base Address High", 0},
+    {ACPI_DMT_UINT32,   ACPI_CSRT1_OFFSET (GsiInterrupt),           "GSI Interrupt", 0},
+    {ACPI_DMT_UINT8,    ACPI_CSRT1_OFFSET (InterruptPolarity),      "Interrupt Polarity", 0},
+    {ACPI_DMT_UINT8,    ACPI_CSRT1_OFFSET (InterruptMode),          "Interrupt Mode", 0},
+    {ACPI_DMT_UINT8,    ACPI_CSRT1_OFFSET (NumChannels),            "Num Channels", 0},
+    {ACPI_DMT_UINT8,    ACPI_CSRT1_OFFSET (DmaAddressWidth),        "DMA Address Width", 0},
+    {ACPI_DMT_UINT16,   ACPI_CSRT1_OFFSET (BaseRequestLine),        "Base Request Line", 0},
+    {ACPI_DMT_UINT16,   ACPI_CSRT1_OFFSET (NumHandshakeSignals),    "Num Handshake Signals", 0},
+    {ACPI_DMT_UINT32,   ACPI_CSRT1_OFFSET (MaxBlockSize),           "Max Block Size", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/* Resource Descriptor subtable */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoCsrt2[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_CSRT2_OFFSET (Length),                 "Length", DT_LENGTH},
+    {ACPI_DMT_UINT16,   ACPI_CSRT2_OFFSET (Type),                   "Type", 0},
+    {ACPI_DMT_UINT16,   ACPI_CSRT2_OFFSET (Subtype),                "Subtype", 0},
+    {ACPI_DMT_UINT32,   ACPI_CSRT2_OFFSET (Uid),                    "UID", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoCsrt2a[] =
+{
+    {ACPI_DMT_RAW_BUFFER, 0,                                        "ResourceInfo", DT_OPTIONAL},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * DBG2 - Debug Port Table 2
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDbg2[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_DBG2_OFFSET (InfoOffset),              "Info Offset", 0},
+    {ACPI_DMT_UINT32,   ACPI_DBG2_OFFSET (InfoCount),               "Info Count", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* Debug Device Information Subtable */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDbg2Device[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_DBG20_OFFSET (Revision),               "Revision", 0},
+    {ACPI_DMT_UINT16,   ACPI_DBG20_OFFSET (Length),                 "Length", DT_LENGTH},
+    {ACPI_DMT_UINT8,    ACPI_DBG20_OFFSET (RegisterCount),          "Register Count", 0},
+    {ACPI_DMT_UINT16,   ACPI_DBG20_OFFSET (NamepathLength),         "Namepath Length", 0},
+    {ACPI_DMT_UINT16,   ACPI_DBG20_OFFSET (NamepathOffset),         "Namepath Offset", 0},
+    {ACPI_DMT_UINT16,   ACPI_DBG20_OFFSET (OemDataLength),          "OEM Data Length", DT_DESCRIBES_OPTIONAL},
+    {ACPI_DMT_UINT16,   ACPI_DBG20_OFFSET (OemDataOffset),          "OEM Data Offset", DT_DESCRIBES_OPTIONAL},
+    {ACPI_DMT_UINT16,   ACPI_DBG20_OFFSET (PortType),               "Port Type", 0},
+    {ACPI_DMT_UINT16,   ACPI_DBG20_OFFSET (PortSubtype),            "Port Subtype", 0},
+    {ACPI_DMT_UINT16,   ACPI_DBG20_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT16,   ACPI_DBG20_OFFSET (BaseAddressOffset),      "Base Address Offset", 0},
+    {ACPI_DMT_UINT16,   ACPI_DBG20_OFFSET (AddressSizeOffset),      "Address Size Offset", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* Variable-length data for the subtable */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDbg2Addr[] =
+{
+    {ACPI_DMT_GAS,      0,                                          "Base Address Register", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDbg2Size[] =
+{
+    {ACPI_DMT_UINT32,   0,                                          "Address Size", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDbg2Name[] =
+{
+    {ACPI_DMT_STRING,   0,                                          "Namepath", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDbg2OemData[] =
+{
+    {ACPI_DMT_RAW_BUFFER, 0,                                        "OEM Data", DT_OPTIONAL},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * DBGP - Debug Port
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDbgp[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_DBGP_OFFSET (Type),                    "Interface Type", 0},
+    {ACPI_DMT_UINT24,   ACPI_DBGP_OFFSET (Reserved[0]),             "Reserved", 0},
+    {ACPI_DMT_GAS,      ACPI_DBGP_OFFSET (DebugPort),               "Debug Port Register", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * DMAR - DMA Remapping table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDmar[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_DMAR_OFFSET (Width),                   "Host Address Width", 0},
+    {ACPI_DMT_UINT8,    ACPI_DMAR_OFFSET (Flags),                   "Flags", 0},
+    {ACPI_DMT_BUF10,    ACPI_DMAR_OFFSET (Reserved[0]),             "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* Common Subtable header (one per Subtable) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDmarHdr[] =
+{
+    {ACPI_DMT_DMAR,     ACPI_DMAR0_OFFSET (Header.Type),            "Subtable Type", 0},
+    {ACPI_DMT_UINT16,   ACPI_DMAR0_OFFSET (Header.Length),          "Length", DT_LENGTH},
+    ACPI_DMT_TERMINATOR
+};
+
+/* Common device scope entry */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDmarScope[] =
+{
+    {ACPI_DMT_DMAR_SCOPE, ACPI_DMARS_OFFSET (EntryType),            "Device Scope Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_DMARS_OFFSET (Length),                 "Entry Length", DT_LENGTH},
+    {ACPI_DMT_UINT16,   ACPI_DMARS_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT8,    ACPI_DMARS_OFFSET (EnumerationId),          "Enumeration ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_DMARS_OFFSET (Bus),                    "PCI Bus Number", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* DMAR Subtables */
+
+/* 0: Hardware Unit Definition */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDmar0[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_DMAR0_OFFSET (Flags),                  "Flags", 0},
+    {ACPI_DMT_UINT8,    ACPI_DMAR0_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT16,   ACPI_DMAR0_OFFSET (Segment),                "PCI Segment Number", 0},
+    {ACPI_DMT_UINT64,   ACPI_DMAR0_OFFSET (Address),                "Register Base Address", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 1: Reserved Memory Definition */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDmar1[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_DMAR1_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT16,   ACPI_DMAR1_OFFSET (Segment),                "PCI Segment Number", 0},
+    {ACPI_DMT_UINT64,   ACPI_DMAR1_OFFSET (BaseAddress),            "Base Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_DMAR1_OFFSET (EndAddress),             "End Address (limit)", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 2: Root Port ATS Capability Definition */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDmar2[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_DMAR2_OFFSET (Flags),                  "Flags", 0},
+    {ACPI_DMT_UINT8,    ACPI_DMAR2_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT16,   ACPI_DMAR2_OFFSET (Segment),                "PCI Segment Number", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 3: Remapping Hardware Static Affinity Structure */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDmar3[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_DMAR3_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT64,   ACPI_DMAR3_OFFSET (BaseAddress),            "Base Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_DMAR3_OFFSET (ProximityDomain),        "Proximity Domain", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 4: ACPI Namespace Device Declaration Structure */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDmar4[] =
+{
+    {ACPI_DMT_UINT24,   ACPI_DMAR4_OFFSET (Reserved[0]),            "Reserved", 0},
+    {ACPI_DMT_UINT8,    ACPI_DMAR4_OFFSET (DeviceNumber),           "Device Number", 0},
+    {ACPI_DMT_STRING,   ACPI_DMAR4_OFFSET (DeviceName[0]),          "Device Name", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * DRTM - Dynamic Root of Trust for Measurement table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDrtm[] =
+{
+    {ACPI_DMT_UINT64,   ACPI_DRTM_OFFSET (EntryBaseAddress),        "Entry Base Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_DRTM_OFFSET (EntryLength),             "Entry Length", 0},
+    {ACPI_DMT_UINT32,   ACPI_DRTM_OFFSET (EntryAddress32),          "Entry 32", 0},
+    {ACPI_DMT_UINT64,   ACPI_DRTM_OFFSET (EntryAddress64),          "Entry 64", 0},
+    {ACPI_DMT_UINT64,   ACPI_DRTM_OFFSET (ExitAddress),             "Exit Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_DRTM_OFFSET (LogAreaAddress),          "Log Area Start", 0},
+    {ACPI_DMT_UINT32,   ACPI_DRTM_OFFSET (LogAreaLength),           "Log Area Length", 0},
+    {ACPI_DMT_UINT64,   ACPI_DRTM_OFFSET (ArchDependentAddress),    "Arch Dependent Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_DRTM_OFFSET (Flags),                   "Flags (decoded below)", 0},
+    {ACPI_DMT_FLAG0,    ACPI_DRTM_FLAG_OFFSET (Flags, 0),           "Namespace in TCB", 0},
+    {ACPI_DMT_FLAG1,    ACPI_DRTM_FLAG_OFFSET (Flags, 0),           "Gap Code on S3 Resume", 0},
+    {ACPI_DMT_FLAG2,    ACPI_DRTM_FLAG_OFFSET (Flags, 0),           "Gap Code on DLME_Exit", 0},
+    {ACPI_DMT_FLAG3,    ACPI_DRTM_FLAG_OFFSET (Flags, 0),           "PCR_Authorities Changed", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDrtm0[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_DRTM0_OFFSET (ValidatedTableCount),    "Validated Table Count", DT_COUNT},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDrtm0a[] =
+{
+    {ACPI_DMT_UINT64,   0,                                          "Table Address", DT_OPTIONAL},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDrtm1[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_DRTM1_OFFSET (ResourceCount),          "Resource Count", DT_COUNT},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDrtm1a[] =
+{
+    {ACPI_DMT_UINT56,   ACPI_DRTM1a_OFFSET (Size[0]),               "Size", DT_OPTIONAL},
+    {ACPI_DMT_UINT8,    ACPI_DRTM1a_OFFSET (Type),                  "Type", 0},
+    {ACPI_DMT_FLAG0,    ACPI_DRTM1a_FLAG_OFFSET (Type, 0),          "Resource Type", 0},
+    {ACPI_DMT_FLAG7,    ACPI_DRTM1a_FLAG_OFFSET (Type, 0),          "Protections", 0},
+    {ACPI_DMT_UINT64,   ACPI_DRTM1a_OFFSET (Address),               "Address", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoDrtm2[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_DRTM2_OFFSET (DpsIdLength),            "DLME Platform Id Length", DT_COUNT},
+    {ACPI_DMT_BUF16,    ACPI_DRTM2_OFFSET (DpsId),                  "DLME Platform Id", DT_COUNT},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * ECDT - Embedded Controller Boot Resources Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoEcdt[] =
+{
+    {ACPI_DMT_GAS,      ACPI_ECDT_OFFSET (Control),                 "Command/Status Register", 0},
+    {ACPI_DMT_GAS,      ACPI_ECDT_OFFSET (Data),                    "Data Register", 0},
+    {ACPI_DMT_UINT32,   ACPI_ECDT_OFFSET (Uid),                     "UID", 0},
+    {ACPI_DMT_UINT8,    ACPI_ECDT_OFFSET (Gpe),                     "GPE Number", 0},
+    {ACPI_DMT_STRING,   ACPI_ECDT_OFFSET (Id[0]),                   "Namepath", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * EINJ - Error Injection table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoEinj[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_EINJ_OFFSET (HeaderLength),            "Injection Header Length", 0},
+    {ACPI_DMT_UINT8,    ACPI_EINJ_OFFSET (Flags),                   "Flags", 0},
+    {ACPI_DMT_UINT24,   ACPI_EINJ_OFFSET (Reserved[0]),             "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_EINJ_OFFSET (Entries),                 "Injection Entry Count", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoEinj0[] =
+{
+    {ACPI_DMT_EINJACT,  ACPI_EINJ0_OFFSET (Action),                 "Action", 0},
+    {ACPI_DMT_EINJINST, ACPI_EINJ0_OFFSET (Instruction),            "Instruction", 0},
+    {ACPI_DMT_UINT8,    ACPI_EINJ0_OFFSET (Flags),                  "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_EINJ0_FLAG_OFFSET (Flags,0),           "Preserve Register Bits", 0},
+
+    {ACPI_DMT_UINT8,    ACPI_EINJ0_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_GAS,      ACPI_EINJ0_OFFSET (RegisterRegion),         "Register Region", 0},
+    {ACPI_DMT_UINT64,   ACPI_EINJ0_OFFSET (Value),                  "Value", 0},
+    {ACPI_DMT_UINT64,   ACPI_EINJ0_OFFSET (Mask),                   "Mask", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * ERST - Error Record Serialization table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoErst[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_ERST_OFFSET (HeaderLength),            "Serialization Header Length", 0},
+    {ACPI_DMT_UINT32,   ACPI_ERST_OFFSET (Reserved),                "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_ERST_OFFSET (Entries),                 "Instruction Entry Count", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoErst0[] =
+{
+    {ACPI_DMT_ERSTACT,  ACPI_ERST0_OFFSET (Action),                 "Action", 0},
+    {ACPI_DMT_ERSTINST, ACPI_ERST0_OFFSET (Instruction),            "Instruction", 0},
+    {ACPI_DMT_UINT8,    ACPI_ERST0_OFFSET (Flags),                  "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_ERST0_FLAG_OFFSET (Flags,0),           "Preserve Register Bits", 0},
+
+    {ACPI_DMT_UINT8,    ACPI_ERST0_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_GAS,      ACPI_ERST0_OFFSET (RegisterRegion),         "Register Region", 0},
+    {ACPI_DMT_UINT64,   ACPI_ERST0_OFFSET (Value),                  "Value", 0},
+    {ACPI_DMT_UINT64,   ACPI_ERST0_OFFSET (Mask),                   "Mask", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * FPDT - Firmware Performance Data Table (ACPI 5.0)
+ *
+ ******************************************************************************/
+
+/* Main table consists of only the standard ACPI header - subtables follow */
+
+/* FPDT subtable header */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoFpdtHdr[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_FPDTH_OFFSET (Type),                   "Subtable Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_FPDTH_OFFSET (Length),                 "Length", DT_LENGTH},
+    {ACPI_DMT_UINT8,    ACPI_FPDTH_OFFSET (Revision),               "Revision", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 0: Firmware Basic Boot Performance Record */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoFpdt0[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_FPDT0_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT64,   ACPI_FPDT1_OFFSET (Address),                "FPDT Boot Record Address", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 1: S3 Performance Table Pointer Record */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoFpdt1[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_FPDT1_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT64,   ACPI_FPDT1_OFFSET (Address),                "S3PT Record Address", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+#if 0
+    /* Boot Performance Record, not supported at this time. */
+    {ACPI_DMT_UINT64,   ACPI_FPDT0_OFFSET (ResetEnd),               "Reset End", 0},
+    {ACPI_DMT_UINT64,   ACPI_FPDT0_OFFSET (LoadStart),              "Load Image Start", 0},
+    {ACPI_DMT_UINT64,   ACPI_FPDT0_OFFSET (StartupStart),           "Start Image Start", 0},
+    {ACPI_DMT_UINT64,   ACPI_FPDT0_OFFSET (ExitServicesEntry),      "Exit Services Entry", 0},
+    {ACPI_DMT_UINT64,   ACPI_FPDT0_OFFSET (ExitServicesExit),       "Exit Services Exit", 0},
+#endif
+
+/*******************************************************************************
+ *
+ * GTDT - Generic Timer Description Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoGtdt[] =
+{
+    {ACPI_DMT_UINT64,   ACPI_GTDT_OFFSET (CounterBlockAddresss),    "Counter Block Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_GTDT_OFFSET (Reserved),                "Reserved", 0},
+    ACPI_DMT_NEW_LINE,
+    {ACPI_DMT_UINT32,   ACPI_GTDT_OFFSET (SecureEl1Interrupt),      "Secure EL1 Interrupt", 0},
+    {ACPI_DMT_UINT32,   ACPI_GTDT_OFFSET (SecureEl1Flags),          "EL1 Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_GTDT_FLAG_OFFSET (SecureEl1Flags,0),   "Trigger Mode", 0},
+    {ACPI_DMT_FLAG1,    ACPI_GTDT_FLAG_OFFSET (SecureEl1Flags,0),   "Polarity", 0},
+    {ACPI_DMT_FLAG2,    ACPI_GTDT_FLAG_OFFSET (SecureEl1Flags,0),   "Always On", 0},
+    ACPI_DMT_NEW_LINE,
+    {ACPI_DMT_UINT32,   ACPI_GTDT_OFFSET (NonSecureEl1Interrupt),   "Non-Secure EL1 Interrupt", 0},
+    {ACPI_DMT_UINT32,   ACPI_GTDT_OFFSET (NonSecureEl1Flags),       "NEL1 Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_GTDT_FLAG_OFFSET (NonSecureEl1Flags,0),"Trigger Mode", 0},
+    {ACPI_DMT_FLAG1,    ACPI_GTDT_FLAG_OFFSET (NonSecureEl1Flags,0),"Polarity", 0},
+    {ACPI_DMT_FLAG2,    ACPI_GTDT_FLAG_OFFSET (NonSecureEl1Flags,0),"Always On", 0},
+    ACPI_DMT_NEW_LINE,
+    {ACPI_DMT_UINT32,   ACPI_GTDT_OFFSET (VirtualTimerInterrupt),   "Virtual Timer Interrupt", 0},
+    {ACPI_DMT_UINT32,   ACPI_GTDT_OFFSET (VirtualTimerFlags),       "VT Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_GTDT_FLAG_OFFSET (VirtualTimerFlags,0),"Trigger Mode", 0},
+    {ACPI_DMT_FLAG1,    ACPI_GTDT_FLAG_OFFSET (VirtualTimerFlags,0),"Polarity", 0},
+    {ACPI_DMT_FLAG2,    ACPI_GTDT_FLAG_OFFSET (VirtualTimerFlags,0),"Always On", 0},
+    ACPI_DMT_NEW_LINE,
+    {ACPI_DMT_UINT32,   ACPI_GTDT_OFFSET (NonSecureEl2Interrupt),   "Non-Secure EL2 Interrupt", 0},
+    {ACPI_DMT_UINT32,   ACPI_GTDT_OFFSET (NonSecureEl2Flags),       "NEL2 Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_GTDT_FLAG_OFFSET (NonSecureEl2Flags,0),"Trigger Mode", 0},
+    {ACPI_DMT_FLAG1,    ACPI_GTDT_FLAG_OFFSET (NonSecureEl2Flags,0),"Polarity", 0},
+    {ACPI_DMT_FLAG2,    ACPI_GTDT_FLAG_OFFSET (NonSecureEl2Flags,0),"Always On", 0},
+    {ACPI_DMT_UINT64,   ACPI_GTDT_OFFSET (CounterReadBlockAddress), "Counter Read Block Address", 0},
+    ACPI_DMT_NEW_LINE,
+    {ACPI_DMT_UINT32,   ACPI_GTDT_OFFSET (PlatformTimerCount),      "Platform Timer Count", 0},
+    {ACPI_DMT_UINT32,   ACPI_GTDT_OFFSET (PlatformTimerOffset),     "Platform Timer Offset", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* GTDT Subtable header (one per Subtable) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoGtdtHdr[] =
+{
+    {ACPI_DMT_GTDT,     ACPI_GTDTH_OFFSET (Type),                   "Subtable Type", 0},
+    {ACPI_DMT_UINT16,   ACPI_GTDTH_OFFSET (Length),                 "Length", DT_LENGTH},
+    ACPI_DMT_TERMINATOR
+};
+
+/* GTDT Subtables */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoGtdt0[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_GTDT0_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT64,   ACPI_GTDT0_OFFSET (BlockAddress),           "Block Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_GTDT0_OFFSET (TimerCount),             "Timer Count", 0},
+    {ACPI_DMT_UINT32,   ACPI_GTDT0_OFFSET (TimerOffset),            "Timer Offset", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoGtdt0a[] =
+{
+    {ACPI_DMT_UINT8 ,   ACPI_GTDT0a_OFFSET (FrameNumber),               "Frame Number", 0},
+    {ACPI_DMT_UINT24,   ACPI_GTDT0a_OFFSET (Reserved[0]),               "Reserved", 0},
+    {ACPI_DMT_UINT64,   ACPI_GTDT0a_OFFSET (BaseAddress),               "Base Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_GTDT0a_OFFSET (El0BaseAddress),            "EL0 Base Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_GTDT0a_OFFSET (TimerInterrupt),            "Timer Interrupt", 0},
+    {ACPI_DMT_UINT32,   ACPI_GTDT0a_OFFSET (TimerFlags),                "Timer Flags (decoded below)", 0},
+    {ACPI_DMT_FLAG0,    ACPI_GTDT0a_FLAG_OFFSET (TimerFlags,0),         "Trigger Mode", 0},
+    {ACPI_DMT_FLAG1,    ACPI_GTDT0a_FLAG_OFFSET (TimerFlags,0),         "Polarity", 0},
+    {ACPI_DMT_UINT32,   ACPI_GTDT0a_OFFSET (VirtualTimerInterrupt),     "Virtual Timer Interrupt", 0},
+    {ACPI_DMT_UINT32,   ACPI_GTDT0a_OFFSET (VirtualTimerFlags),         "Virtual Timer Flags (decoded below)", 0},
+    {ACPI_DMT_FLAG0,    ACPI_GTDT0a_FLAG_OFFSET (VirtualTimerFlags,0),  "Trigger Mode", 0},
+    {ACPI_DMT_FLAG1,    ACPI_GTDT0a_FLAG_OFFSET (VirtualTimerFlags,0),  "Polarity", 0},
+    {ACPI_DMT_UINT32,   ACPI_GTDT0a_OFFSET (CommonFlags),               "Common Flags (decoded below)", 0},
+    {ACPI_DMT_FLAG0,    ACPI_GTDT0a_FLAG_OFFSET (CommonFlags,0),        "Secure", 0},
+    {ACPI_DMT_FLAG1,    ACPI_GTDT0a_FLAG_OFFSET (CommonFlags,0),        "Always On", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoGtdt1[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_GTDT1_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT64,   ACPI_GTDT1_OFFSET (RefreshFrameAddress),    "Refresh Frame Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_GTDT1_OFFSET (ControlFrameAddress),    "Control Frame Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_GTDT1_OFFSET (TimerInterrupt),         "Timer Interrupt", 0},
+    {ACPI_DMT_UINT32,   ACPI_GTDT1_OFFSET (TimerFlags),             "Timer Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_GTDT1_FLAG_OFFSET (TimerFlags,0),      "Trigger Mode", 0},
+    {ACPI_DMT_FLAG1,    ACPI_GTDT1_FLAG_OFFSET (TimerFlags,0),      "Polarity", 0},
+    {ACPI_DMT_FLAG2,    ACPI_GTDT1_FLAG_OFFSET (TimerFlags,0),      "Security", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * HEST - Hardware Error Source table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoHest[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_HEST_OFFSET (ErrorSourceCount),        "Error Source Count", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* Common HEST structures for subtables */
+
+#define ACPI_DM_HEST_HEADER \
+    {ACPI_DMT_HEST,     ACPI_HEST0_OFFSET (Header.Type),            "Subtable Type", 0}, \
+    {ACPI_DMT_UINT16,   ACPI_HEST0_OFFSET (Header.SourceId),        "Source Id", 0}
+
+#define ACPI_DM_HEST_AER \
+    {ACPI_DMT_UINT16,   ACPI_HEST6_OFFSET (Aer.Reserved1),              "Reserved", 0}, \
+    {ACPI_DMT_UINT8,    ACPI_HEST6_OFFSET (Aer.Flags),                  "Flags (decoded below)", DT_FLAG}, \
+    {ACPI_DMT_FLAG0,    ACPI_HEST6_FLAG_OFFSET (Aer.Flags,0),           "Firmware First", 0}, \
+    {ACPI_DMT_UINT8,    ACPI_HEST6_OFFSET (Aer.Enabled),                "Enabled", 0}, \
+    {ACPI_DMT_UINT32,   ACPI_HEST6_OFFSET (Aer.RecordsToPreallocate),   "Records To Preallocate", 0}, \
+    {ACPI_DMT_UINT32,   ACPI_HEST6_OFFSET (Aer.MaxSectionsPerRecord),   "Max Sections Per Record", 0}, \
+    {ACPI_DMT_UINT32,   ACPI_HEST6_OFFSET (Aer.Bus),                    "Bus", 0}, \
+    {ACPI_DMT_UINT16,   ACPI_HEST6_OFFSET (Aer.Device),                 "Device", 0}, \
+    {ACPI_DMT_UINT16,   ACPI_HEST6_OFFSET (Aer.Function),               "Function", 0}, \
+    {ACPI_DMT_UINT16,   ACPI_HEST6_OFFSET (Aer.DeviceControl),          "DeviceControl", 0}, \
+    {ACPI_DMT_UINT16,   ACPI_HEST6_OFFSET (Aer.Reserved2),              "Reserved", 0}, \
+    {ACPI_DMT_UINT32,   ACPI_HEST6_OFFSET (Aer.UncorrectableMask),      "Uncorrectable Mask", 0}, \
+    {ACPI_DMT_UINT32,   ACPI_HEST6_OFFSET (Aer.UncorrectableSeverity),  "Uncorrectable Severity", 0}, \
+    {ACPI_DMT_UINT32,   ACPI_HEST6_OFFSET (Aer.CorrectableMask),        "Correctable Mask", 0}, \
+    {ACPI_DMT_UINT32,   ACPI_HEST6_OFFSET (Aer.AdvancedCapabilities),   "Advanced Capabilities", 0}
+
+
+/* HEST Subtables */
+
+/* 0: IA32 Machine Check Exception */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoHest0[] =
+{
+    ACPI_DM_HEST_HEADER,
+    {ACPI_DMT_UINT16,   ACPI_HEST0_OFFSET (Reserved1),              "Reserved1", 0},
+    {ACPI_DMT_UINT8,    ACPI_HEST0_OFFSET (Flags),                  "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_HEST0_FLAG_OFFSET (Flags,0),           "Firmware First", 0},
+
+    {ACPI_DMT_UINT8,    ACPI_HEST0_OFFSET (Enabled),                "Enabled", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST0_OFFSET (RecordsToPreallocate),   "Records To Preallocate", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST0_OFFSET (MaxSectionsPerRecord),   "Max Sections Per Record", 0},
+    {ACPI_DMT_UINT64,   ACPI_HEST0_OFFSET (GlobalCapabilityData),   "Global Capability Data", 0},
+    {ACPI_DMT_UINT64,   ACPI_HEST0_OFFSET (GlobalControlData),      "Global Control Data", 0},
+    {ACPI_DMT_UINT8,    ACPI_HEST0_OFFSET (NumHardwareBanks),       "Num Hardware Banks", 0},
+    {ACPI_DMT_UINT56,   ACPI_HEST0_OFFSET (Reserved3[0]),           "Reserved2", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 1: IA32 Corrected Machine Check */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoHest1[] =
+{
+    ACPI_DM_HEST_HEADER,
+    {ACPI_DMT_UINT16,   ACPI_HEST1_OFFSET (Reserved1),              "Reserved1", 0},
+    {ACPI_DMT_UINT8,    ACPI_HEST1_OFFSET (Flags),                  "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_HEST1_FLAG_OFFSET (Flags,0),           "Firmware First", 0},
+
+    {ACPI_DMT_UINT8,    ACPI_HEST1_OFFSET (Enabled),                "Enabled", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST1_OFFSET (RecordsToPreallocate),   "Records To Preallocate", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST1_OFFSET (MaxSectionsPerRecord),   "Max Sections Per Record", 0},
+    {ACPI_DMT_HESTNTFY, ACPI_HEST1_OFFSET (Notify),                 "Notify", 0},
+    {ACPI_DMT_UINT8,    ACPI_HEST1_OFFSET (NumHardwareBanks),       "Num Hardware Banks", 0},
+    {ACPI_DMT_UINT24,   ACPI_HEST1_OFFSET (Reserved2[0]),           "Reserved2", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 2: IA32 Non-Maskable Interrupt */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoHest2[] =
+{
+    ACPI_DM_HEST_HEADER,
+    {ACPI_DMT_UINT32,   ACPI_HEST2_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST2_OFFSET (RecordsToPreallocate),   "Records To Preallocate", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST2_OFFSET (MaxSectionsPerRecord),   "Max Sections Per Record", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST2_OFFSET (MaxRawDataLength),       "Max Raw Data Length", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 6: PCI Express Root Port AER */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoHest6[] =
+{
+    ACPI_DM_HEST_HEADER,
+    ACPI_DM_HEST_AER,
+    {ACPI_DMT_UINT32,   ACPI_HEST6_OFFSET (RootErrorCommand),       "Root Error Command", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 7: PCI Express AER (AER Endpoint) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoHest7[] =
+{
+    ACPI_DM_HEST_HEADER,
+    ACPI_DM_HEST_AER,
+    ACPI_DMT_TERMINATOR
+};
+
+/* 8: PCI Express/PCI-X Bridge AER */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoHest8[] =
+{
+    ACPI_DM_HEST_HEADER,
+    ACPI_DM_HEST_AER,
+    {ACPI_DMT_UINT32,   ACPI_HEST8_OFFSET (UncorrectableMask2),     "2nd Uncorrectable Mask", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST8_OFFSET (UncorrectableSeverity2), "2nd Uncorrectable Severity", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST8_OFFSET (AdvancedCapabilities2),  "2nd Advanced Capabilities", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 9: Generic Hardware Error Source */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoHest9[] =
+{
+    ACPI_DM_HEST_HEADER,
+    {ACPI_DMT_UINT16,   ACPI_HEST9_OFFSET (RelatedSourceId),        "Related Source Id", 0},
+    {ACPI_DMT_UINT8,    ACPI_HEST9_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT8,    ACPI_HEST9_OFFSET (Enabled),                "Enabled", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST9_OFFSET (RecordsToPreallocate),   "Records To Preallocate", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST9_OFFSET (MaxSectionsPerRecord),   "Max Sections Per Record", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST9_OFFSET (MaxRawDataLength),       "Max Raw Data Length", 0},
+    {ACPI_DMT_GAS,      ACPI_HEST9_OFFSET (ErrorStatusAddress),     "Error Status Address", 0},
+    {ACPI_DMT_HESTNTFY, ACPI_HEST9_OFFSET (Notify),                 "Notify", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST9_OFFSET (ErrorBlockLength),       "Error Status Block Length", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 10: Generic Hardware Error Source - Version 2 */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoHest10[] =
+{
+    ACPI_DM_HEST_HEADER,
+    {ACPI_DMT_UINT16,   ACPI_HEST10_OFFSET (RelatedSourceId),       "Related Source Id", 0},
+    {ACPI_DMT_UINT8,    ACPI_HEST10_OFFSET (Reserved),              "Reserved", 0},
+    {ACPI_DMT_UINT8,    ACPI_HEST10_OFFSET (Enabled),               "Enabled", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST10_OFFSET (RecordsToPreallocate),  "Records To Preallocate", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST10_OFFSET (MaxSectionsPerRecord),  "Max Sections Per Record", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST10_OFFSET (MaxRawDataLength),      "Max Raw Data Length", 0},
+    {ACPI_DMT_GAS,      ACPI_HEST10_OFFSET (ErrorStatusAddress),    "Error Status Address", 0},
+    {ACPI_DMT_HESTNTFY, ACPI_HEST10_OFFSET (Notify),                "Notify", 0},
+    {ACPI_DMT_UINT32,   ACPI_HEST10_OFFSET (ErrorBlockLength),      "Error Status Block Length", 0},
+    {ACPI_DMT_GAS,      ACPI_HEST10_OFFSET (ReadAckRegister),       "Read Ack Register", 0},
+    {ACPI_DMT_UINT64,   ACPI_HEST10_OFFSET (ReadAckPreserve),       "Read Ack Preserve", 0},
+    {ACPI_DMT_UINT64,   ACPI_HEST10_OFFSET (ReadAckWrite),          "Read Ack Write", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoHestNotify[] =
+{
+    {ACPI_DMT_HESTNTYP, ACPI_HESTN_OFFSET (Type),                   "Notify Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_HESTN_OFFSET (Length),                 "Notify Length", DT_LENGTH},
+    {ACPI_DMT_UINT16,   ACPI_HESTN_OFFSET (ConfigWriteEnable),      "Configuration Write Enable", 0},
+    {ACPI_DMT_UINT32,   ACPI_HESTN_OFFSET (PollInterval),           "PollInterval", 0},
+    {ACPI_DMT_UINT32,   ACPI_HESTN_OFFSET (Vector),                 "Vector", 0},
+    {ACPI_DMT_UINT32,   ACPI_HESTN_OFFSET (PollingThresholdValue),  "Polling Threshold Value", 0},
+    {ACPI_DMT_UINT32,   ACPI_HESTN_OFFSET (PollingThresholdWindow), "Polling Threshold Window", 0},
+    {ACPI_DMT_UINT32,   ACPI_HESTN_OFFSET (ErrorThresholdValue),    "Error Threshold Value", 0},
+    {ACPI_DMT_UINT32,   ACPI_HESTN_OFFSET (ErrorThresholdWindow),   "Error Threshold Window", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*
+ * IA32 Error Bank(s) - Follows the ACPI_HEST_IA_MACHINE_CHECK and
+ * ACPI_HEST_IA_CORRECTED structures.
+ */
+ACPI_DMTABLE_INFO           AcpiDmTableInfoHestBank[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_HESTB_OFFSET (BankNumber),             "Bank Number", 0},
+    {ACPI_DMT_UINT8,    ACPI_HESTB_OFFSET (ClearStatusOnInit),      "Clear Status On Init", 0},
+    {ACPI_DMT_UINT8,    ACPI_HESTB_OFFSET (StatusFormat),           "Status Format", 0},
+    {ACPI_DMT_UINT8,    ACPI_HESTB_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_HESTB_OFFSET (ControlRegister),        "Control Register", 0},
+    {ACPI_DMT_UINT64,   ACPI_HESTB_OFFSET (ControlData),            "Control Data", 0},
+    {ACPI_DMT_UINT32,   ACPI_HESTB_OFFSET (StatusRegister),         "Status Register", 0},
+    {ACPI_DMT_UINT32,   ACPI_HESTB_OFFSET (AddressRegister),        "Address Register", 0},
+    {ACPI_DMT_UINT32,   ACPI_HESTB_OFFSET (MiscRegister),           "Misc Register", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * HPET - High Precision Event Timer table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoHpet[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_HPET_OFFSET (Id),                      "Hardware Block ID", 0},
+    {ACPI_DMT_GAS,      ACPI_HPET_OFFSET (Address),                 "Timer Block Register", 0},
+    {ACPI_DMT_UINT8,    ACPI_HPET_OFFSET (Sequence),                "Sequence Number", 0},
+    {ACPI_DMT_UINT16,   ACPI_HPET_OFFSET (MinimumTick),             "Minimum Clock Ticks", 0},
+    {ACPI_DMT_UINT8,    ACPI_HPET_OFFSET (Flags),                   "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_HPET_FLAG_OFFSET (Flags,0),            "4K Page Protect", 0},
+    {ACPI_DMT_FLAG1,    ACPI_HPET_FLAG_OFFSET (Flags,0),            "64K Page Protect", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * IORT - IO Remapping Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIort[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_IORT_OFFSET (NodeCount),               "Node Count", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT_OFFSET (NodeOffset),              "Node Offset", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT_OFFSET (Reserved),                "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* Optional padding field */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIortPad[] =
+{
+    {ACPI_DMT_RAW_BUFFER, 0,                                        "Optional Padding", DT_OPTIONAL},
+    ACPI_DMT_TERMINATOR
+};
+
+/* Common Subtable header (one per Subtable) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIortHdr[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_IORTH_OFFSET (Type),                   "Type", 0},
+    {ACPI_DMT_UINT16,   ACPI_IORTH_OFFSET (Length),                 "Length", DT_LENGTH},
+    {ACPI_DMT_UINT8,    ACPI_IORTH_OFFSET (Revision),               "Revision", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORTH_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORTH_OFFSET (MappingCount),           "Mapping Count", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORTH_OFFSET (MappingOffset),          "Mapping Offset", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIortMap[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_IORTM_OFFSET (InputBase),              "Input base", DT_OPTIONAL},
+    {ACPI_DMT_UINT32,   ACPI_IORTM_OFFSET (IdCount),                "ID Count", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORTM_OFFSET (OutputBase),             "Output Base", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORTM_OFFSET (OutputReference),        "Output Reference", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORTM_OFFSET (Flags),                  "Flags (decoded below)", 0},
+    {ACPI_DMT_FLAG0,    ACPI_IORTM_FLAG_OFFSET (Flags, 0),          "Single Mapping", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIortAcc[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_IORTA_OFFSET (CacheCoherency),         "Cache Coherency", 0},
+    {ACPI_DMT_UINT8,    ACPI_IORTA_OFFSET (Hints),                  "Hints (decoded below)", 0},
+    {ACPI_DMT_FLAG0,    ACPI_IORTA_FLAG_OFFSET (Hints, 0),          "Transient", 0},
+    {ACPI_DMT_FLAG1,    ACPI_IORTA_FLAG_OFFSET (Hints, 0),          "Write Allocate", 0},
+    {ACPI_DMT_FLAG2,    ACPI_IORTA_FLAG_OFFSET (Hints, 0),          "Read Allocate", 0},
+    {ACPI_DMT_FLAG3,    ACPI_IORTA_FLAG_OFFSET (Hints, 0),          "Override", 0},
+    {ACPI_DMT_UINT16,   ACPI_IORTA_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT8,    ACPI_IORTA_OFFSET (MemoryFlags),            "Memory Flags (decoded below)", 0},
+    {ACPI_DMT_FLAG0,    ACPI_IORTA_FLAG_OFFSET (MemoryFlags, 0),    "Coherency", 0},
+    {ACPI_DMT_FLAG1,    ACPI_IORTA_FLAG_OFFSET (MemoryFlags, 0),    "Device Attribute", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* IORT subtables */
+
+/* 0x00: ITS Group */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIort0[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_IORT0_OFFSET (ItsCount),               "ItsCount", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIort0a[] =
+{
+    {ACPI_DMT_UINT32,   0,                                          "Identifiers", DT_OPTIONAL},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 0x01: Named Component */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIort1[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_IORT1_OFFSET (NodeFlags),              "Node Flags", 0},
+    {ACPI_DMT_IORTMEM,  ACPI_IORT1_OFFSET (MemoryProperties),       "Memory Properties", 0},
+    {ACPI_DMT_UINT8,    ACPI_IORT1_OFFSET (MemoryAddressLimit),     "Memory Size Limit", 0},
+    {ACPI_DMT_STRING,   ACPI_IORT1_OFFSET (DeviceName[0]),          "Device Name", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIort1a[] =
+{
+    {ACPI_DMT_RAW_BUFFER, 0,                                        "Padding", DT_OPTIONAL},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 0x02: PCI Root Complex */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIort2[] =
+{
+    {ACPI_DMT_IORTMEM,  ACPI_IORT2_OFFSET (MemoryProperties),       "Memory Properties", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT2_OFFSET (AtsAttribute),           "ATS Attribute", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT2_OFFSET (PciSegmentNumber),       "PCI Segment Number", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 0x03: SMMUv1/2 */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIort3[] =
+{
+    {ACPI_DMT_UINT64,   ACPI_IORT3_OFFSET (BaseAddress),            "Base Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_IORT3_OFFSET (Span),                   "Span", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT3_OFFSET (Model),                  "Model", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT3_OFFSET (Flags),                  "Flags (decoded below)", 0},
+    {ACPI_DMT_FLAG0,    ACPI_IORT3_FLAG_OFFSET (Flags, 0),          "DVM Supported", 0},
+    {ACPI_DMT_FLAG1,    ACPI_IORT3_FLAG_OFFSET (Flags, 0),          "Coherent Walk", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT3_OFFSET (GlobalInterruptOffset),  "Global Interrupt Offset", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT3_OFFSET (ContextInterruptCount),  "Context Interrupt Count", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT3_OFFSET (ContextInterruptOffset), "Context Interrupt Offset", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT3_OFFSET (PmuInterruptCount),      "PMU Interrupt Count", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT3_OFFSET (PmuInterruptOffset),     "PMU Interrupt Offset", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIort3a[] =
+{
+    {ACPI_DMT_UINT64,   0,                                          "SMMU_NSgIrpt Interrupt", 0},
+    {ACPI_DMT_UINT64,   0,                                          "SMMU_NSgCfgIrpt Interrupt", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIort3b[] =
+{
+    {ACPI_DMT_UINT64,   0,                                          "Context Interrupt", DT_OPTIONAL},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIort3c[] =
+{
+    {ACPI_DMT_UINT64,   0,                                          "PMU Interrupt", DT_OPTIONAL},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 0x04: SMMUv3 */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIort4[] =
+{
+    {ACPI_DMT_UINT64,   ACPI_IORT4_OFFSET (BaseAddress),            "Base Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT4_OFFSET (Flags),                  "Flags (decoded below)", 0},
+    {ACPI_DMT_FLAG0,    ACPI_IORT4_FLAG_OFFSET (Flags, 0),          "COHACC Override", 0},
+    {ACPI_DMT_FLAG1,    ACPI_IORT4_FLAG_OFFSET (Flags, 0),          "HTTU Override", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT4_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT64,   ACPI_IORT4_OFFSET (VatosAddress),           "VATOS Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT4_OFFSET (Model),                  "Model", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT4_OFFSET (EventGsiv),              "Event GSIV", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT4_OFFSET (PriGsiv),                "PRI GSIV", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT4_OFFSET (GerrGsiv),               "GERR GSIV", 0},
+    {ACPI_DMT_UINT32,   ACPI_IORT4_OFFSET (SyncGsiv),               "Sync GSIV", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/*******************************************************************************
+ *
+ * IVRS - I/O Virtualization Reporting Structure
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIvrs[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_IVRS_OFFSET (Info),                    "Virtualization Info", 0},
+    {ACPI_DMT_UINT64,   ACPI_IVRS_OFFSET (Reserved),                "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* Common Subtable header (one per Subtable) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIvrsHdr[] =
+{
+    {ACPI_DMT_IVRS,     ACPI_IVRSH_OFFSET (Type),                   "Subtable Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_IVRSH_OFFSET (Flags),                  "Flags", 0},
+    {ACPI_DMT_UINT16,   ACPI_IVRSH_OFFSET (Length),                 "Length", DT_LENGTH},
+    {ACPI_DMT_UINT16,   ACPI_IVRSH_OFFSET (DeviceId),               "DeviceId", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* IVRS subtables */
+
+/* 0x10: I/O Virtualization Hardware Definition (IVHD) Block */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIvrs0[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_IVRS0_OFFSET (CapabilityOffset),       "Capability Offset", 0},
+    {ACPI_DMT_UINT64,   ACPI_IVRS0_OFFSET (BaseAddress),            "Base Address", 0},
+    {ACPI_DMT_UINT16,   ACPI_IVRS0_OFFSET (PciSegmentGroup),        "PCI Segment Group", 0},
+    {ACPI_DMT_UINT16,   ACPI_IVRS0_OFFSET (Info),                   "Virtualization Info", 0},
+    {ACPI_DMT_UINT32,   ACPI_IVRS0_OFFSET (Reserved),               "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 0x20, 0x21, 0x22: I/O Virtualization Memory Definition (IVMD) Block */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIvrs1[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_IVRS1_OFFSET (AuxData),                "Auxiliary Data", 0},
+    {ACPI_DMT_UINT64,   ACPI_IVRS1_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT64,   ACPI_IVRS1_OFFSET (StartAddress),           "Start Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_IVRS1_OFFSET (MemoryLength),           "Memory Length", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* Device entry header for IVHD block */
+
+#define ACPI_DMT_IVRS_DE_HEADER \
+    {ACPI_DMT_UINT8,    ACPI_IVRSD_OFFSET (Type),                   "Entry Type", 0}, \
+    {ACPI_DMT_UINT16,   ACPI_IVRSD_OFFSET (Id),                     "Device ID", 0}, \
+    {ACPI_DMT_UINT8,    ACPI_IVRSD_OFFSET (DataSetting),            "Data Setting", 0}
+
+/* 4-byte device entry */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIvrs4[] =
+{
+    ACPI_DMT_IVRS_DE_HEADER,
+    {ACPI_DMT_EXIT,     0,                                          NULL, 0},
+};
+
+/* 8-byte device entry */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIvrs8a[] =
+{
+    ACPI_DMT_IVRS_DE_HEADER,
+    {ACPI_DMT_UINT8,    ACPI_IVRS8A_OFFSET (Reserved1),             "Reserved", 0},
+    {ACPI_DMT_UINT16,   ACPI_IVRS8A_OFFSET (UsedId),                "Source Used Device ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_IVRS8A_OFFSET (Reserved2),             "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 8-byte device entry */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIvrs8b[] =
+{
+    ACPI_DMT_IVRS_DE_HEADER,
+    {ACPI_DMT_UINT32,   ACPI_IVRS8B_OFFSET (ExtendedData),          "Extended Data", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 8-byte device entry */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoIvrs8c[] =
+{
+    ACPI_DMT_IVRS_DE_HEADER,
+    {ACPI_DMT_UINT8,    ACPI_IVRS8C_OFFSET (Handle),                "Handle", 0},
+    {ACPI_DMT_UINT16,   ACPI_IVRS8C_OFFSET (UsedId),                "Source Used Device ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_IVRS8C_OFFSET (Variety),               "Variety", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * LPIT - Low Power Idle Table
+ *
+ ******************************************************************************/
+
+/* Main table consists only of the standard ACPI table header */
+
+/* Common Subtable header (one per Subtable) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoLpitHdr[] =
+{
+    {ACPI_DMT_LPIT,     ACPI_LPITH_OFFSET (Type),                   "Subtable Type", 0},
+    {ACPI_DMT_UINT32,   ACPI_LPITH_OFFSET (Length),                 "Length", DT_LENGTH},
+    {ACPI_DMT_UINT16,   ACPI_LPITH_OFFSET (UniqueId),               "Unique ID", 0},
+    {ACPI_DMT_UINT16,   ACPI_LPITH_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_LPITH_OFFSET (Flags),                  "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_LPITH_FLAG_OFFSET (Flags, 0),          "State Disabled", 0},
+    {ACPI_DMT_FLAG1,    ACPI_LPITH_FLAG_OFFSET (Flags, 0),          "No Counter", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* LPIT Subtables */
+
+/* 0: Native C-state */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoLpit0[] =
+{
+    {ACPI_DMT_GAS,      ACPI_LPIT0_OFFSET (EntryTrigger),           "Entry Trigger", 0},
+    {ACPI_DMT_UINT32,   ACPI_LPIT0_OFFSET (Residency),              "Residency", 0},
+    {ACPI_DMT_UINT32,   ACPI_LPIT0_OFFSET (Latency),                "Latency", 0},
+    {ACPI_DMT_GAS,      ACPI_LPIT0_OFFSET (ResidencyCounter),       "Residency Counter", 0},
+    {ACPI_DMT_UINT64,   ACPI_LPIT0_OFFSET (CounterFrequency),       "Counter Frequency", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * MADT - Multiple APIC Description Table and subtables
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_MADT_OFFSET (Address),                 "Local Apic Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT_OFFSET (Flags),                   "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_MADT_FLAG_OFFSET (Flags,0),            "PC-AT Compatibility", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* Common Subtable header (one per Subtable) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadtHdr[] =
+{
+    {ACPI_DMT_MADT,     ACPI_MADTH_OFFSET (Type),                   "Subtable Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_MADTH_OFFSET (Length),                 "Length", DT_LENGTH},
+    ACPI_DMT_TERMINATOR
+};
+
+/* MADT Subtables */
+
+/* 0: processor APIC */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt0[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_MADT0_OFFSET (ProcessorId),            "Processor ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_MADT0_OFFSET (Id),                     "Local Apic ID", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT0_OFFSET (LapicFlags),             "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_MADT0_FLAG_OFFSET (LapicFlags,0),      "Processor Enabled", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 1: IO APIC */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt1[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_MADT1_OFFSET (Id),                     "I/O Apic ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_MADT1_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT1_OFFSET (Address),                "Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT1_OFFSET (GlobalIrqBase),          "Interrupt", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 2: Interrupt Override */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt2[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_MADT2_OFFSET (Bus),                    "Bus", 0},
+    {ACPI_DMT_UINT8,    ACPI_MADT2_OFFSET (SourceIrq),              "Source", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT2_OFFSET (GlobalIrq),              "Interrupt", 0},
+    {ACPI_DMT_UINT16,   ACPI_MADT2_OFFSET (IntiFlags),              "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAGS0,   ACPI_MADT2_FLAG_OFFSET (IntiFlags,0),       "Polarity", 0},
+    {ACPI_DMT_FLAGS2,   ACPI_MADT2_FLAG_OFFSET (IntiFlags,0),       "Trigger Mode", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 3: NMI Sources */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt3[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_MADT3_OFFSET (IntiFlags),              "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAGS0,   ACPI_MADT3_FLAG_OFFSET (IntiFlags,0),       "Polarity", 0},
+    {ACPI_DMT_FLAGS2,   ACPI_MADT3_FLAG_OFFSET (IntiFlags,0),       "Trigger Mode", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT3_OFFSET (GlobalIrq),              "Interrupt", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 4: Local APIC NMI */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt4[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_MADT4_OFFSET (ProcessorId),            "Processor ID", 0},
+    {ACPI_DMT_UINT16,   ACPI_MADT4_OFFSET (IntiFlags),              "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAGS0,   ACPI_MADT4_FLAG_OFFSET (IntiFlags,0),       "Polarity", 0},
+    {ACPI_DMT_FLAGS2,   ACPI_MADT4_FLAG_OFFSET (IntiFlags,0),       "Trigger Mode", 0},
+    {ACPI_DMT_UINT8,    ACPI_MADT4_OFFSET (Lint),                   "Interrupt Input LINT", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 5: Address Override */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt5[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_MADT5_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT64,   ACPI_MADT5_OFFSET (Address),                "APIC Address", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 6: I/O Sapic */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt6[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_MADT6_OFFSET (Id),                     "I/O Sapic ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_MADT6_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT6_OFFSET (GlobalIrqBase),          "Interrupt Base", 0},
+    {ACPI_DMT_UINT64,   ACPI_MADT6_OFFSET (Address),                "Address", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 7: Local Sapic */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt7[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_MADT7_OFFSET (ProcessorId),            "Processor ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_MADT7_OFFSET (Id),                     "Local Sapic ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_MADT7_OFFSET (Eid),                    "Local Sapic EID", 0},
+    {ACPI_DMT_UINT24,   ACPI_MADT7_OFFSET (Reserved[0]),            "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT7_OFFSET (LapicFlags),             "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_MADT7_FLAG_OFFSET (LapicFlags,0),      "Processor Enabled", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT7_OFFSET (Uid),                    "Processor UID", 0},
+    {ACPI_DMT_STRING,   ACPI_MADT7_OFFSET (UidString[0]),           "Processor UID String", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 8: Platform Interrupt Source */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt8[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_MADT8_OFFSET (IntiFlags),              "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAGS0,   ACPI_MADT8_FLAG_OFFSET (IntiFlags,0),       "Polarity", 0},
+    {ACPI_DMT_FLAGS2,   ACPI_MADT8_FLAG_OFFSET (IntiFlags,0),       "Trigger Mode", 0},
+    {ACPI_DMT_UINT8,    ACPI_MADT8_OFFSET (Type),                   "InterruptType", 0},
+    {ACPI_DMT_UINT8,    ACPI_MADT8_OFFSET (Id),                     "Processor ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_MADT8_OFFSET (Eid),                    "Processor EID", 0},
+    {ACPI_DMT_UINT8,    ACPI_MADT8_OFFSET (IoSapicVector),          "I/O Sapic Vector", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT8_OFFSET (GlobalIrq),              "Interrupt", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT8_OFFSET (Flags),                  "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_MADT8_OFFSET (Flags),                  "CPEI Override", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 9: Processor Local X2_APIC (ACPI 4.0) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt9[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_MADT9_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT9_OFFSET (LocalApicId),            "Processor x2Apic ID", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT9_OFFSET (LapicFlags),             "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_MADT9_FLAG_OFFSET (LapicFlags,0),      "Processor Enabled", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT9_OFFSET (Uid),                    "Processor UID", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 10: Local X2_APIC NMI (ACPI 4.0) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt10[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_MADT10_OFFSET (IntiFlags),             "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAGS0,   ACPI_MADT10_FLAG_OFFSET (IntiFlags,0),      "Polarity", 0},
+    {ACPI_DMT_FLAGS2,   ACPI_MADT10_FLAG_OFFSET (IntiFlags,0),      "Trigger Mode", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT10_OFFSET (Uid),                   "Processor UID", 0},
+    {ACPI_DMT_UINT8,    ACPI_MADT10_OFFSET (Lint),                  "Interrupt Input LINT", 0},
+    {ACPI_DMT_UINT24,   ACPI_MADT10_OFFSET (Reserved[0]),           "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 11: Generic Interrupt Controller (ACPI 5.0) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt11[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_MADT11_OFFSET (Reserved),              "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT11_OFFSET (CpuInterfaceNumber),    "CPU Interface Number", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT11_OFFSET (Uid),                   "Processor UID", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT11_OFFSET (Flags),                 "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_MADT11_FLAG_OFFSET (Flags,0),          "Processor Enabled", 0},
+    {ACPI_DMT_FLAG1,    ACPI_MADT11_FLAG_OFFSET (Flags,0),          "Performance Interrupt Trigger Mode", 0},
+    {ACPI_DMT_FLAG2,    ACPI_MADT11_FLAG_OFFSET (Flags,0),          "Virtual GIC Interrupt Trigger Mode", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT11_OFFSET (ParkingVersion),        "Parking Protocol Version", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT11_OFFSET (PerformanceInterrupt),  "Performance Interrupt", 0},
+    {ACPI_DMT_UINT64,   ACPI_MADT11_OFFSET (ParkedAddress),         "Parked Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_MADT11_OFFSET (BaseAddress),           "Base Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_MADT11_OFFSET (GicvBaseAddress),       "Virtual GIC Base Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_MADT11_OFFSET (GichBaseAddress),       "Hypervisor GIC Base Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT11_OFFSET (VgicInterrupt),         "Virtual GIC Interrupt", 0},
+    {ACPI_DMT_UINT64,   ACPI_MADT11_OFFSET (GicrBaseAddress),       "Redistributor Base Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_MADT11_OFFSET (ArmMpidr),              "ARM MPIDR", 0},
+    {ACPI_DMT_UINT8,    ACPI_MADT11_OFFSET (EfficiencyClass),       "Efficiency Class", 0},
+    {ACPI_DMT_UINT24,   ACPI_MADT11_OFFSET (Reserved2[0]),          "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 12: Generic Interrupt Distributor (ACPI 5.0) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt12[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_MADT12_OFFSET (Reserved),              "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT12_OFFSET (GicId),                 "Local GIC Hardware ID", 0},
+    {ACPI_DMT_UINT64,   ACPI_MADT12_OFFSET (BaseAddress),           "Base Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT12_OFFSET (GlobalIrqBase),         "Interrupt Base", 0},
+    {ACPI_DMT_UINT8,    ACPI_MADT12_OFFSET (Version),               "Version", 0},
+    {ACPI_DMT_UINT24,   ACPI_MADT12_OFFSET (Reserved2[0]),          "Reserved", 0},
+   ACPI_DMT_TERMINATOR
+};
+
+/* 13: Generic MSI Frame (ACPI 5.1) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt13[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_MADT13_OFFSET (Reserved),              "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT13_OFFSET (MsiFrameId),            "MSI Frame ID", 0},
+    {ACPI_DMT_UINT64,   ACPI_MADT13_OFFSET (BaseAddress),           "Base Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT13_OFFSET (Flags),                 "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_MADT13_FLAG_OFFSET (Flags,0),          "Select SPI", 0},
+    {ACPI_DMT_UINT16,   ACPI_MADT13_OFFSET (SpiCount),              "SPI Count", 0},
+    {ACPI_DMT_UINT16,   ACPI_MADT13_OFFSET (SpiBase),               "SPI Base", 0},
+   ACPI_DMT_TERMINATOR
+};
+
+/* 14: Generic Redistributor (ACPI 5.1) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt14[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_MADT14_OFFSET (Reserved),              "Reserved", 0},
+    {ACPI_DMT_UINT64,   ACPI_MADT14_OFFSET (BaseAddress),           "Base Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT14_OFFSET (Length),                "Length", 0},
+   ACPI_DMT_TERMINATOR
+};
+
+/* 15: Generic Translator (ACPI 6.0) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt15[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_MADT15_OFFSET (Reserved),              "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT15_OFFSET (TranslationId),         "Translation ID", 0},
+    {ACPI_DMT_UINT64,   ACPI_MADT15_OFFSET (BaseAddress),           "Base Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT15_OFFSET (Reserved2),             "Reserved", 0},
+   ACPI_DMT_TERMINATOR
+};
+
+/*******************************************************************************
+ *
+ * MCFG - PCI Memory Mapped Configuration table and Subtable
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMcfg[] =
+{
+    {ACPI_DMT_UINT64,   ACPI_MCFG_OFFSET (Reserved[0]),             "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMcfg0[] =
+{
+    {ACPI_DMT_UINT64,   ACPI_MCFG0_OFFSET (Address),                "Base Address", 0},
+    {ACPI_DMT_UINT16,   ACPI_MCFG0_OFFSET (PciSegment),             "Segment Group Number", 0},
+    {ACPI_DMT_UINT8,    ACPI_MCFG0_OFFSET (StartBusNumber),         "Start Bus Number", 0},
+    {ACPI_DMT_UINT8,    ACPI_MCFG0_OFFSET (EndBusNumber),           "End Bus Number", 0},
+    {ACPI_DMT_UINT32,   ACPI_MCFG0_OFFSET (Reserved),               "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * MCHI - Management Controller Host Interface table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMchi[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_MCHI_OFFSET (InterfaceType),           "Interface Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_MCHI_OFFSET (Protocol),                "Protocol", 0},
+    {ACPI_DMT_UINT64,   ACPI_MCHI_OFFSET (ProtocolData),            "Protocol Data", 0},
+    {ACPI_DMT_UINT8,    ACPI_MCHI_OFFSET (InterruptType),           "Interrupt Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_MCHI_OFFSET (Gpe),                     "Gpe", 0},
+    {ACPI_DMT_UINT8,    ACPI_MCHI_OFFSET (PciDeviceFlag),           "Pci Device Flag", 0},
+    {ACPI_DMT_UINT32,   ACPI_MCHI_OFFSET (GlobalInterrupt),         "Global Interrupt", 0},
+    {ACPI_DMT_GAS,      ACPI_MCHI_OFFSET (ControlRegister),         "Control Register", 0},
+    {ACPI_DMT_UINT8,    ACPI_MCHI_OFFSET (PciSegment),              "Pci Segment", 0},
+    {ACPI_DMT_UINT8,    ACPI_MCHI_OFFSET (PciBus),                  "Pci Bus", 0},
+    {ACPI_DMT_UINT8,    ACPI_MCHI_OFFSET (PciDevice),               "Pci Device", 0},
+    {ACPI_DMT_UINT8,    ACPI_MCHI_OFFSET (PciFunction),             "Pci Function", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * MPST - Memory Power State Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMpst[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_MPST_OFFSET (ChannelId),               "Channel ID", 0},
+    {ACPI_DMT_UINT24,   ACPI_MPST_OFFSET (Reserved1[0]),            "Reserved", 0},
+    {ACPI_DMT_UINT16,   ACPI_MPST_OFFSET (PowerNodeCount),          "Power Node Count", 0},
+    {ACPI_DMT_UINT16,   ACPI_MPST_OFFSET (Reserved2),               "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* MPST subtables */
+
+/* 0: Memory Power Node Structure */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMpst0[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_MPST0_OFFSET (Flags),                  "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_MPST0_FLAG_OFFSET (Flags,0),           "Node Enabled", 0},
+    {ACPI_DMT_FLAG1,    ACPI_MPST0_FLAG_OFFSET (Flags,0),           "Power Managed", 0},
+    {ACPI_DMT_FLAG2,    ACPI_MPST0_FLAG_OFFSET (Flags,0),           "Hot Plug Capable", 0},
+
+    {ACPI_DMT_UINT8,    ACPI_MPST0_OFFSET (Reserved1),              "Reserved", 0},
+    {ACPI_DMT_UINT16,   ACPI_MPST0_OFFSET (NodeId),                 "Node ID", 0},
+    {ACPI_DMT_UINT32,   ACPI_MPST0_OFFSET (Length),                 "Length", 0},
+    {ACPI_DMT_UINT64,   ACPI_MPST0_OFFSET (RangeAddress),           "Range Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_MPST0_OFFSET (RangeLength),            "Range Length", 0},
+    {ACPI_DMT_UINT32,   ACPI_MPST0_OFFSET (NumPowerStates),         "Num Power States", 0},
+    {ACPI_DMT_UINT32,   ACPI_MPST0_OFFSET (NumPhysicalComponents),  "Num Physical Components", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 0A: Sub-subtable - Memory Power State Structure (follows Memory Power Node above) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMpst0A[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_MPST0A_OFFSET (PowerState),            "Power State", 0},
+    {ACPI_DMT_UINT8,    ACPI_MPST0A_OFFSET (InfoIndex),             "InfoIndex", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 0B: Sub-subtable - Physical Component ID Structure (follows Memory Power State(s) above) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMpst0B[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_MPST0B_OFFSET (ComponentId),           "Component Id", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 01: Power Characteristics Count (follows all Power Node(s) above) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMpst1[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_MPST1_OFFSET (CharacteristicsCount),   "Characteristics Count", 0},
+    {ACPI_DMT_UINT16,   ACPI_MPST1_OFFSET (Reserved),               "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 02: Memory Power State Characteristics Structure */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMpst2[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_MPST2_OFFSET (StructureId),            "Structure ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_MPST2_OFFSET (Flags),                  "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_MPST2_FLAG_OFFSET (Flags,0),           "Memory Preserved", 0},
+    {ACPI_DMT_FLAG1,    ACPI_MPST2_FLAG_OFFSET (Flags,0),           "Auto Entry", 0},
+    {ACPI_DMT_FLAG2,    ACPI_MPST2_FLAG_OFFSET (Flags,0),           "Auto Exit", 0},
+
+    {ACPI_DMT_UINT16,   ACPI_MPST2_OFFSET (Reserved1),              "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_MPST2_OFFSET (AveragePower),           "Average Power", 0},
+    {ACPI_DMT_UINT32,   ACPI_MPST2_OFFSET (PowerSaving),            "Power Saving", 0},
+    {ACPI_DMT_UINT64,   ACPI_MPST2_OFFSET (ExitLatency),            "Exit Latency", 0},
+    {ACPI_DMT_UINT64,   ACPI_MPST2_OFFSET (Reserved2),              "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * MSCT - Maximum System Characteristics Table (ACPI 4.0)
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMsct[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_MSCT_OFFSET (ProximityOffset),         "Proximity Offset", 0},
+    {ACPI_DMT_UINT32,   ACPI_MSCT_OFFSET (MaxProximityDomains),     "Max Proximity Domains", 0},
+    {ACPI_DMT_UINT32,   ACPI_MSCT_OFFSET (MaxClockDomains),         "Max Clock Domains", 0},
+    {ACPI_DMT_UINT64,   ACPI_MSCT_OFFSET (MaxAddress),              "Max Physical Address", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* Subtable - Maximum Proximity Domain Information. Version 1 */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMsct0[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_MSCT0_OFFSET (Revision),               "Revision", 0},
+    {ACPI_DMT_UINT8,    ACPI_MSCT0_OFFSET (Length),                 "Length", DT_LENGTH},
+    {ACPI_DMT_UINT32,   ACPI_MSCT0_OFFSET (RangeStart),             "Domain Range Start", 0},
+    {ACPI_DMT_UINT32,   ACPI_MSCT0_OFFSET (RangeEnd),               "Domain Range End", 0},
+    {ACPI_DMT_UINT32,   ACPI_MSCT0_OFFSET (ProcessorCapacity),      "Processor Capacity", 0},
+    {ACPI_DMT_UINT64,   ACPI_MSCT0_OFFSET (MemoryCapacity),         "Memory Capacity", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * MTMR - MID Timer Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMtmr[] =
+{
+    ACPI_DMT_TERMINATOR
+};
+
+/* MTMR Subtables - MTMR Entry */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoMtmr0[] =
+{
+    {ACPI_DMT_GAS,      ACPI_MTMR0_OFFSET (PhysicalAddress),        "PhysicalAddress", 0},
+    {ACPI_DMT_UINT32,   ACPI_MTMR0_OFFSET (Frequency),              "Frequency", 0},
+    {ACPI_DMT_UINT32,   ACPI_MTMR0_OFFSET (Irq),                    "IRQ", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * NFIT - NVDIMM Firmware Interface Table and Subtables - (ACPI 6.0)
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoNfit[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_NFIT_OFFSET (Reserved),                "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* Common Subtable header */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoNfitHdr[] =
+{
+    {ACPI_DMT_NFIT,     ACPI_NFITH_OFFSET (Type),                   "Subtable Type", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFITH_OFFSET (Length),                 "Length", DT_LENGTH},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 0: System Physical Address Range Structure */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoNfit0[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_NFIT0_OFFSET (RangeIndex),             "Range Index", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT0_OFFSET (Flags),                  "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_NFIT0_FLAG_OFFSET (Flags,0),           "Add/Online Operation Only", 0},
+    {ACPI_DMT_FLAG1,    ACPI_NFIT0_FLAG_OFFSET (Flags,0),           "Proximity Domain Valid", 0},
+    {ACPI_DMT_UINT32,   ACPI_NFIT0_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_NFIT0_OFFSET (ProximityDomain),        "Proximity Domain", 0},
+    {ACPI_DMT_UUID,     ACPI_NFIT0_OFFSET (RangeGuid[0]),           "Address Range GUID", 0},
+    {ACPI_DMT_UINT64,   ACPI_NFIT0_OFFSET (Address),                "Address Range Base", 0},
+    {ACPI_DMT_UINT64,   ACPI_NFIT0_OFFSET (Length),                 "Address Range Length", 0},
+    {ACPI_DMT_UINT64,   ACPI_NFIT0_OFFSET (MemoryMapping),          "Memory Map Attribute", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 1: Memory Device to System Address Range Map Structure */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoNfit1[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_NFIT1_OFFSET (DeviceHandle),           "Device Handle", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT1_OFFSET (PhysicalId),             "Physical Id", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT1_OFFSET (RegionId),               "Region Id", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT1_OFFSET (RangeIndex),             "Range Index", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT1_OFFSET (RegionIndex),            "Control Region Index", 0},
+    {ACPI_DMT_UINT64,   ACPI_NFIT1_OFFSET (RegionSize),             "Region Size", 0},
+    {ACPI_DMT_UINT64,   ACPI_NFIT1_OFFSET (RegionOffset),           "Region Offset", 0},
+    {ACPI_DMT_UINT64,   ACPI_NFIT1_OFFSET (Address),                "Address Region Base", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT1_OFFSET (InterleaveIndex),        "Interleave Index", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT1_OFFSET (InterleaveWays),         "Interleave Ways", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT1_OFFSET (Flags),                  "Flags", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_NFIT1_FLAG_OFFSET (Flags,0),           "Save to device failed", 0},
+    {ACPI_DMT_FLAG1,    ACPI_NFIT1_FLAG_OFFSET (Flags,0),           "Restore from device failed", 0},
+    {ACPI_DMT_FLAG2,    ACPI_NFIT1_FLAG_OFFSET (Flags,0),           "Platform flush failed", 0},
+    {ACPI_DMT_FLAG3,    ACPI_NFIT1_FLAG_OFFSET (Flags,0),           "Device not armed", 0},
+    {ACPI_DMT_FLAG4,    ACPI_NFIT1_FLAG_OFFSET (Flags,0),           "Health events observed", 0},
+    {ACPI_DMT_FLAG5,    ACPI_NFIT1_FLAG_OFFSET (Flags,0),           "Health events enabled", 0},
+    {ACPI_DMT_FLAG6,    ACPI_NFIT1_FLAG_OFFSET (Flags,0),           "Mapping failed", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT1_OFFSET (Reserved),               "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 2: Interleave Structure */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoNfit2[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_NFIT2_OFFSET (InterleaveIndex),        "Interleave Index", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT2_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_NFIT2_OFFSET (LineCount),              "Line Count", 0},
+    {ACPI_DMT_UINT32,   ACPI_NFIT2_OFFSET (LineSize),               "Line Size", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoNfit2a[] =
+{
+    {ACPI_DMT_UINT32,   0,                                          "Line Offset", DT_OPTIONAL},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 3: SMBIOS Management Information Structure */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoNfit3[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_NFIT3_OFFSET (Reserved),               "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoNfit3a[] =
+{
+    {ACPI_DMT_RAW_BUFFER, 0,                                        "SMBIOS Table Entries", DT_OPTIONAL},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 4: NVDIMM Control Region Structure */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoNfit4[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_NFIT4_OFFSET (RegionIndex),            "Region Index", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT4_OFFSET (VendorId),               "Vendor Id", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT4_OFFSET (DeviceId),               "Device Id", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT4_OFFSET (RevisionId),             "Revision Id", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT4_OFFSET (SubsystemVendorId),      "Subsystem Vendor Id", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT4_OFFSET (SubsystemDeviceId),      "Subsystem Device Id", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT4_OFFSET (SubsystemRevisionId),    "Subsystem Revision Id", 0},
+    {ACPI_DMT_UINT8,    ACPI_NFIT4_OFFSET (ValidFields),            "Valid Fields", 0},
+    {ACPI_DMT_UINT8,    ACPI_NFIT4_OFFSET (ManufacturingLocation),  "Manufacturing Location", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT4_OFFSET (ManufacturingDate),      "Manufacturing Date", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT4_OFFSET (Reserved[0]),            "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_NFIT4_OFFSET (SerialNumber),           "Serial Number", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT4_OFFSET (Code),                   "Code", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT4_OFFSET (Windows),                "Window Count", 0},
+    {ACPI_DMT_UINT64,   ACPI_NFIT4_OFFSET (WindowSize),             "Window Size", 0},
+    {ACPI_DMT_UINT64,   ACPI_NFIT4_OFFSET (CommandOffset),          "Command Offset", 0},
+    {ACPI_DMT_UINT64,   ACPI_NFIT4_OFFSET (CommandSize),            "Command Size", 0},
+    {ACPI_DMT_UINT64,   ACPI_NFIT4_OFFSET (StatusOffset),           "Status Offset", 0},
+    {ACPI_DMT_UINT64,   ACPI_NFIT4_OFFSET (StatusSize),             "Status Size", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT4_OFFSET (Flags),                  "Flags", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_NFIT4_FLAG_OFFSET (Flags,0),           "Windows buffered", 0},
+    {ACPI_DMT_UINT48,   ACPI_NFIT4_OFFSET (Reserved1[0]),           "Reserved1", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 5: NVDIMM Block Data Window Region Structure */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoNfit5[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_NFIT5_OFFSET (RegionIndex),            "Region Index", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT5_OFFSET (Windows),                "Window Count", 0},
+    {ACPI_DMT_UINT64,   ACPI_NFIT5_OFFSET (Offset),                 "Offset", 0},
+    {ACPI_DMT_UINT64,   ACPI_NFIT5_OFFSET (Size),                   "Size", 0},
+    {ACPI_DMT_UINT64,   ACPI_NFIT5_OFFSET (Capacity),               "Capacity", 0},
+    {ACPI_DMT_UINT64,   ACPI_NFIT5_OFFSET (StartAddress),           "Start Address", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 6: Flush Hint Address Structure */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoNfit6[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_NFIT6_OFFSET (DeviceHandle),           "Device Handle", 0},
+    {ACPI_DMT_UINT16,   ACPI_NFIT6_OFFSET (HintCount),              "Hint Count", 0},
+    {ACPI_DMT_UINT48,   ACPI_NFIT6_OFFSET (Reserved[0]),            "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoNfit6a[] =
+{
+    {ACPI_DMT_UINT64,   0,                                          "Hint Address", DT_OPTIONAL},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * PCCT - Platform Communications Channel Table (ACPI 5.0)
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoPcct[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_PCCT_OFFSET (Flags),                   "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_PCCT_FLAG_OFFSET (Flags,0),            "Doorbell", 0},
+    {ACPI_DMT_UINT64,   ACPI_PCCT_OFFSET (Reserved),                "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* PCCT subtables */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoPcctHdr[] =
+{
+    {ACPI_DMT_PCCT,     ACPI_PCCT0_OFFSET (Header.Type),            "Subtable Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_PCCT0_OFFSET (Header.Length),          "Length", DT_LENGTH},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 0: Generic Communications Subspace */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoPcct0[] =
+{
+    {ACPI_DMT_UINT48,   ACPI_PCCT0_OFFSET (Reserved[0]),            "Reserved", 0},
+    {ACPI_DMT_UINT64,   ACPI_PCCT0_OFFSET (BaseAddress),            "Base Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_PCCT0_OFFSET (Length),                 "Address Length", 0},
+    {ACPI_DMT_GAS,      ACPI_PCCT0_OFFSET (DoorbellRegister),       "Doorbell Register", 0},
+    {ACPI_DMT_UINT64,   ACPI_PCCT0_OFFSET (PreserveMask),           "Preserve Mask", 0},
+    {ACPI_DMT_UINT64,   ACPI_PCCT0_OFFSET (WriteMask),              "Write Mask", 0},
+    {ACPI_DMT_UINT32,   ACPI_PCCT0_OFFSET (Latency),                "Command Latency", 0},
+    {ACPI_DMT_UINT32,   ACPI_PCCT0_OFFSET (MaxAccessRate),          "Maximum Access Rate", 0},
+    {ACPI_DMT_UINT16,   ACPI_PCCT0_OFFSET (MinTurnaroundTime),      "Minimum Turnaround Time", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 1: HW-reduced Communications Subspace (ACPI 5.1) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoPcct1[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_PCCT1_OFFSET (DoorbellInterrupt),      "Doorbell Interrupt", 0},
+    {ACPI_DMT_UINT8,    ACPI_PCCT1_OFFSET (Flags),                  "Flags (Decoded Below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_PCCT1_FLAG_OFFSET (Flags,0),           "Polarity", 0},
+    {ACPI_DMT_FLAG1,    ACPI_PCCT1_FLAG_OFFSET (Flags,0),           "Mode", 0},
+    {ACPI_DMT_UINT8,    ACPI_PCCT1_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT64,   ACPI_PCCT1_OFFSET (BaseAddress),            "Base Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_PCCT1_OFFSET (Length),                 "Address Length", 0},
+    {ACPI_DMT_GAS,      ACPI_PCCT1_OFFSET (DoorbellRegister),       "Doorbell Register", 0},
+    {ACPI_DMT_UINT64,   ACPI_PCCT1_OFFSET (PreserveMask),           "Preserve Mask", 0},
+    {ACPI_DMT_UINT64,   ACPI_PCCT1_OFFSET (WriteMask),              "Write Mask", 0},
+    {ACPI_DMT_UINT32,   ACPI_PCCT1_OFFSET (Latency),                "Command Latency", 0},
+    {ACPI_DMT_UINT32,   ACPI_PCCT1_OFFSET (MaxAccessRate),          "Maximum Access Rate", 0},
+    {ACPI_DMT_UINT16,   ACPI_PCCT1_OFFSET (MinTurnaroundTime),      "Minimum Turnaround Time", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 2: HW-reduced Communications Subspace Type 2 (ACPI 6.1) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoPcct2[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_PCCT2_OFFSET (DoorbellInterrupt),      "Doorbell Interrupt", 0},
+    {ACPI_DMT_UINT8,    ACPI_PCCT2_OFFSET (Flags),                  "Flags (Decoded Below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_PCCT2_FLAG_OFFSET (Flags,0),           "Polarity", 0},
+    {ACPI_DMT_FLAG1,    ACPI_PCCT2_FLAG_OFFSET (Flags,0),           "Mode", 0},
+    {ACPI_DMT_UINT8,    ACPI_PCCT2_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT64,   ACPI_PCCT2_OFFSET (BaseAddress),            "Base Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_PCCT2_OFFSET (Length),                 "Address Length", 0},
+    {ACPI_DMT_GAS,      ACPI_PCCT2_OFFSET (DoorbellRegister),       "Doorbell Register", 0},
+    {ACPI_DMT_UINT64,   ACPI_PCCT2_OFFSET (PreserveMask),           "Preserve Mask", 0},
+    {ACPI_DMT_UINT64,   ACPI_PCCT2_OFFSET (WriteMask),              "Write Mask", 0},
+    {ACPI_DMT_UINT32,   ACPI_PCCT2_OFFSET (Latency),                "Command Latency", 0},
+    {ACPI_DMT_UINT32,   ACPI_PCCT2_OFFSET (MaxAccessRate),          "Maximum Access Rate", 0},
+    {ACPI_DMT_UINT16,   ACPI_PCCT2_OFFSET (MinTurnaroundTime),      "Minimum Turnaround Time", 0},
+    {ACPI_DMT_GAS,      ACPI_PCCT2_OFFSET (DoorbellAckRegister),    "Doorbell ACK Register", 0},
+    {ACPI_DMT_UINT64,   ACPI_PCCT2_OFFSET (AckPreserveMask),        "ACK Preserve Mask", 0},
+    {ACPI_DMT_UINT64,   ACPI_PCCT2_OFFSET (AckWriteMask),           "ACK Write Mask", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * PMTT - Platform Memory Topology Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoPmtt[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_PMTT_OFFSET (Reserved),                "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* Common Subtable header (one per Subtable) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoPmttHdr[] =
+{
+    {ACPI_DMT_PMTT,     ACPI_PMTTH_OFFSET (Type),                   "Subtable Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_PMTTH_OFFSET (Reserved1),              "Reserved", 0},
+    {ACPI_DMT_UINT16,   ACPI_PMTTH_OFFSET (Length),                 "Length", DT_LENGTH},
+    {ACPI_DMT_UINT16,   ACPI_PMTTH_OFFSET (Flags),                  "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_PMTTH_FLAG_OFFSET (Flags,0),           "Top-level Device", 0},
+    {ACPI_DMT_FLAG1,    ACPI_PMTTH_FLAG_OFFSET (Flags,0),           "Physical Element", 0},
+    {ACPI_DMT_FLAGS2,   ACPI_PMTTH_FLAG_OFFSET (Flags,0),           "Memory Type", 0},
+    {ACPI_DMT_UINT16,   ACPI_PMTTH_OFFSET (Reserved2),              "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* PMTT Subtables */
+
+/* 0: Socket */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoPmtt0[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_PMTT0_OFFSET (SocketId),               "Socket ID", 0},
+    {ACPI_DMT_UINT16,   ACPI_PMTT0_OFFSET (Reserved),               "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 1: Memory Controller */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoPmtt1[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_PMTT1_OFFSET (ReadLatency),            "Read Latency", 0},
+    {ACPI_DMT_UINT32,   ACPI_PMTT1_OFFSET (WriteLatency),           "Write Latency", 0},
+    {ACPI_DMT_UINT32,   ACPI_PMTT1_OFFSET (ReadBandwidth),          "Read Bandwidth", 0},
+    {ACPI_DMT_UINT32,   ACPI_PMTT1_OFFSET (WriteBandwidth),         "Write Bandwidth", 0},
+    {ACPI_DMT_UINT16,   ACPI_PMTT1_OFFSET (AccessWidth),            "Access Width", 0},
+    {ACPI_DMT_UINT16,   ACPI_PMTT1_OFFSET (Alignment),              "Alignment", 0},
+    {ACPI_DMT_UINT16,   ACPI_PMTT1_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT16,   ACPI_PMTT1_OFFSET (DomainCount),            "Domain Count", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 1a: Proximity Domain */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoPmtt1a[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_PMTT1A_OFFSET (ProximityDomain),       "Proximity Domain", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 2: Physical Component */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoPmtt2[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_PMTT2_OFFSET (ComponentId),            "Component ID", 0},
+    {ACPI_DMT_UINT16,   ACPI_PMTT2_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_PMTT2_OFFSET (MemorySize),             "Memory Size", 0},
+    {ACPI_DMT_UINT32,   ACPI_PMTT2_OFFSET (BiosHandle),             "Bios Handle", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * RASF -  RAS Feature table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoRasf[] =
+{
+    {ACPI_DMT_BUF12,    ACPI_RASF_OFFSET (ChannelId[0]),            "Channel ID", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/*******************************************************************************
+ *
+ * S3PT - S3 Performance Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoS3pt[] =
+{
+    {ACPI_DMT_SIG,     ACPI_S3PT_OFFSET (Signature[0]),             "Signature", 0},
+    {ACPI_DMT_UINT32,  ACPI_S3PT_OFFSET (Length),                   "Length", DT_LENGTH},
+    ACPI_DMT_TERMINATOR
+};
+
+/* S3PT subtable header */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoS3ptHdr[] =
+{
+    {ACPI_DMT_UINT16,  ACPI_S3PTH_OFFSET (Type),                    "Type", 0},
+    {ACPI_DMT_UINT8,   ACPI_S3PTH_OFFSET (Length),                  "Length", DT_LENGTH},
+    {ACPI_DMT_UINT8,   ACPI_S3PTH_OFFSET (Revision),                "Revision", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 0: Basic S3 Resume Performance Record */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoS3pt0[] =
+{
+    {ACPI_DMT_UINT32,  ACPI_S3PT0_OFFSET (ResumeCount),             "Resume Count", 0},
+    {ACPI_DMT_UINT64,  ACPI_S3PT0_OFFSET (FullResume),              "Full Resume", 0},
+    {ACPI_DMT_UINT64,  ACPI_S3PT0_OFFSET (AverageResume),           "Average Resume", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 1: Basic S3 Suspend Performance Record */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoS3pt1[] =
+{
+    {ACPI_DMT_UINT64,  ACPI_S3PT1_OFFSET (SuspendStart),            "Suspend Start", 0},
+    {ACPI_DMT_UINT64,  ACPI_S3PT1_OFFSET (SuspendEnd),              "Suspend End", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * SBST - Smart Battery Specification Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoSbst[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_SBST_OFFSET (WarningLevel),            "Warning Level", 0},
+    {ACPI_DMT_UINT32,   ACPI_SBST_OFFSET (LowLevel),                "Low Level", 0},
+    {ACPI_DMT_UINT32,   ACPI_SBST_OFFSET (CriticalLevel),           "Critical Level", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * SLIC - Software Licensing Description Table. This table contains the standard
+ * ACPI header followed by proprietary data structures
+ *
+ ******************************************************************************/
+
+/* Single subtable, a proprietary format, so treat it as a buffer */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoSlic[] =
+{
+    {ACPI_DMT_RAW_BUFFER, 0,                                        "Software Licensing Structure", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * SLIT - System Locality Information Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoSlit[] =
+{
+    {ACPI_DMT_UINT64,   ACPI_SLIT_OFFSET (LocalityCount),           "Localities", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * SPCR - Serial Port Console Redirection table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoSpcr[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_SPCR_OFFSET (InterfaceType),           "Interface Type", 0},
+    {ACPI_DMT_UINT24,   ACPI_SPCR_OFFSET (Reserved[0]),             "Reserved", 0},
+    {ACPI_DMT_GAS,      ACPI_SPCR_OFFSET (SerialPort),              "Serial Port Register", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPCR_OFFSET (InterruptType),           "Interrupt Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPCR_OFFSET (PcInterrupt),             "PCAT-compatible IRQ", 0},
+    {ACPI_DMT_UINT32,   ACPI_SPCR_OFFSET (Interrupt),               "Interrupt", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPCR_OFFSET (BaudRate),                "Baud Rate", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPCR_OFFSET (Parity),                  "Parity", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPCR_OFFSET (StopBits),                "Stop Bits", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPCR_OFFSET (FlowControl),             "Flow Control", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPCR_OFFSET (TerminalType),            "Terminal Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPCR_OFFSET (Reserved2),               "Reserved", 0},
+    {ACPI_DMT_UINT16,   ACPI_SPCR_OFFSET (PciDeviceId),             "PCI Device ID", 0},
+    {ACPI_DMT_UINT16,   ACPI_SPCR_OFFSET (PciVendorId),             "PCI Vendor ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPCR_OFFSET (PciBus),                  "PCI Bus", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPCR_OFFSET (PciDevice),               "PCI Device", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPCR_OFFSET (PciFunction),             "PCI Function", 0},
+    {ACPI_DMT_UINT32,   ACPI_SPCR_OFFSET (PciFlags),                "PCI Flags", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPCR_OFFSET (PciSegment),              "PCI Segment", 0},
+    {ACPI_DMT_UINT32,   ACPI_SPCR_OFFSET (Reserved2),               "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * SPMI - Server Platform Management Interface table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoSpmi[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_SPMI_OFFSET (InterfaceType),           "Interface Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPMI_OFFSET (Reserved),                "Reserved", DT_NON_ZERO}, /* Value must be 1 */
+    {ACPI_DMT_UINT16,   ACPI_SPMI_OFFSET (SpecRevision),            "IPMI Spec Version", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPMI_OFFSET (InterruptType),           "Interrupt Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPMI_OFFSET (GpeNumber),               "GPE Number", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPMI_OFFSET (Reserved1),               "Reserved", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPMI_OFFSET (PciDeviceFlag),           "PCI Device Flag", 0},
+    {ACPI_DMT_UINT32,   ACPI_SPMI_OFFSET (Interrupt),               "Interrupt", 0},
+    {ACPI_DMT_GAS,      ACPI_SPMI_OFFSET (IpmiRegister),            "IPMI Register", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPMI_OFFSET (PciSegment),              "PCI Segment", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPMI_OFFSET (PciBus),                  "PCI Bus", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPMI_OFFSET (PciDevice),               "PCI Device", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPMI_OFFSET (PciFunction),             "PCI Function", 0},
+    {ACPI_DMT_UINT8,    ACPI_SPMI_OFFSET (Reserved2),               "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * SRAT - System Resource Affinity Table and Subtables
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoSrat[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_SRAT_OFFSET (TableRevision),           "Table Revision", 0},
+    {ACPI_DMT_UINT64,   ACPI_SRAT_OFFSET (Reserved),                "Reserved", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* Common Subtable header (one per Subtable) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoSratHdr[] =
+{
+    {ACPI_DMT_SRAT,     ACPI_SRATH_OFFSET (Type),                   "Subtable Type", 0},
+    {ACPI_DMT_UINT8,    ACPI_SRATH_OFFSET (Length),                 "Length", DT_LENGTH},
+    ACPI_DMT_TERMINATOR
+};
+
+/* SRAT Subtables */
+
+/* 0: Processor Local APIC/SAPIC Affinity */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoSrat0[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_SRAT0_OFFSET (ProximityDomainLo),      "Proximity Domain Low(8)", 0},
+    {ACPI_DMT_UINT8,    ACPI_SRAT0_OFFSET (ApicId),                 "Apic ID", 0},
+    {ACPI_DMT_UINT32,   ACPI_SRAT0_OFFSET (Flags),                  "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_SRAT0_FLAG_OFFSET (Flags,0),           "Enabled", 0},
+    {ACPI_DMT_UINT8,    ACPI_SRAT0_OFFSET (LocalSapicEid),          "Local Sapic EID", 0},
+    {ACPI_DMT_UINT24,   ACPI_SRAT0_OFFSET (ProximityDomainHi[0]),   "Proximity Domain High(24)", 0},
+    {ACPI_DMT_UINT32,   ACPI_SRAT0_OFFSET (ClockDomain),            "Clock Domain", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 1: Memory Affinity */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoSrat1[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_SRAT1_OFFSET (ProximityDomain),        "Proximity Domain", 0},
+    {ACPI_DMT_UINT16,   ACPI_SRAT1_OFFSET (Reserved),               "Reserved1", 0},
+    {ACPI_DMT_UINT64,   ACPI_SRAT1_OFFSET (BaseAddress),            "Base Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_SRAT1_OFFSET (Length),                 "Address Length", 0},
+    {ACPI_DMT_UINT32,   ACPI_SRAT1_OFFSET (Reserved1),              "Reserved2", 0},
+    {ACPI_DMT_UINT32,   ACPI_SRAT1_OFFSET (Flags),                  "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_SRAT1_FLAG_OFFSET (Flags,0),           "Enabled", 0},
+    {ACPI_DMT_FLAG1,    ACPI_SRAT1_FLAG_OFFSET (Flags,0),           "Hot Pluggable", 0},
+    {ACPI_DMT_FLAG2,    ACPI_SRAT1_FLAG_OFFSET (Flags,0),           "Non-Volatile", 0},
+    {ACPI_DMT_UINT64,   ACPI_SRAT1_OFFSET (Reserved2),              "Reserved3", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* 2: Processor Local X2_APIC Affinity (ACPI 4.0) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoSrat2[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_SRAT2_OFFSET (Reserved),               "Reserved1", 0},
+    {ACPI_DMT_UINT32,   ACPI_SRAT2_OFFSET (ProximityDomain),        "Proximity Domain", 0},
+    {ACPI_DMT_UINT32,   ACPI_SRAT2_OFFSET (ApicId),                 "Apic ID", 0},
+    {ACPI_DMT_UINT32,   ACPI_SRAT2_OFFSET (Flags),                  "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_SRAT2_FLAG_OFFSET (Flags,0),           "Enabled", 0},
+    {ACPI_DMT_UINT32,   ACPI_SRAT2_OFFSET (ClockDomain),            "Clock Domain", 0},
+    {ACPI_DMT_UINT32,   ACPI_SRAT2_OFFSET (Reserved2),              "Reserved2", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* : GICC Affinity (ACPI 5.1) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoSrat3[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_SRAT3_OFFSET (ProximityDomain),        "Proximity Domain", 0},
+    {ACPI_DMT_UINT32,   ACPI_SRAT3_OFFSET (AcpiProcessorUid),       "Acpi Processor UID", 0},
+    {ACPI_DMT_UINT32,   ACPI_SRAT3_OFFSET (Flags),                  "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_SRAT3_FLAG_OFFSET (Flags,0),           "Enabled", 0},
+    {ACPI_DMT_UINT32,   ACPI_SRAT3_OFFSET (ClockDomain),            "Clock Domain", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * STAO - Status Override Table (_STA override) - ACPI 6.0
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoStao[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_STAO_OFFSET (IgnoreUart),              "Ignore UART", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoStaoStr[] =
+{
+    {ACPI_DMT_STRING,   0,                                          "Namepath", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * TCPA - Trusted Computing Platform Alliance table (Client)
+ *
+ * NOTE: There are two versions of the table with the same signature --
+ * the client version and the server version. The common PlatformClass
+ * field is used to differentiate the two types of tables.
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoTcpaHdr[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_TCPA_OFFSET (PlatformClass),           "Platform Class", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoTcpaClient[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_TCPA_CLIENT_OFFSET (MinimumLogLength), "Min Event Log Length", 0},
+    {ACPI_DMT_UINT64,   ACPI_TCPA_CLIENT_OFFSET (LogAddress),       "Event Log Address", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoTcpaServer[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_TCPA_SERVER_OFFSET (Reserved),         "Reserved", 0},
+    {ACPI_DMT_UINT64,   ACPI_TCPA_SERVER_OFFSET (MinimumLogLength), "Min Event Log Length", 0},
+    {ACPI_DMT_UINT64,   ACPI_TCPA_SERVER_OFFSET (LogAddress),       "Event Log Address", 0},
+    {ACPI_DMT_UINT16,   ACPI_TCPA_SERVER_OFFSET (SpecRevision),     "Specification Revision", 0},
+    {ACPI_DMT_UINT8,    ACPI_TCPA_SERVER_OFFSET (DeviceFlags),      "Device Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_TCPA_SERVER_OFFSET (DeviceFlags),      "Pci Device", 0},
+    {ACPI_DMT_FLAG1,    ACPI_TCPA_SERVER_OFFSET (DeviceFlags),      "Bus is Pnp", 0},
+    {ACPI_DMT_FLAG2,    ACPI_TCPA_SERVER_OFFSET (DeviceFlags),      "Address Valid", 0},
+    {ACPI_DMT_UINT8,    ACPI_TCPA_SERVER_OFFSET (InterruptFlags),   "Interrupt Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_TCPA_SERVER_OFFSET (InterruptFlags),   "Mode", 0},
+    {ACPI_DMT_FLAG1,    ACPI_TCPA_SERVER_OFFSET (InterruptFlags),   "Polarity", 0},
+    {ACPI_DMT_FLAG2,    ACPI_TCPA_SERVER_OFFSET (InterruptFlags),   "GPE SCI Triggered", 0},
+    {ACPI_DMT_FLAG3,    ACPI_TCPA_SERVER_OFFSET (InterruptFlags),   "Global System Interrupt", 0},
+    {ACPI_DMT_UINT8,    ACPI_TCPA_SERVER_OFFSET (GpeNumber),        "Gpe Number", 0},
+    {ACPI_DMT_UINT24,   ACPI_TCPA_SERVER_OFFSET (Reserved2[0]),     "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_TCPA_SERVER_OFFSET (GlobalInterrupt),  "Global Interrupt", 0},
+    {ACPI_DMT_GAS,      ACPI_TCPA_SERVER_OFFSET (Address),          "Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_TCPA_SERVER_OFFSET (Reserved3),        "Reserved", 0},
+    {ACPI_DMT_GAS,      ACPI_TCPA_SERVER_OFFSET (ConfigAddress),    "Configuration Address", 0},
+    {ACPI_DMT_UINT8,    ACPI_TCPA_SERVER_OFFSET (Group),            "Pci Group", 0},
+    {ACPI_DMT_UINT8,    ACPI_TCPA_SERVER_OFFSET (Bus),              "Pci Bus", 0},
+    {ACPI_DMT_UINT8,    ACPI_TCPA_SERVER_OFFSET (Device),           "Pci Device", 0},
+    {ACPI_DMT_UINT8,    ACPI_TCPA_SERVER_OFFSET (Function),         "Pci Function", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * TPM2 - Trusted Platform Module (TPM) 2.0 Hardware Interface Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoTpm2[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_TPM2_OFFSET (PlatformClass),           "Platform Class", 0},
+    {ACPI_DMT_UINT16,   ACPI_TPM2_OFFSET (Reserved),                "Reserved", 0},
+    {ACPI_DMT_UINT64,   ACPI_TPM2_OFFSET (ControlAddress),          "Control Address", 0},
+    {ACPI_DMT_UINT32,   ACPI_TPM2_OFFSET (StartMethod),             "Start Method", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * UEFI - UEFI Boot optimization Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoUefi[] =
+{
+    {ACPI_DMT_UUID,     ACPI_UEFI_OFFSET (Identifier[0]),           "UUID Identifier", 0},
+    {ACPI_DMT_UINT16,   ACPI_UEFI_OFFSET (DataOffset),              "Data Offset", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * VRTC - Virtual Real Time Clock Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoVrtc[] =
+{
+    ACPI_DMT_TERMINATOR
+};
+
+/* VRTC Subtables - VRTC Entry */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoVrtc0[] =
+{
+    {ACPI_DMT_GAS,      ACPI_VRTC0_OFFSET (PhysicalAddress),        "PhysicalAddress", 0},
+    {ACPI_DMT_UINT32,   ACPI_VRTC0_OFFSET (Irq),                    "IRQ", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * WAET - Windows ACPI Emulated devices Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoWaet[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_WAET_OFFSET (Flags),                   "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_WAET_OFFSET (Flags),                   "RTC needs no INT ack", 0},
+    {ACPI_DMT_FLAG1,    ACPI_WAET_OFFSET (Flags),                   "PM timer, one read only", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * WDAT - Watchdog Action Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoWdat[] =
+{
+    {ACPI_DMT_UINT32,   ACPI_WDAT_OFFSET (HeaderLength),            "Header Length", DT_LENGTH},
+    {ACPI_DMT_UINT16,   ACPI_WDAT_OFFSET (PciSegment),              "PCI Segment", 0},
+    {ACPI_DMT_UINT8,    ACPI_WDAT_OFFSET (PciBus),                  "PCI Bus", 0},
+    {ACPI_DMT_UINT8,    ACPI_WDAT_OFFSET (PciDevice),               "PCI Device", 0},
+    {ACPI_DMT_UINT8,    ACPI_WDAT_OFFSET (PciFunction),             "PCI Function", 0},
+    {ACPI_DMT_UINT24,   ACPI_WDAT_OFFSET (Reserved[0]),             "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_WDAT_OFFSET (TimerPeriod),             "Timer Period", 0},
+    {ACPI_DMT_UINT32,   ACPI_WDAT_OFFSET (MaxCount),                "Max Count", 0},
+    {ACPI_DMT_UINT32,   ACPI_WDAT_OFFSET (MinCount),                "Min Count", 0},
+    {ACPI_DMT_UINT8,    ACPI_WDAT_OFFSET (Flags),                   "Flags (decoded below)", DT_FLAG},
+    {ACPI_DMT_FLAG0,    ACPI_WDAT_OFFSET (Flags),                   "Enabled", 0},
+    {ACPI_DMT_FLAG7,    ACPI_WDAT_OFFSET (Flags),                   "Stopped When Asleep", 0},
+    {ACPI_DMT_UINT24,   ACPI_WDAT_OFFSET (Reserved2[0]),            "Reserved", 0},
+    {ACPI_DMT_UINT32,   ACPI_WDAT_OFFSET (Entries),                 "Watchdog Entry Count", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+/* WDAT Subtables - Watchdog Instruction Entries */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoWdat0[] =
+{
+    {ACPI_DMT_UINT8,    ACPI_WDAT0_OFFSET (Action),                 "Watchdog Action", 0},
+    {ACPI_DMT_UINT8,    ACPI_WDAT0_OFFSET (Instruction),            "Instruction", 0},
+    {ACPI_DMT_UINT16,   ACPI_WDAT0_OFFSET (Reserved),               "Reserved", 0},
+    {ACPI_DMT_GAS,      ACPI_WDAT0_OFFSET (RegisterRegion),         "Register Region", 0},
+    {ACPI_DMT_UINT32,   ACPI_WDAT0_OFFSET (Value),                  "Value", 0},
+    {ACPI_DMT_UINT32,   ACPI_WDAT0_OFFSET (Mask),                   "Register Mask", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * WDDT - Watchdog Description Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoWddt[] =
+{
+    {ACPI_DMT_UINT16,   ACPI_WDDT_OFFSET (SpecVersion),             "Specification Version", 0},
+    {ACPI_DMT_UINT16,   ACPI_WDDT_OFFSET (TableVersion),            "Table Version", 0},
+    {ACPI_DMT_UINT16,   ACPI_WDDT_OFFSET (PciVendorId),             "PCI Vendor ID", 0},
+    {ACPI_DMT_GAS,      ACPI_WDDT_OFFSET (Address),                 "Timer Register", 0},
+    {ACPI_DMT_UINT16,   ACPI_WDDT_OFFSET (MaxCount),                "Max Count", 0},
+    {ACPI_DMT_UINT16,   ACPI_WDDT_OFFSET (MinCount),                "Min Count", 0},
+    {ACPI_DMT_UINT16,   ACPI_WDDT_OFFSET (Period),                  "Period", 0},
+    {ACPI_DMT_UINT16,   ACPI_WDDT_OFFSET (Status),                  "Status (decoded below)", 0},
+
+    /* Status Flags byte 0 */
+
+    {ACPI_DMT_FLAG0,    ACPI_WDDT_FLAG_OFFSET (Status,0),           "Available", 0},
+    {ACPI_DMT_FLAG1,    ACPI_WDDT_FLAG_OFFSET (Status,0),           "Active", 0},
+    {ACPI_DMT_FLAG2,    ACPI_WDDT_FLAG_OFFSET (Status,0),           "OS Owns", 0},
+
+    /* Status Flags byte 1 */
+
+    {ACPI_DMT_FLAG3,    ACPI_WDDT_FLAG_OFFSET (Status,1),           "User Reset", 0},
+    {ACPI_DMT_FLAG4,    ACPI_WDDT_FLAG_OFFSET (Status,1),           "Timeout Reset", 0},
+    {ACPI_DMT_FLAG5,    ACPI_WDDT_FLAG_OFFSET (Status,1),           "Power Fail Reset", 0},
+    {ACPI_DMT_FLAG6,    ACPI_WDDT_FLAG_OFFSET (Status,1),           "Unknown Reset", 0},
+
+    {ACPI_DMT_UINT16,   ACPI_WDDT_OFFSET (Capability),              "Capability (decoded below)", 0},
+
+    /* Capability Flags byte 0 */
+
+    {ACPI_DMT_FLAG0,    ACPI_WDDT_FLAG_OFFSET (Capability,0),       "Auto Reset", 0},
+    {ACPI_DMT_FLAG1,    ACPI_WDDT_FLAG_OFFSET (Capability,0),       "Timeout Alert", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * WDRT - Watchdog Resource Table
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoWdrt[] =
+{
+    {ACPI_DMT_GAS,      ACPI_WDRT_OFFSET (ControlRegister),         "Control Register", 0},
+    {ACPI_DMT_GAS,      ACPI_WDRT_OFFSET (CountRegister),           "Count Register", 0},
+    {ACPI_DMT_UINT16,   ACPI_WDRT_OFFSET (PciDeviceId),             "PCI Device ID", 0},
+    {ACPI_DMT_UINT16,   ACPI_WDRT_OFFSET (PciVendorId),             "PCI Vendor ID", 0},
+    {ACPI_DMT_UINT8,    ACPI_WDRT_OFFSET (PciBus),                  "PCI Bus", 0},
+    {ACPI_DMT_UINT8,    ACPI_WDRT_OFFSET (PciDevice),               "PCI Device", 0},
+    {ACPI_DMT_UINT8,    ACPI_WDRT_OFFSET (PciFunction),             "PCI Function", 0},
+    {ACPI_DMT_UINT8,    ACPI_WDRT_OFFSET (PciSegment),              "PCI Segment", 0},
+    {ACPI_DMT_UINT16,   ACPI_WDRT_OFFSET (MaxCount),                "Max Count", 0},
+    {ACPI_DMT_UINT8,    ACPI_WDRT_OFFSET (Units),                   "Counter Units", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * WPBT - Windows Platform Environment Table (ACPI 6.0)
+ *        Version 1
+ *
+ * Conforms to "Windows Platform Binary Table (WPBT)" 29 November 2011
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoWpbt[] =
+{
+    {ACPI_DMT_UINT32,      ACPI_WPBT_OFFSET (HandoffSize),          "Handoff Size", 0},
+    {ACPI_DMT_UINT64,      ACPI_WPBT_OFFSET (HandoffAddress),       "Handoff Address", 0},
+    {ACPI_DMT_UINT8,       ACPI_WPBT_OFFSET (Layout),               "Layout", 0},
+    {ACPI_DMT_UINT8,       ACPI_WPBT_OFFSET (Type),                 "Type", 0},
+    {ACPI_DMT_UINT16,      ACPI_WPBT_OFFSET (ArgumentsLength),      "Arguments Length", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoWpbt0[] =
+{
+    {ACPI_DMT_UNICODE,     sizeof (ACPI_TABLE_WPBT),                "Command-line Arguments", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*******************************************************************************
+ *
+ * XENV -  Xen Environment table (ACPI 6.0)
+ *
+ ******************************************************************************/
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoXenv[] =
+{
+    {ACPI_DMT_UINT64,   ACPI_XENV_OFFSET (GrantTableAddress),       "Grant Table Address", 0},
+    {ACPI_DMT_UINT64,   ACPI_XENV_OFFSET (GrantTableSize),          "Grant Table Size", 0},
+    {ACPI_DMT_UINT32,   ACPI_XENV_OFFSET (EventInterrupt),          "Event Interrupt", 0},
+    {ACPI_DMT_UINT8,    ACPI_XENV_OFFSET (EventFlags),              "Event Flags", 0},
+    ACPI_DMT_TERMINATOR
+};
+
+
+/*! [Begin] no source code translation */
+
+/*
+ * Generic types (used in UEFI and custom tables)
+ *
+ * Examples:
+ *
+ *     Buffer : cc 04 ff bb
+ *      UINT8 : 11
+ *     UINT16 : 1122
+ *     UINT24 : 112233
+ *     UINT32 : 11223344
+ *     UINT56 : 11223344556677
+ *     UINT64 : 1122334455667788
+ *
+ *     String : "This is string"
+ *    Unicode : "This string encoded to Unicode"
+ *
+ *       GUID : 11223344-5566-7788-99aa-bbccddeeff00
+ * DevicePath : "\PciRoot(0)\Pci(0x1f,1)\Usb(0,0)"
+ */
+
+#define ACPI_DM_GENERIC_ENTRY(FieldType, FieldName) \
+    {{FieldType, 0, FieldName, 0}, ACPI_DMT_TERMINATOR}
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoGeneric[][2] =
+{
+    ACPI_DM_GENERIC_ENTRY (ACPI_DMT_UINT8,      "UINT8"),
+    ACPI_DM_GENERIC_ENTRY (ACPI_DMT_UINT16,     "UINT16"),
+    ACPI_DM_GENERIC_ENTRY (ACPI_DMT_UINT24,     "UINT24"),
+    ACPI_DM_GENERIC_ENTRY (ACPI_DMT_UINT32,     "UINT32"),
+    ACPI_DM_GENERIC_ENTRY (ACPI_DMT_UINT40,     "UINT40"),
+    ACPI_DM_GENERIC_ENTRY (ACPI_DMT_UINT48,     "UINT48"),
+    ACPI_DM_GENERIC_ENTRY (ACPI_DMT_UINT56,     "UINT56"),
+    ACPI_DM_GENERIC_ENTRY (ACPI_DMT_UINT64,     "UINT64"),
+    ACPI_DM_GENERIC_ENTRY (ACPI_DMT_STRING,     "String"),
+    ACPI_DM_GENERIC_ENTRY (ACPI_DMT_UNICODE,    "Unicode"),
+    ACPI_DM_GENERIC_ENTRY (ACPI_DMT_BUFFER,     "Buffer"),
+    ACPI_DM_GENERIC_ENTRY (ACPI_DMT_UUID,       "GUID"),
+    ACPI_DM_GENERIC_ENTRY (ACPI_DMT_STRING,     "DevicePath"),
+    ACPI_DM_GENERIC_ENTRY (ACPI_DMT_LABEL,      "Label"),
+    {ACPI_DMT_TERMINATOR}
+};
+/*! [End] no source code translation !*/

--- a/sys/src/libacpi/acpica/common/getopt.c
+++ b/sys/src/libacpi/acpica/common/getopt.c
@@ -1,0 +1,348 @@
+/******************************************************************************
+ *
+ * Module Name: getopt
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+/*
+ * ACPICA getopt() implementation
+ *
+ * Option strings:
+ *    "f"       - Option has no arguments
+ *    "f:"      - Option requires an argument
+ *    "f+"      - Option has an optional argument
+ *    "f^"      - Option has optional single-char sub-options
+ *    "f|"      - Option has required single-char sub-options
+ */
+
+#include "acpi.h"
+#include "accommon.h"
+#include "acapps.h"
+
+#define ACPI_OPTION_ERROR(msg, badchar) \
+    if (AcpiGbl_Opterr) {AcpiLogError ("%s%c\n", msg, badchar);}
+
+
+int                 AcpiGbl_Opterr = 1;
+int                 AcpiGbl_Optind = 1;
+int                 AcpiGbl_SubOptChar = 0;
+char                *AcpiGbl_Optarg;
+
+static int          CurrentCharPtr = 1;
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiGetoptArgument
+ *
+ * PARAMETERS:  argc, argv          - from main
+ *
+ * RETURN:      0 if an argument was found, -1 otherwise. Sets AcpiGbl_Optarg
+ *              to point to the next argument.
+ *
+ * DESCRIPTION: Get the next argument. Used to obtain arguments for the
+ *              two-character options after the original call to AcpiGetopt.
+ *              Note: Either the argument starts at the next character after
+ *              the option, or it is pointed to by the next argv entry.
+ *              (After call to AcpiGetopt, we need to backup to the previous
+ *              argv entry).
+ *
+ ******************************************************************************/
+
+int
+AcpiGetoptArgument (
+    int                     argc,
+    char                    **argv)
+{
+
+    AcpiGbl_Optind--;
+    CurrentCharPtr++;
+
+    if (argv[AcpiGbl_Optind][(int) (CurrentCharPtr+1)] != '\0')
+    {
+        AcpiGbl_Optarg = &argv[AcpiGbl_Optind++][(int) (CurrentCharPtr+1)];
+    }
+    else if (++AcpiGbl_Optind >= argc)
+    {
+        ACPI_OPTION_ERROR ("\nOption requires an argument", 0);
+
+        CurrentCharPtr = 1;
+        return (-1);
+    }
+    else
+    {
+        AcpiGbl_Optarg = argv[AcpiGbl_Optind++];
+    }
+
+    CurrentCharPtr = 1;
+    return (0);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiGetopt
+ *
+ * PARAMETERS:  argc, argv          - from main
+ *              opts                - options info list
+ *
+ * RETURN:      Option character or ACPI_OPT_END
+ *
+ * DESCRIPTION: Get the next option
+ *
+ ******************************************************************************/
+
+int
+AcpiGetopt(
+    int                     argc,
+    char                    **argv,
+    char                    *opts)
+{
+    int                     CurrentChar;
+    char                    *OptsPtr;
+
+
+    if (CurrentCharPtr == 1)
+    {
+        if (AcpiGbl_Optind >= argc ||
+            argv[AcpiGbl_Optind][0] != '-' ||
+            argv[AcpiGbl_Optind][1] == '\0')
+        {
+            return (ACPI_OPT_END);
+        }
+        else if (strcmp (argv[AcpiGbl_Optind], "--") == 0)
+        {
+            AcpiGbl_Optind++;
+            return (ACPI_OPT_END);
+        }
+    }
+
+    /* Get the option */
+
+    CurrentChar = argv[AcpiGbl_Optind][CurrentCharPtr];
+
+    /* Make sure that the option is legal */
+
+    if (CurrentChar == ':' ||
+       (OptsPtr = strchr (opts, CurrentChar)) == NULL)
+    {
+        ACPI_OPTION_ERROR ("Illegal option: -", CurrentChar);
+
+        if (argv[AcpiGbl_Optind][++CurrentCharPtr] == '\0')
+        {
+            AcpiGbl_Optind++;
+            CurrentCharPtr = 1;
+        }
+
+        return ('?');
+    }
+
+    /* Option requires an argument? */
+
+    if (*++OptsPtr == ':')
+    {
+        if (argv[AcpiGbl_Optind][(int) (CurrentCharPtr+1)] != '\0')
+        {
+            AcpiGbl_Optarg = &argv[AcpiGbl_Optind++][(int) (CurrentCharPtr+1)];
+        }
+        else if (++AcpiGbl_Optind >= argc)
+        {
+            ACPI_OPTION_ERROR (
+                "Option requires an argument: -", CurrentChar);
+
+            CurrentCharPtr = 1;
+            return ('?');
+        }
+        else
+        {
+            AcpiGbl_Optarg = argv[AcpiGbl_Optind++];
+        }
+
+        CurrentCharPtr = 1;
+    }
+
+    /* Option has an optional argument? */
+
+    else if (*OptsPtr == '+')
+    {
+        if (argv[AcpiGbl_Optind][(int) (CurrentCharPtr+1)] != '\0')
+        {
+            AcpiGbl_Optarg = &argv[AcpiGbl_Optind++][(int) (CurrentCharPtr+1)];
+        }
+        else if (++AcpiGbl_Optind >= argc)
+        {
+            AcpiGbl_Optarg = NULL;
+        }
+        else
+        {
+            AcpiGbl_Optarg = argv[AcpiGbl_Optind++];
+        }
+
+        CurrentCharPtr = 1;
+    }
+
+    /* Option has optional single-char arguments? */
+
+    else if (*OptsPtr == '^')
+    {
+        if (argv[AcpiGbl_Optind][(int) (CurrentCharPtr+1)] != '\0')
+        {
+            AcpiGbl_Optarg = &argv[AcpiGbl_Optind][(int) (CurrentCharPtr+1)];
+        }
+        else
+        {
+            AcpiGbl_Optarg = "^";
+        }
+
+        AcpiGbl_SubOptChar = AcpiGbl_Optarg[0];
+        AcpiGbl_Optind++;
+        CurrentCharPtr = 1;
+    }
+
+    /* Option has a required single-char argument? */
+
+    else if (*OptsPtr == '|')
+    {
+        if (argv[AcpiGbl_Optind][(int) (CurrentCharPtr+1)] != '\0')
+        {
+            AcpiGbl_Optarg = &argv[AcpiGbl_Optind][(int) (CurrentCharPtr+1)];
+        }
+        else
+        {
+            ACPI_OPTION_ERROR (
+                "Option requires a single-character suboption: -",
+                CurrentChar);
+
+            CurrentCharPtr = 1;
+            return ('?');
+        }
+
+        AcpiGbl_SubOptChar = AcpiGbl_Optarg[0];
+        AcpiGbl_Optind++;
+        CurrentCharPtr = 1;
+    }
+
+    /* Option with no arguments */
+
+    else
+    {
+        if (argv[AcpiGbl_Optind][++CurrentCharPtr] == '\0')
+        {
+            CurrentCharPtr = 1;
+            AcpiGbl_Optind++;
+        }
+
+        AcpiGbl_Optarg = NULL;
+    }
+
+    return (CurrentChar);
+}

--- a/sys/src/libacpi/acpica/components/debugger/build.json
+++ b/sys/src/libacpi/acpica/components/debugger/build.json
@@ -5,14 +5,16 @@
 		],
 		"Install": "/$ARCH/lib/",
 		"Library": "libacpi.a",
+		"NSourceFiles": [
+			"dbinput.c",
+			"dbfileio.c"
+		],
 		"SourceFiles": [
 			"dbcmds.c",
 			"dbconvert.c",
 			"dbdisply.c",
 			"dbexec.c",
-			"dbfileio.c",
 			"dbhistry.c",
-			"dbinput.c",
 			"dbmethod.c",
 			"dbnames.c",
 			"dbobject.c",

--- a/sys/src/libacpi/acpica/components/resources/build.json
+++ b/sys/src/libacpi/acpica/components/resources/build.json
@@ -3,6 +3,8 @@
 		"Include": [
 			"../../acpiflags.json"
 		],
+		"Install": "/$ARCH/lib/",
+		"Library": "libacpi.a",
 		"SourceFiles": [
 			"rsaddr.c",
 			"rscalc.c",

--- a/sys/src/libacpi/acpica/components/tables/build.json
+++ b/sys/src/libacpi/acpica/components/tables/build.json
@@ -3,6 +3,8 @@
 		"Include": [
 			"../../acpiflags.json"
 		],
+		"Install": "/$ARCH/lib/",
+		"Library": "libacpi.a",
 		"SourceFiles": [
 			"tbdata.c",
 			"tbfadt.c",

--- a/sys/src/libacpi/acpica/components/utilities/build.json
+++ b/sys/src/libacpi/acpica/components/utilities/build.json
@@ -1,11 +1,10 @@
 {
 	"Libacpi": {
-		"Cflags": [
-		    "-DACPI_USE_LOCAL_CACHE"
-		    ],
 		"Include": [
 			"../../acpiflags.json"
 		],
+		"Install": "/$ARCH/lib/",
+		"Library": "libacpi.a",
 		"SourceFiles": [
 			"utaddress.c",
 			"utalloc.c",

--- a/sys/src/libacpi/acpica/libacpi.json
+++ b/sys/src/libacpi/acpica/libacpi.json
@@ -1,9 +1,8 @@
 {
 	"Libacpi": {
 		"Projects": [
-			"components/build.json"
-		],
-		"NInstall": "/$ARCH/lib/",
-		"NLibrary": "libacpi.a"
+			"components/build.json",
+			"common/build.json"
+		]
 		}
 }

--- a/sys/src/libacpi/build.json
+++ b/sys/src/libacpi/build.json
@@ -1,0 +1,17 @@
+{
+	"Libacpi": {
+		"Projects": [
+		    "acpica/libacpi.json"
+		],
+		"Include": [
+			"/sys/src/libacpi/acpica/acpiflags.json"
+		],
+		"Install": "/$ARCH/lib/",
+		"Library": "libacpi.a",
+		"SourceFiles": [
+			"hack.c",
+			"harvey.c"
+			]
+		}
+}
+	

--- a/sys/src/libacpi/hack.c
+++ b/sys/src/libacpi/hack.c
@@ -1440,6 +1440,7 @@ AcpiDbCommandDispatch (
     ACPI_PARSE_OBJECT       *Op)
 {
 	sysfatal("%s", __func__);
+	return AE_OK;
 }
 void ACPI_SYSTEM_XFACE
 AcpiDbExecuteThread (
@@ -1454,4 +1455,5 @@ AcpiDbGetNextToken (
     ACPI_OBJECT_TYPE        *ReturnType)
 {
 	sysfatal("%s", __func__);
+	return AE_OK;
 }

--- a/sys/src/libacpi/hack.c
+++ b/sys/src/libacpi/hack.c
@@ -1,0 +1,1457 @@
+/*******************************************************************************
+ *
+ * Module Name: dbinput - user front-end to the AML debugger
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2016, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+#include "acdebug.h"
+
+#if 0
+#ifdef ACPI_APPLICATION
+#include "acapps.h"
+#endif
+
+#define _COMPONENT          ACPI_CA_DEBUGGER
+        ACPI_MODULE_NAME    ("dbinput")
+
+
+/* Local prototypes */
+
+static UINT32
+AcpiDbGetLine (
+    char                    *InputBuffer);
+
+static UINT32
+AcpiDbMatchCommand (
+    char                    *UserCommand);
+
+static void
+AcpiDbSingleThread (
+    void);
+
+static void
+AcpiDbDisplayCommandInfo (
+    const char              *Command,
+    BOOLEAN                 DisplayAll);
+
+static void
+AcpiDbDisplayHelp (
+    char                    *Command);
+
+static BOOLEAN
+AcpiDbMatchCommandHelp (
+    const char                  *Command,
+    const ACPI_DB_COMMAND_HELP  *Help);
+
+
+/*
+ * Top-level debugger commands.
+ *
+ * This list of commands must match the string table below it
+ */
+enum AcpiExDebuggerCommands
+{
+    CMD_NOT_FOUND = 0,
+    CMD_NULL,
+    CMD_ALLOCATIONS,
+    CMD_ARGS,
+    CMD_ARGUMENTS,
+    CMD_BREAKPOINT,
+    CMD_BUSINFO,
+    CMD_CALL,
+    CMD_DEBUG,
+    CMD_DISASSEMBLE,
+    CMD_DISASM,
+    CMD_DUMP,
+    CMD_EVALUATE,
+    CMD_EXECUTE,
+    CMD_EXIT,
+    CMD_FIND,
+    CMD_GO,
+    CMD_HANDLERS,
+    CMD_HELP,
+    CMD_HELP2,
+    CMD_HISTORY,
+    CMD_HISTORY_EXE,
+    CMD_HISTORY_LAST,
+    CMD_INFORMATION,
+    CMD_INTEGRITY,
+    CMD_INTO,
+    CMD_LEVEL,
+    CMD_LIST,
+    CMD_LOCALS,
+    CMD_LOCKS,
+    CMD_METHODS,
+    CMD_NAMESPACE,
+    CMD_NOTIFY,
+    CMD_OBJECTS,
+    CMD_OSI,
+    CMD_OWNER,
+    CMD_PATHS,
+    CMD_PREDEFINED,
+    CMD_PREFIX,
+    CMD_QUIT,
+    CMD_REFERENCES,
+    CMD_RESOURCES,
+    CMD_RESULTS,
+    CMD_SET,
+    CMD_STATS,
+    CMD_STOP,
+    CMD_TABLES,
+    CMD_TEMPLATE,
+    CMD_TRACE,
+    CMD_TREE,
+    CMD_TYPE,
+#ifdef ACPI_APPLICATION
+    CMD_ENABLEACPI,
+    CMD_EVENT,
+    CMD_GPE,
+    CMD_GPES,
+    CMD_SCI,
+    CMD_SLEEP,
+
+    CMD_CLOSE,
+    CMD_LOAD,
+    CMD_OPEN,
+    CMD_UNLOAD,
+
+    CMD_TERMINATE,
+    CMD_THREADS,
+
+    CMD_TEST,
+#endif
+};
+
+#define CMD_FIRST_VALID     2
+
+
+/* Second parameter is the required argument count */
+
+static const ACPI_DB_COMMAND_INFO   AcpiGbl_DbCommands[] =
+{
+    {"<NOT FOUND>",  0},
+    {"<NULL>",       0},
+    {"ALLOCATIONS",  0},
+    {"ARGS",         0},
+    {"ARGUMENTS",    0},
+    {"BREAKPOINT",   1},
+    {"BUSINFO",      0},
+    {"CALL",         0},
+    {"DEBUG",        1},
+    {"DISASSEMBLE",  1},
+    {"DISASM",       1},
+    {"DUMP",         1},
+    {"EVALUATE",     1},
+    {"EXECUTE",      1},
+    {"EXIT",         0},
+    {"FIND",         1},
+    {"GO",           0},
+    {"HANDLERS",     0},
+    {"HELP",         0},
+    {"?",            0},
+    {"HISTORY",      0},
+    {"!",            1},
+    {"!!",           0},
+    {"INFORMATION",  0},
+    {"INTEGRITY",    0},
+    {"INTO",         0},
+    {"LEVEL",        0},
+    {"LIST",         0},
+    {"LOCALS",       0},
+    {"LOCKS",        0},
+    {"METHODS",      0},
+    {"NAMESPACE",    0},
+    {"NOTIFY",       2},
+    {"OBJECTS",      0},
+    {"OSI",          0},
+    {"OWNER",        1},
+    {"PATHS",        0},
+    {"PREDEFINED",   0},
+    {"PREFIX",       0},
+    {"QUIT",         0},
+    {"REFERENCES",   1},
+    {"RESOURCES",    0},
+    {"RESULTS",      0},
+    {"SET",          3},
+    {"STATS",        1},
+    {"STOP",         0},
+    {"TABLES",       0},
+    {"TEMPLATE",     1},
+    {"TRACE",        1},
+    {"TREE",         0},
+    {"TYPE",         1},
+#ifdef ACPI_APPLICATION
+    {"ENABLEACPI",   0},
+    {"EVENT",        1},
+    {"GPE",          1},
+    {"GPES",         0},
+    {"SCI",          0},
+    {"SLEEP",        0},
+
+    {"CLOSE",        0},
+    {"LOAD",         1},
+    {"OPEN",         1},
+    {"UNLOAD",       1},
+
+    {"TERMINATE",    0},
+    {"THREADS",      3},
+
+    {"TEST",         1},
+#endif
+    {NULL,           0}
+};
+
+/*
+ * Help for all debugger commands. First argument is the number of lines
+ * of help to output for the command.
+ */
+static const ACPI_DB_COMMAND_HELP   AcpiGbl_DbCommandHelp[] =
+{
+    {0, "\nGeneral-Purpose Commands:",         "\n"},
+    {1, "  Allocations",                       "Display list of current memory allocations\n"},
+    {2, "  Dump <Address>|<Namepath>",         "\n"},
+    {0, "       [Byte|Word|Dword|Qword]",      "Display ACPI objects or memory\n"},
+    {1, "  Handlers",                          "Info about global handlers\n"},
+    {1, "  Help [Command]",                    "This help screen or individual command\n"},
+    {1, "  History",                           "Display command history buffer\n"},
+    {1, "  Level <DebugLevel>] [console]",     "Get/Set debug level for file or console\n"},
+    {1, "  Locks",                             "Current status of internal mutexes\n"},
+    {1, "  Osi [Install|Remove <name>]",       "Display or modify global _OSI list\n"},
+    {1, "  Quit or Exit",                      "Exit this command\n"},
+    {8, "  Stats <SubCommand>",                "Display namespace and memory statistics\n"},
+    {1, "     Allocations",                    "Display list of current memory allocations\n"},
+    {1, "     Memory",                         "Dump internal memory lists\n"},
+    {1, "     Misc",                           "Namespace search and mutex stats\n"},
+    {1, "     Objects",                        "Summary of namespace objects\n"},
+    {1, "     Sizes",                          "Sizes for each of the internal objects\n"},
+    {1, "     Stack",                          "Display CPU stack usage\n"},
+    {1, "     Tables",                         "Info about current ACPI table(s)\n"},
+    {1, "  Tables",                            "Display info about loaded ACPI tables\n"},
+    {1, "  ! <CommandNumber>",                 "Execute command from history buffer\n"},
+    {1, "  !!",                                "Execute last command again\n"},
+
+    {0, "\nNamespace Access Commands:",        "\n"},
+    {1, "  Businfo",                           "Display system bus info\n"},
+    {1, "  Disassemble <Method>",              "Disassemble a control method\n"},
+    {1, "  Find <AcpiName> (? is wildcard)",   "Find ACPI name(s) with wildcards\n"},
+    {1, "  Integrity",                         "Validate namespace integrity\n"},
+    {1, "  Methods",                           "Display list of loaded control methods\n"},
+    {1, "  Namespace [Object] [Depth]",        "Display loaded namespace tree/subtree\n"},
+    {1, "  Notify <Object> <Value>",           "Send a notification on Object\n"},
+    {1, "  Objects [ObjectType]",              "Display summary of all objects or just given type\n"},
+    {1, "  Owner <OwnerId> [Depth]",           "Display loaded namespace by object owner\n"},
+    {1, "  Paths",                             "Display full pathnames of namespace objects\n"},
+    {1, "  Predefined",                        "Check all predefined names\n"},
+    {1, "  Prefix [<Namepath>]",               "Set or Get current execution prefix\n"},
+    {1, "  References <Addr>",                 "Find all references to object at addr\n"},
+    {1, "  Resources [DeviceName]",            "Display Device resources (no arg = all devices)\n"},
+    {1, "  Set N <NamedObject> <Value>",       "Set value for named integer\n"},
+    {1, "  Template <Object>",                 "Format/dump a Buffer/ResourceTemplate\n"},
+    {1, "  Type <Object>",                     "Display object type\n"},
+
+    {0, "\nControl Method Execution Commands:","\n"},
+    {1, "  Arguments (or Args)",               "Display method arguments\n"},
+    {1, "  Breakpoint <AmlOffset>",            "Set an AML execution breakpoint\n"},
+    {1, "  Call",                              "Run to next control method invocation\n"},
+    {1, "  Debug <Namepath> [Arguments]",      "Single Step a control method\n"},
+    {6, "  Evaluate",                          "Synonym for Execute\n"},
+    {5, "  Execute <Namepath> [Arguments]",    "Execute control method\n"},
+    {1, "     Hex Integer",                    "Integer method argument\n"},
+    {1, "     \"Ascii String\"",               "String method argument\n"},
+    {1, "     (Hex Byte List)",                "Buffer method argument\n"},
+    {1, "     [Package Element List]",         "Package method argument\n"},
+    {1, "  Go",                                "Allow method to run to completion\n"},
+    {1, "  Information",                       "Display info about the current method\n"},
+    {1, "  Into",                              "Step into (not over) a method call\n"},
+    {1, "  List [# of Aml Opcodes]",           "Display method ASL statements\n"},
+    {1, "  Locals",                            "Display method local variables\n"},
+    {1, "  Results",                           "Display method result stack\n"},
+    {1, "  Set <A|L> <#> <Value>",             "Set method data (Arguments/Locals)\n"},
+    {1, "  Stop",                              "Terminate control method\n"},
+    {5, "  Trace <State> [<Namepath>] [Once]", "Trace control method execution\n"},
+    {1, "     Enable",                         "Enable all messages\n"},
+    {1, "     Disable",                        "Disable tracing\n"},
+    {1, "     Method",                         "Enable method execution messages\n"},
+    {1, "     Opcode",                         "Enable opcode execution messages\n"},
+    {1, "  Tree",                              "Display control method calling tree\n"},
+    {1, "  <Enter>",                           "Single step next AML opcode (over calls)\n"},
+
+#ifdef ACPI_APPLICATION
+    {0, "\nHardware Simulation Commands:",         "\n"},
+    {1, "  EnableAcpi",                        "Enable ACPI (hardware) mode\n"},
+    {1, "  Event <F|G> <Value>",               "Generate AcpiEvent (Fixed/GPE)\n"},
+    {1, "  Gpe <GpeNum> [GpeBlockDevice]",     "Simulate a GPE\n"},
+    {1, "  Gpes",                              "Display info on all GPE devices\n"},
+    {1, "  Sci",                               "Generate an SCI\n"},
+    {1, "  Sleep [SleepState]",                "Simulate sleep/wake sequence(s) (0-5)\n"},
+
+    {0, "\nFile I/O Commands:",                "\n"},
+    {1, "  Close",                             "Close debug output file\n"},
+    {1, "  Load <Input Filename>",             "Load ACPI table from a file\n"},
+    {1, "  Open <Output Filename>",            "Open a file for debug output\n"},
+    {1, "  Unload <Namepath>",                 "Unload an ACPI table via namespace object\n"},
+
+    {0, "\nUser Space Commands:",              "\n"},
+    {1, "  Terminate",                         "Delete namespace and all internal objects\n"},
+    {1, "  Thread <Threads><Loops><NamePath>", "Spawn threads to execute method(s)\n"},
+
+    {0, "\nDebug Test Commands:",              "\n"},
+    {3, "  Test <TestName>",                   "Invoke a debug test\n"},
+    {1, "     Objects",                        "Read/write/compare all namespace data objects\n"},
+    {1, "     Predefined",                     "Execute all ACPI predefined names (_STA, etc.)\n"},
+#endif
+    {0, NULL, NULL}
+};
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDbMatchCommandHelp
+ *
+ * PARAMETERS:  Command             - Command string to match
+ *              Help                - Help table entry to attempt match
+ *
+ * RETURN:      TRUE if command matched, FALSE otherwise
+ *
+ * DESCRIPTION: Attempt to match a command in the help table in order to
+ *              print help information for a single command.
+ *
+ ******************************************************************************/
+
+static BOOLEAN
+AcpiDbMatchCommandHelp (
+    const char                  *Command,
+    const ACPI_DB_COMMAND_HELP  *Help)
+{
+    char                    *Invocation = Help->Invocation;
+    UINT32                  LineCount;
+
+
+    /* Valid commands in the help table begin with a couple of spaces */
+
+    if (*Invocation != ' ')
+    {
+        return (FALSE);
+    }
+
+    while (*Invocation == ' ')
+    {
+        Invocation++;
+    }
+
+    /* Match command name (full command or substring) */
+
+    while ((*Command) && (*Invocation) && (*Invocation != ' '))
+    {
+        if (tolower ((int) *Command) != tolower ((int) *Invocation))
+        {
+            return (FALSE);
+        }
+
+        Invocation++;
+        Command++;
+    }
+
+    /* Print the appropriate number of help lines */
+
+    LineCount = Help->LineCount;
+    while (LineCount)
+    {
+        AcpiOsPrintf ("%-38s : %s", Help->Invocation, Help->Description);
+        Help++;
+        LineCount--;
+    }
+
+    return (TRUE);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDbDisplayCommandInfo
+ *
+ * PARAMETERS:  Command             - Command string to match
+ *              DisplayAll          - Display all matching commands, or just
+ *                                    the first one (substring match)
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Display help information for a Debugger command.
+ *
+ ******************************************************************************/
+
+static void
+AcpiDbDisplayCommandInfo (
+    const char              *Command,
+    BOOLEAN                 DisplayAll)
+{
+    const ACPI_DB_COMMAND_HELP  *Next;
+    BOOLEAN                     Matched;
+
+
+    Next = AcpiGbl_DbCommandHelp;
+    while (Next->Invocation)
+    {
+        Matched = AcpiDbMatchCommandHelp (Command, Next);
+        if (!DisplayAll && Matched)
+        {
+            return;
+        }
+
+        Next++;
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDbDisplayHelp
+ *
+ * PARAMETERS:  Command             - Optional command string to display help.
+ *                                    if not specified, all debugger command
+ *                                    help strings are displayed
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Display help for a single debugger command, or all of them.
+ *
+ ******************************************************************************/
+
+static void
+AcpiDbDisplayHelp (
+    char                    *Command)
+{
+    const ACPI_DB_COMMAND_HELP  *Next = AcpiGbl_DbCommandHelp;
+
+
+    if (!Command)
+    {
+        /* No argument to help, display help for all commands */
+
+        while (Next->Invocation)
+        {
+            AcpiOsPrintf ("%-38s%s", Next->Invocation, Next->Description);
+            Next++;
+        }
+    }
+    else
+    {
+        /* Display help for all commands that match the subtring */
+
+        AcpiDbDisplayCommandInfo (Command, TRUE);
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDbGetNextToken
+ *
+ * PARAMETERS:  String          - Command buffer
+ *              Next            - Return value, end of next token
+ *
+ * RETURN:      Pointer to the start of the next token.
+ *
+ * DESCRIPTION: Command line parsing. Get the next token on the command line
+ *
+ ******************************************************************************/
+
+char *
+AcpiDbGetNextToken (
+    char                    *String,
+    char                    **Next,
+    ACPI_OBJECT_TYPE        *ReturnType)
+{
+    char                    *Start;
+    UINT32                  Depth;
+    ACPI_OBJECT_TYPE        Type = ACPI_TYPE_INTEGER;
+
+
+    /* At end of buffer? */
+
+    if (!String || !(*String))
+    {
+        return (NULL);
+    }
+
+    /* Remove any spaces at the beginning */
+
+    if (*String == ' ')
+    {
+        while (*String && (*String == ' '))
+        {
+            String++;
+        }
+
+        if (!(*String))
+        {
+            return (NULL);
+        }
+    }
+
+    switch (*String)
+    {
+    case '"':
+
+        /* This is a quoted string, scan until closing quote */
+
+        String++;
+        Start = String;
+        Type = ACPI_TYPE_STRING;
+
+        /* Find end of string */
+
+        while (*String && (*String != '"'))
+        {
+            String++;
+        }
+        break;
+
+    case '(':
+
+        /* This is the start of a buffer, scan until closing paren */
+
+        String++;
+        Start = String;
+        Type = ACPI_TYPE_BUFFER;
+
+        /* Find end of buffer */
+
+        while (*String && (*String != ')'))
+        {
+            String++;
+        }
+        break;
+
+    case '[':
+
+        /* This is the start of a package, scan until closing bracket */
+
+        String++;
+        Depth = 1;
+        Start = String;
+        Type = ACPI_TYPE_PACKAGE;
+
+        /* Find end of package (closing bracket) */
+
+        while (*String)
+        {
+            /* Handle String package elements */
+
+            if (*String == '"')
+            {
+                /* Find end of string */
+
+                String++;
+                while (*String && (*String != '"'))
+                {
+                    String++;
+                }
+                if (!(*String))
+                {
+                    break;
+                }
+            }
+            else if (*String == '[')
+            {
+                Depth++;         /* A nested package declaration */
+            }
+            else if (*String == ']')
+            {
+                Depth--;
+                if (Depth == 0) /* Found final package closing bracket */
+                {
+                    break;
+                }
+            }
+
+            String++;
+        }
+        break;
+
+    default:
+
+        Start = String;
+
+        /* Find end of token */
+
+        while (*String && (*String != ' '))
+        {
+            String++;
+        }
+        break;
+    }
+
+    if (!(*String))
+    {
+        *Next = NULL;
+    }
+    else
+    {
+        *String = 0;
+        *Next = String + 1;
+    }
+
+    *ReturnType = Type;
+    return (Start);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDbGetLine
+ *
+ * PARAMETERS:  InputBuffer         - Command line buffer
+ *
+ * RETURN:      Count of arguments to the command
+ *
+ * DESCRIPTION: Get the next command line from the user. Gets entire line
+ *              up to the next newline
+ *
+ ******************************************************************************/
+
+static UINT32
+AcpiDbGetLine (
+    char                    *InputBuffer)
+{
+    UINT32                  i;
+    UINT32                  Count;
+    char                    *Next;
+    char                    *This;
+
+
+    if (AcpiUtSafeStrcpy (AcpiGbl_DbParsedBuf, sizeof (AcpiGbl_DbParsedBuf),
+        InputBuffer))
+    {
+        AcpiOsPrintf (
+            "Buffer overflow while parsing input line (max %u characters)\n",
+            sizeof (AcpiGbl_DbParsedBuf));
+        return (0);
+    }
+
+    This = AcpiGbl_DbParsedBuf;
+    for (i = 0; i < ACPI_DEBUGGER_MAX_ARGS; i++)
+    {
+        AcpiGbl_DbArgs[i] = AcpiDbGetNextToken (This, &Next,
+            &AcpiGbl_DbArgTypes[i]);
+        if (!AcpiGbl_DbArgs[i])
+        {
+            break;
+        }
+
+        This = Next;
+    }
+
+    /* Uppercase the actual command */
+
+    AcpiUtStrupr (AcpiGbl_DbArgs[0]);
+
+    Count = i;
+    if (Count)
+    {
+        Count--;  /* Number of args only */
+    }
+
+    return (Count);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDbMatchCommand
+ *
+ * PARAMETERS:  UserCommand             - User command line
+ *
+ * RETURN:      Index into command array, -1 if not found
+ *
+ * DESCRIPTION: Search command array for a command match
+ *
+ ******************************************************************************/
+
+static UINT32
+AcpiDbMatchCommand (
+    char                    *UserCommand)
+{
+    UINT32                  i;
+
+
+    if (!UserCommand || UserCommand[0] == 0)
+    {
+        return (CMD_NULL);
+    }
+
+    for (i = CMD_FIRST_VALID; AcpiGbl_DbCommands[i].Name; i++)
+    {
+        if (strstr (
+            ACPI_CAST_PTR (char, AcpiGbl_DbCommands[i].Name), UserCommand) ==
+            AcpiGbl_DbCommands[i].Name)
+        {
+            return (i);
+        }
+    }
+
+    /* Command not recognized */
+
+    return (CMD_NOT_FOUND);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDbCommandDispatch
+ *
+ * PARAMETERS:  InputBuffer         - Command line buffer
+ *              WalkState           - Current walk
+ *              Op                  - Current (executing) parse op
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Command dispatcher.
+ *
+ ******************************************************************************/
+
+ACPI_STATUS
+AcpiDbCommandDispatch (
+    char                    *InputBuffer,
+    ACPI_WALK_STATE         *WalkState,
+    ACPI_PARSE_OBJECT       *Op)
+{
+    UINT32                  Temp;
+    UINT32                  CommandIndex;
+    UINT32                  ParamCount;
+    char                    *CommandLine;
+    ACPI_STATUS             Status = AE_CTRL_TRUE;
+
+
+    /* If AcpiTerminate has been called, terminate this thread */
+
+    if (AcpiGbl_DbTerminateLoop)
+    {
+        return (AE_CTRL_TERMINATE);
+    }
+
+    /* Find command and add to the history buffer */
+
+    ParamCount = AcpiDbGetLine (InputBuffer);
+    CommandIndex = AcpiDbMatchCommand (AcpiGbl_DbArgs[0]);
+    Temp = 0;
+
+    /*
+     * We don't want to add the !! command to the history buffer. It
+     * would cause an infinite loop because it would always be the
+     * previous command.
+     */
+    if (CommandIndex != CMD_HISTORY_LAST)
+    {
+        AcpiDbAddToHistory (InputBuffer);
+    }
+
+    /* Verify that we have the minimum number of params */
+
+    if (ParamCount < AcpiGbl_DbCommands[CommandIndex].MinArgs)
+    {
+        AcpiOsPrintf ("%u parameters entered, [%s] requires %u parameters\n",
+            ParamCount, AcpiGbl_DbCommands[CommandIndex].Name,
+            AcpiGbl_DbCommands[CommandIndex].MinArgs);
+
+        AcpiDbDisplayCommandInfo (
+            AcpiGbl_DbCommands[CommandIndex].Name, FALSE);
+        return (AE_CTRL_TRUE);
+    }
+
+    /* Decode and dispatch the command */
+
+    switch (CommandIndex)
+    {
+    case CMD_NULL:
+
+        if (Op)
+        {
+            return (AE_OK);
+        }
+        break;
+
+    case CMD_ALLOCATIONS:
+
+#ifdef ACPI_DBG_TRACK_ALLOCATIONS
+        AcpiUtDumpAllocations ((UINT32) -1, NULL);
+#endif
+        break;
+
+    case CMD_ARGS:
+    case CMD_ARGUMENTS:
+
+        AcpiDbDisplayArguments ();
+        break;
+
+    case CMD_BREAKPOINT:
+
+        AcpiDbSetMethodBreakpoint (AcpiGbl_DbArgs[1], WalkState, Op);
+        break;
+
+    case CMD_BUSINFO:
+
+        AcpiDbGetBusInfo ();
+        break;
+
+    case CMD_CALL:
+
+        AcpiDbSetMethodCallBreakpoint (Op);
+        Status = AE_OK;
+        break;
+
+    case CMD_DEBUG:
+
+        AcpiDbExecute (AcpiGbl_DbArgs[1],
+            &AcpiGbl_DbArgs[2], &AcpiGbl_DbArgTypes[2], EX_SINGLE_STEP);
+        break;
+
+    case CMD_DISASSEMBLE:
+    case CMD_DISASM:
+
+        (void) AcpiDbDisassembleMethod (AcpiGbl_DbArgs[1]);
+        break;
+
+    case CMD_DUMP:
+
+        AcpiDbDecodeAndDisplayObject (AcpiGbl_DbArgs[1], AcpiGbl_DbArgs[2]);
+        break;
+
+    case CMD_EVALUATE:
+    case CMD_EXECUTE:
+
+        AcpiDbExecute (AcpiGbl_DbArgs[1],
+            &AcpiGbl_DbArgs[2], &AcpiGbl_DbArgTypes[2], EX_NO_SINGLE_STEP);
+        break;
+
+    case CMD_FIND:
+
+        Status = AcpiDbFindNameInNamespace (AcpiGbl_DbArgs[1]);
+        break;
+
+    case CMD_GO:
+
+        AcpiGbl_CmSingleStep = FALSE;
+        return (AE_OK);
+
+    case CMD_HANDLERS:
+
+        AcpiDbDisplayHandlers ();
+        break;
+
+    case CMD_HELP:
+    case CMD_HELP2:
+
+        AcpiDbDisplayHelp (AcpiGbl_DbArgs[1]);
+        break;
+
+    case CMD_HISTORY:
+
+        AcpiDbDisplayHistory ();
+        break;
+
+    case CMD_HISTORY_EXE: /* ! command */
+
+        CommandLine = AcpiDbGetFromHistory (AcpiGbl_DbArgs[1]);
+        if (!CommandLine)
+        {
+            return (AE_CTRL_TRUE);
+        }
+
+        Status = AcpiDbCommandDispatch (CommandLine, WalkState, Op);
+        return (Status);
+
+    case CMD_HISTORY_LAST: /* !! command */
+
+        CommandLine = AcpiDbGetFromHistory (NULL);
+        if (!CommandLine)
+        {
+            return (AE_CTRL_TRUE);
+        }
+
+        Status = AcpiDbCommandDispatch (CommandLine, WalkState, Op);
+        return (Status);
+
+    case CMD_INFORMATION:
+
+        AcpiDbDisplayMethodInfo (Op);
+        break;
+
+    case CMD_INTEGRITY:
+
+        AcpiDbCheckIntegrity ();
+        break;
+
+    case CMD_INTO:
+
+        if (Op)
+        {
+            AcpiGbl_CmSingleStep = TRUE;
+            return (AE_OK);
+        }
+        break;
+
+    case CMD_LEVEL:
+
+        if (ParamCount == 0)
+        {
+            AcpiOsPrintf (
+                "Current debug level for file output is:    %8.8lX\n",
+                AcpiGbl_DbDebugLevel);
+            AcpiOsPrintf (
+                "Current debug level for console output is: %8.8lX\n",
+                AcpiGbl_DbConsoleDebugLevel);
+        }
+        else if (ParamCount == 2)
+        {
+            Temp = AcpiGbl_DbConsoleDebugLevel;
+            AcpiGbl_DbConsoleDebugLevel =
+                strtoul (AcpiGbl_DbArgs[1], NULL, 16);
+            AcpiOsPrintf (
+                "Debug Level for console output was %8.8lX, now %8.8lX\n",
+                Temp, AcpiGbl_DbConsoleDebugLevel);
+        }
+        else
+        {
+            Temp = AcpiGbl_DbDebugLevel;
+            AcpiGbl_DbDebugLevel = strtoul (AcpiGbl_DbArgs[1], NULL, 16);
+            AcpiOsPrintf (
+                "Debug Level for file output was %8.8lX, now %8.8lX\n",
+                Temp, AcpiGbl_DbDebugLevel);
+        }
+        break;
+
+    case CMD_LIST:
+
+        AcpiDbDisassembleAml (AcpiGbl_DbArgs[1], Op);
+        break;
+
+    case CMD_LOCKS:
+
+        AcpiDbDisplayLocks ();
+        break;
+
+    case CMD_LOCALS:
+
+        AcpiDbDisplayLocals ();
+        break;
+
+    case CMD_METHODS:
+
+        Status = AcpiDbDisplayObjects ("METHOD", AcpiGbl_DbArgs[1]);
+        break;
+
+    case CMD_NAMESPACE:
+
+        AcpiDbDumpNamespace (AcpiGbl_DbArgs[1], AcpiGbl_DbArgs[2]);
+        break;
+
+    case CMD_NOTIFY:
+
+        Temp = strtoul (AcpiGbl_DbArgs[2], NULL, 0);
+        AcpiDbSendNotify (AcpiGbl_DbArgs[1], Temp);
+        break;
+
+    case CMD_OBJECTS:
+
+        AcpiUtStrupr (AcpiGbl_DbArgs[1]);
+        Status = AcpiDbDisplayObjects (AcpiGbl_DbArgs[1], AcpiGbl_DbArgs[2]);
+        break;
+
+    case CMD_OSI:
+
+        AcpiDbDisplayInterfaces (AcpiGbl_DbArgs[1], AcpiGbl_DbArgs[2]);
+        break;
+
+    case CMD_OWNER:
+
+        AcpiDbDumpNamespaceByOwner (AcpiGbl_DbArgs[1], AcpiGbl_DbArgs[2]);
+        break;
+
+    case CMD_PATHS:
+
+        AcpiDbDumpNamespacePaths ();
+        break;
+
+    case CMD_PREFIX:
+
+        AcpiDbSetScope (AcpiGbl_DbArgs[1]);
+        break;
+
+    case CMD_REFERENCES:
+
+        AcpiDbFindReferences (AcpiGbl_DbArgs[1]);
+        break;
+
+    case CMD_RESOURCES:
+
+        AcpiDbDisplayResources (AcpiGbl_DbArgs[1]);
+        break;
+
+    case CMD_RESULTS:
+
+        AcpiDbDisplayResults ();
+        break;
+
+    case CMD_SET:
+
+        AcpiDbSetMethodData (AcpiGbl_DbArgs[1], AcpiGbl_DbArgs[2],
+            AcpiGbl_DbArgs[3]);
+        break;
+
+    case CMD_STATS:
+
+        Status = AcpiDbDisplayStatistics (AcpiGbl_DbArgs[1]);
+        break;
+
+    case CMD_STOP:
+
+        return (AE_NOT_IMPLEMENTED);
+
+    case CMD_TABLES:
+
+        AcpiDbDisplayTableInfo (AcpiGbl_DbArgs[1]);
+        break;
+
+    case CMD_TEMPLATE:
+
+        AcpiDbDisplayTemplate (AcpiGbl_DbArgs[1]);
+        break;
+
+    case CMD_TRACE:
+
+        AcpiDbTrace (AcpiGbl_DbArgs[1], AcpiGbl_DbArgs[2], AcpiGbl_DbArgs[3]);
+        break;
+
+    case CMD_TREE:
+
+        AcpiDbDisplayCallingTree ();
+        break;
+
+    case CMD_TYPE:
+
+        AcpiDbDisplayObjectType (AcpiGbl_DbArgs[1]);
+        break;
+
+#ifdef ACPI_APPLICATION
+
+    /* Hardware simulation commands. */
+
+    case CMD_ENABLEACPI:
+#if (!ACPI_REDUCED_HARDWARE)
+
+        Status = AcpiEnable();
+        if (ACPI_FAILURE(Status))
+        {
+            AcpiOsPrintf("AcpiEnable failed (Status=%X)\n", Status);
+            return (Status);
+        }
+#endif /* !ACPI_REDUCED_HARDWARE */
+        break;
+
+    case CMD_EVENT:
+
+        AcpiOsPrintf ("Event command not implemented\n");
+        break;
+
+    case CMD_GPE:
+
+        AcpiDbGenerateGpe (AcpiGbl_DbArgs[1], AcpiGbl_DbArgs[2]);
+        break;
+
+    case CMD_GPES:
+
+        AcpiDbDisplayGpes ();
+        break;
+
+    case CMD_SCI:
+
+        AcpiDbGenerateSci ();
+        break;
+
+    case CMD_SLEEP:
+
+        Status = AcpiDbSleep (AcpiGbl_DbArgs[1]);
+        break;
+
+    /* File I/O commands. */
+
+    case CMD_CLOSE:
+
+        AcpiDbCloseDebugFile ();
+        break;
+
+    case CMD_LOAD:
+        {
+            ACPI_NEW_TABLE_DESC     *ListHead = NULL;
+
+            Status = AcGetAllTablesFromFile (AcpiGbl_DbArgs[1],
+                ACPI_GET_ALL_TABLES, &ListHead);
+            if (ACPI_SUCCESS (Status))
+            {
+                AcpiDbLoadTables (ListHead);
+            }
+        }
+        break;
+
+    case CMD_OPEN:
+
+        AcpiDbOpenDebugFile (AcpiGbl_DbArgs[1]);
+        break;
+
+    /* User space commands. */
+
+    case CMD_TERMINATE:
+
+        AcpiDbSetOutputDestination (ACPI_DB_REDIRECTABLE_OUTPUT);
+        AcpiUtSubsystemShutdown ();
+
+        /*
+         * TBD: [Restructure] Need some way to re-initialize without
+         * re-creating the semaphores!
+         */
+
+        AcpiGbl_DbTerminateLoop = TRUE;
+        /*  AcpiInitialize (NULL);  */
+        break;
+
+    case CMD_THREADS:
+
+        AcpiDbCreateExecutionThreads (AcpiGbl_DbArgs[1], AcpiGbl_DbArgs[2],
+            AcpiGbl_DbArgs[3]);
+        break;
+
+    /* Debug test commands. */
+
+    case CMD_PREDEFINED:
+
+        AcpiDbCheckPredefinedNames ();
+        break;
+
+    case CMD_TEST:
+
+        AcpiDbExecuteTest (AcpiGbl_DbArgs[1]);
+        break;
+
+    case CMD_UNLOAD:
+
+        AcpiDbUnloadAcpiTable (AcpiGbl_DbArgs[1]);
+        break;
+#endif
+
+    case CMD_EXIT:
+    case CMD_QUIT:
+
+        if (Op)
+        {
+            AcpiOsPrintf ("Method execution terminated\n");
+            return (AE_CTRL_TERMINATE);
+        }
+
+        if (!AcpiGbl_DbOutputToFile)
+        {
+            AcpiDbgLevel = ACPI_DEBUG_DEFAULT;
+        }
+
+#ifdef ACPI_APPLICATION
+        AcpiDbCloseDebugFile ();
+#endif
+        AcpiGbl_DbTerminateLoop = TRUE;
+        return (AE_CTRL_TERMINATE);
+
+    case CMD_NOT_FOUND:
+    default:
+
+        AcpiOsPrintf ("%s: unknown command\n", AcpiGbl_DbArgs[0]);
+        return (AE_CTRL_TRUE);
+    }
+
+    if (ACPI_SUCCESS (Status))
+    {
+        Status = AE_CTRL_TRUE;
+    }
+
+    return (Status);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDbExecuteThread
+ *
+ * PARAMETERS:  Context         - Not used
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Debugger execute thread. Waits for a command line, then
+ *              simply dispatches it.
+ *
+ ******************************************************************************/
+
+void ACPI_SYSTEM_XFACE
+AcpiDbExecuteThread (
+    void                    *Context)
+{
+    ACPI_STATUS             Status = AE_OK;
+    ACPI_STATUS             MStatus;
+
+
+    while (Status != AE_CTRL_TERMINATE && !AcpiGbl_DbTerminateLoop)
+    {
+        AcpiGbl_MethodExecuting = FALSE;
+        AcpiGbl_StepToNextCall = FALSE;
+
+        MStatus = AcpiOsAcquireMutex (AcpiGbl_DbCommandReady,
+            ACPI_WAIT_FOREVER);
+        if (ACPI_FAILURE (MStatus))
+        {
+            return;
+        }
+
+        Status = AcpiDbCommandDispatch (AcpiGbl_DbLineBuf, NULL, NULL);
+
+        AcpiOsReleaseMutex (AcpiGbl_DbCommandComplete);
+    }
+    AcpiGbl_DbThreadsTerminated = TRUE;
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDbSingleThread
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Debugger execute thread. Waits for a command line, then
+ *              simply dispatches it.
+ *
+ ******************************************************************************/
+
+static void
+AcpiDbSingleThread (
+    void)
+{
+
+    AcpiGbl_MethodExecuting = FALSE;
+    AcpiGbl_StepToNextCall = FALSE;
+
+    (void) AcpiDbCommandDispatch (AcpiGbl_DbLineBuf, NULL, NULL);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDbUserCommands
+ *
+ * PARAMETERS:  Prompt              - User prompt (depends on mode)
+ *              Op                  - Current executing parse op
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Command line execution for the AML debugger. Commands are
+ *              matched and dispatched here.
+ *
+ ******************************************************************************/
+
+ACPI_STATUS
+AcpiDbUserCommands (
+    char                    Prompt,
+    ACPI_PARSE_OBJECT       *Op)
+{
+    ACPI_STATUS             Status = AE_OK;
+
+
+    AcpiOsPrintf ("\n");
+
+    /* TBD: [Restructure] Need a separate command line buffer for step mode */
+
+    while (!AcpiGbl_DbTerminateLoop)
+    {
+        /* Force output to console until a command is entered */
+
+        AcpiDbSetOutputDestination (ACPI_DB_CONSOLE_OUTPUT);
+
+        /* Different prompt if method is executing */
+
+        if (!AcpiGbl_MethodExecuting)
+        {
+            AcpiOsPrintf ("%1c ", ACPI_DEBUGGER_COMMAND_PROMPT);
+        }
+        else
+        {
+            AcpiOsPrintf ("%1c ", ACPI_DEBUGGER_EXECUTE_PROMPT);
+        }
+
+        /* Get the user input line */
+
+        Status = AcpiOsGetLine (AcpiGbl_DbLineBuf,
+            ACPI_DB_LINE_BUFFER_SIZE, NULL);
+        if (ACPI_FAILURE (Status))
+        {
+            ACPI_EXCEPTION ((AE_INFO, Status, "While parsing command line"));
+            return (Status);
+        }
+
+        /* Check for single or multithreaded debug */
+
+        if (AcpiGbl_DebuggerConfiguration & DEBUGGER_MULTI_THREADED)
+        {
+            /*
+             * Signal the debug thread that we have a command to execute,
+             * and wait for the command to complete.
+             */
+            AcpiOsReleaseMutex (AcpiGbl_DbCommandReady);
+
+            Status = AcpiOsAcquireMutex (AcpiGbl_DbCommandComplete,
+                ACPI_WAIT_FOREVER);
+            if (ACPI_FAILURE (Status))
+            {
+                return (Status);
+            }
+        }
+        else
+        {
+            /* Just call to the command line interpreter */
+
+            AcpiDbSingleThread ();
+        }
+    }
+
+    return (Status);
+}
+#endif
+ACPI_STATUS
+AcpiDbCommandDispatch (
+    char                    *InputBuffer,
+    ACPI_WALK_STATE         *WalkState,
+    ACPI_PARSE_OBJECT       *Op)
+{
+	sysfatal("%s", __func__);
+}
+void ACPI_SYSTEM_XFACE
+AcpiDbExecuteThread (
+    void                    *Context)
+{
+	sysfatal("%s", __func__);
+}
+char *
+AcpiDbGetNextToken (
+    char                    *String,
+    char                    **Next,
+    ACPI_OBJECT_TYPE        *ReturnType)
+{
+	sysfatal("%s", __func__);
+}

--- a/sys/src/libacpi/hack.c
+++ b/sys/src/libacpi/hack.c
@@ -1455,5 +1455,5 @@ AcpiDbGetNextToken (
     ACPI_OBJECT_TYPE        *ReturnType)
 {
 	sysfatal("%s", __func__);
-	return AE_OK;
+	return NULL;
 }

--- a/sys/src/libacpi/harvey.c
+++ b/sys/src/libacpi/harvey.c
@@ -232,7 +232,7 @@ AcpiOsMapMemory (
 		fprint(2,"%s: read %s: %r\n", __func__, name);
 		return nil;
 	}
-	hexdump(v, Length);
+	//hexdump(v, Length);
 	return v;
 }
 

--- a/sys/src/libacpi/harvey.c
+++ b/sys/src/libacpi/harvey.c
@@ -165,16 +165,19 @@ AcpiOsSignal (
 	return AE_OK;
 }
 
+/* N.B. Only works for single thread! */
 void ACPI_INTERNAL_VAR_XFACE
 AcpiOsPrintf (
     const char              *Format,
     ...)
 {
+	static char buf[65536];
 	va_list args;
 
 	va_start(args, Format);
-	fprint(2,(char *)Format, args);
+	vseprint(buf, &buf[65535], (char *)Format, args);
 	va_end(args);
+	fprint(2,buf);
 }
 
 void
@@ -232,7 +235,7 @@ AcpiOsMapMemory (
 		fprint(2,"%s: read %s: %r\n", __func__, name);
 		return nil;
 	}
-	//hexdump(v, Length);
+	hexdump(v, Length);
 	return v;
 }
 
@@ -399,7 +402,7 @@ ACPI_THREAD_ID
 AcpiOsGetThreadId (
     void)
 {
-	static int pid = -1;
+	static int pid = 2525;
 	if (pid < 0)
 		pid = getpid();
 	return pid;
@@ -578,6 +581,7 @@ AcpiOsTerminate (
     void)
 {
 	sysfatal("%s\n", __func__);
+	return AE_OK;
 }
 
 /* Another acpica failure of vision: code in libraries that depends on functions defined only

--- a/sys/src/libacpi/harvey.c
+++ b/sys/src/libacpi/harvey.c
@@ -1,0 +1,629 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+#include <acpi.h>
+
+#define MiB (1<<20)
+
+static uint32_t rsdp;
+static char *name;
+
+static int xisprint(int c)
+{
+	return (c >= 32 && c <= 126);
+}
+
+static void hexdump(void *v, int length)
+{
+	int i;
+	uint8_t *m = v;
+	uintptr_t memory = (uintptr_t) v;
+	int all_zero = 0;
+	fprint(2,"hexdump: %p, %u\n", v, length);
+	for (i = 0; i < length; i += 16) {
+		int j;
+
+		all_zero++;
+		for (j = 0; (j < 16) && (i + j < length); j++) {
+			if (m[i + j] != 0) {
+				all_zero = 0;
+				break;
+			}
+		}
+
+		if (all_zero < 2) {
+			fprint(2,"%p:", (void *)(memory + i));
+			for (j = 0; j < 16; j++)
+				fprint(2," %02x", m[i + j]);
+			fprint(2,"  ");
+			for (j = 0; j < 16; j++)
+				fprint(2,"%c", xisprint(m[i + j]) ? m[i + j] : '.');
+			fprint(2,"\n");
+		} else if (all_zero == 2) {
+			fprint(2,"...\n");
+		}
+	}
+}
+
+static int rawfd(void){
+	if (name == nil)
+		name = smprint("#%C/raw", L'α');
+	fprint(2,"Rawfd: open '%s'\n", name);
+	return open(name, OREAD);
+}
+
+static int tbdf(ACPI_PCI_ID *p)
+{
+	return (p->Bus << 8) | (p->Device << 3) | (p->Function);
+}
+
+
+ACPI_STATUS
+AcpiOsReadPciConfiguration (
+    ACPI_PCI_ID             *PciId,
+    UINT32                  Reg,
+    UINT64                  *Value,
+    UINT32                  Width)
+{
+	uint32_t dev = tbdf(PciId);
+	fprint(2,"%s 0x%lx\n", __func__, dev);
+	sysfatal("NOT");
+#if 0
+	switch(Width) {
+	case 32:
+		*Value = pcicfgr32(&p, Reg);
+		break;
+	case 16:
+		*Value = pcicfgr16(&p, Reg);
+		break;
+	case 8:
+		*Value = pcicfgr8(&p, Reg);
+		break;
+	default:
+		sysfatal("Can't read pci: bad width %d\n", Width);
+	}
+#endif
+	return AE_OK;
+
+}
+
+ACPI_STATUS
+AcpiOsWritePciConfiguration (
+    ACPI_PCI_ID             *PciId,
+    UINT32                  Reg,
+    UINT64                  Value,
+    UINT32                  Width)
+{
+	uint32_t dev = tbdf(PciId);
+	fprint(2,"%s 0x%lx\n", __func__, dev);
+	sysfatal("NOT");
+#if 0
+	switch(Width) {
+	case 32:
+		pcicfgw32(&p, Reg, Value);
+		break;
+	case 16:
+		pcicfgw16(&p, Reg, Value);
+		break;
+	case 8:
+		pcicfgw8(&p, Reg, Value);
+		break;
+	default:
+		sysfatal("Can't read pci: bad width %d\n", Width);
+	}
+#endif
+	return AE_OK;
+}
+
+/*
+ * Miscellaneous
+ */
+BOOLEAN
+AcpiOsReadable (
+    void                    *Pointer,
+    ACPI_SIZE               Length)
+{
+	fprint(2,"%s\n", __func__);
+	sysfatal("%s", __func__);
+	return AE_OK;
+}
+
+
+BOOLEAN
+AcpiOsWritable (
+    void                    *Pointer,
+    ACPI_SIZE               Length)
+{
+	fprint(2,"%s\n", __func__);
+	sysfatal("%s", __func__);
+	return AE_OK;
+}
+
+
+UINT64
+AcpiOsGetTimer (
+    void)
+{
+	fprint(2,"%s\n", __func__);
+	sysfatal("%s", __func__);
+	return AE_OK;
+}
+
+
+ACPI_STATUS
+AcpiOsSignal (
+    UINT32                  Function,
+    void                    *Info)
+{
+	fprint(2,"%s\n", __func__);
+	sysfatal("%s", __func__);
+	return AE_OK;
+}
+
+void ACPI_INTERNAL_VAR_XFACE
+AcpiOsPrintf (
+    const char              *Format,
+    ...)
+{
+	va_list args;
+
+	va_start(args, Format);
+	fprint(2,(char *)Format, args);
+	va_end(args);
+}
+
+void
+AcpiOsVprintf (
+    const char              *Format,
+    va_list                 Args)
+{
+	/* This is a leaf function, and this function is required to implement
+	 * the va_list argument. I couldn't find any other way to do this. */
+	static char buf[1024];
+	vseprint(buf, &buf[1023], (char *)Format, Args);
+	fprint(2,buf);
+}
+
+void
+AcpiOsFree (
+    void *                  Memory)
+{
+	//fprint(2,"%s\n", __func__);
+	free(Memory);
+}
+
+void *
+AcpiOsAllocate (
+    ACPI_SIZE               Size)
+{
+	//fprint(2,"%s\n", __func__);
+	return malloc(Size);
+}
+
+void *
+AcpiOsMapMemory (
+    ACPI_PHYSICAL_ADDRESS   Where,
+    ACPI_SIZE               Length)
+{
+
+	int fd, amt;
+	fd = rawfd();
+	fprint(2,"%s %p %d\n", __func__, (void *)Where, Length);
+	void *v = malloc(Length);
+	if (!v){
+		sysfatal("%s: %r", __func__);
+		return nil;
+	}
+	fd = rawfd();
+	if (fd < 0) {
+		fprint(2,"%s: open %s: %r\n", __func__, name);
+		return nil;
+	}
+	
+	amt = pread(fd, v, Length, Where);
+	close(fd);
+	if (amt < Length){
+		free(v);
+		fprint(2,"%s: read %s: %r\n", __func__, name);
+		return nil;
+	}
+	hexdump(v, Length);
+	return v;
+}
+
+void
+AcpiOsUnmapMemory (
+    void                    *LogicalAddress,
+    ACPI_SIZE               Size)
+{
+	free(LogicalAddress);
+	fprint(2,"%s %p %d \n", __func__, LogicalAddress, Size);
+}
+
+ACPI_STATUS
+AcpiOsGetPhysicalAddress (
+    void                    *LogicalAddress,
+    ACPI_PHYSICAL_ADDRESS   *PhysicalAddress)
+{
+	ACPI_PHYSICAL_ADDRESS ret = (uintptr_t)LogicalAddress;
+	fprint(2,"%s %p = %p", __func__, (void *)ret, LogicalAddress);
+	*PhysicalAddress = ret;
+	return AE_OK;
+}
+
+/* This is the single threaded version of
+ * these functions. This is now NetBSD does it. */
+ACPI_STATUS
+AcpiOsCreateSemaphore (
+    UINT32                  MaxUnits,
+    UINT32                  InitialUnits,
+    ACPI_SEMAPHORE          *OutHandle)
+{
+	//fprint(2,"%s\n", __func__);
+	*OutHandle = (ACPI_SEMAPHORE) 1;
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsDeleteSemaphore (
+    ACPI_SEMAPHORE          Handle)
+{
+	//fprint(2,"%s\n", __func__);
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsWaitSemaphore (
+    ACPI_SEMAPHORE          Handle,
+    UINT32                  Units,
+    UINT16                  Timeout)
+{
+	//fprint(2,"%s\n", __func__);
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsSignalSemaphore (
+    ACPI_SEMAPHORE          Handle,
+    UINT32                  Units)
+{
+	//fprint(2,"%s\n", __func__);
+	return AE_OK;
+}
+
+/* this is the single threaded case and as minix shows there is nothing to do. */
+ACPI_STATUS
+AcpiOsCreateLock (
+    ACPI_SPINLOCK           *OutHandle)
+{
+	//fprint(2,"%s\n", __func__);
+	*OutHandle = nil;
+	return AE_OK;
+}
+
+void
+AcpiOsDeleteLock (
+    ACPI_SPINLOCK           Handle)
+{
+	//fprint(2,"%s\n", __func__);
+}
+
+ACPI_CPU_FLAGS
+AcpiOsAcquireLock (
+    ACPI_SPINLOCK           Handle)
+{
+	//fprint(2,"%s\n", __func__);
+	return 0;
+}
+
+void
+AcpiOsReleaseLock (
+    ACPI_SPINLOCK           Handle,
+    ACPI_CPU_FLAGS          Flags)
+{
+	//fprint(2,"%s\n", __func__);
+}
+
+struct handler {
+	ACPI_OSD_HANDLER        ServiceRoutine;
+	void                    *Context;
+};
+
+/* The ACPI interrupt signature and the Harvey one are not compatible. So, we pass an arg to
+ * intrenable that can in turn be used to this function to call the ACPI handler. */
+static void acpihandler(void*_, void *arg)
+{
+	struct handler *h = arg;
+	h->ServiceRoutine(h->Context);
+}
+
+ACPI_STATUS
+AcpiOsInstallInterruptHandler (
+    UINT32                  InterruptNumber,
+    ACPI_OSD_HANDLER        ServiceRoutine,
+    void                    *Context)
+{
+	/* minix says "don't do it". So we don't, yet. */
+	return AE_OK;
+	struct handler *h = malloc(sizeof(*h));
+	if (! h)
+		return AE_NO_MEMORY;
+	h->ServiceRoutine = ServiceRoutine;
+	h->Context = Context;
+	fprint(2,"NOT DOING %s %d %p %p \n", __func__, InterruptNumber, ServiceRoutine, Context);
+	/* once enabled, can't be disabled; ignore the return value unless it's nil. */
+	//intrenable(InterruptNumber, acpihandler, h, 0x5, "ACPI interrupt handler");
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsRemoveInterruptHandler (
+    UINT32                  InterruptNumber,
+    ACPI_OSD_HANDLER        ServiceRoutine)
+{
+	fprint(2,"%s\n", __func__);
+	sysfatal("%s", __func__);
+	return AE_OK;
+}
+
+void
+AcpiOsWaitEventsComplete (
+	void)
+{
+	fprint(2,"%s\n", __func__);
+	sysfatal("%s", __func__);
+}
+
+void
+AcpiOsSleep (
+    UINT64                  Milliseconds)
+{
+	fprint(2,"%s\n", __func__);
+	sysfatal("%s", __func__);
+}
+
+void
+AcpiOsStall(
+    UINT32                  Microseconds)
+{
+	fprint(2,"%s\n", __func__);
+	sysfatal("%s", __func__);
+}
+
+ACPI_THREAD_ID
+AcpiOsGetThreadId (
+    void)
+{
+	static int pid = -1;
+	if (pid < 0)
+		pid = getpid();
+	return pid;
+}
+
+ACPI_STATUS
+AcpiOsExecute (
+    ACPI_EXECUTE_TYPE       Type,
+    ACPI_OSD_EXEC_CALLBACK  Function,
+    void                    *Context)
+{
+	fprint(2,"%s\n", __func__);
+	sysfatal("%s", __func__);
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsReadPort (
+    ACPI_IO_ADDRESS         Address,
+    UINT32                  *Value,
+    UINT32                  Width)
+{
+	/* Ooooooookay ... ACPI specifies the IO width in *bits*. */
+#if 0
+	switch(Width) {
+	case 4*8:
+		*Value = inl(Address);
+		break;
+	case 2*8:
+		*Value = ins(Address);
+		break;
+	case 1*8:
+		*Value = inb(Address);
+		break;
+	default:
+		sysfatal("%s, bad width %d", __func__, Width);
+		break;
+	}
+#endif
+	fprint(2,"%s 0x%x 0x%x\n", __func__, Address, *Value);
+	sysfatal("NOT");
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsWritePort (
+    ACPI_IO_ADDRESS         Address,
+    UINT32                  Value,
+    UINT32                  Width)
+{
+#if 0
+	switch(Width) {
+	case 4*8:
+		outl(Address, Value);
+		break;
+	case 2*8:
+		outs(Address, Value);
+		break;
+	case 1*8:
+		outb(Address, Value);
+		break;
+	default:
+		sysfatal("%s, bad width %d", __func__, Width);
+		break;
+	}
+#endif
+	fprint(2,"%s 0x%x 0x%x\n", __func__, Address, Value);
+	sysfatal("NOT");
+	return AE_OK;
+}
+
+/*
+ * Platform and hardware-independent physical memory interfaces
+ */
+ACPI_STATUS
+AcpiOsReadMemory (
+    ACPI_PHYSICAL_ADDRESS   Address,
+    UINT64                  *Value,
+    UINT32                  Width)
+{
+	fprint(2,"%s\n", __func__);
+	sysfatal("%s", __func__);
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsWriteMemory (
+    ACPI_PHYSICAL_ADDRESS   Address,
+    UINT64                  Value,
+    UINT32                  Width)
+{
+	fprint(2,"%s\n", __func__);
+	sysfatal("%s", __func__);
+	return AE_OK;
+}
+/* Just try to read the rsdp, if that fails, we're screwed anyway. */
+ACPI_STATUS
+AcpiOsInitialize(void)
+{
+	int fd, amt;
+	fprint(2,"%s\n", __func__);
+
+	fd = rawfd();
+	if (fd < 0) {
+		fprint(2,"%s: open %s: %r\n", __func__, name);
+		return AE_ERROR;
+	}
+	
+	amt = read(fd, &rsdp, sizeof(rsdp));
+	if (amt < sizeof(rsdp)) {
+		fprint(2,"%s: read %s: %r\n", __func__, name);
+		return AE_ERROR;
+	}
+	close(fd);
+
+	return AE_OK;
+}
+/*
+ * ACPI Table interfaces
+ */
+ACPI_PHYSICAL_ADDRESS
+AcpiOsGetRootPointer (
+    void)
+{
+	fprint(2,"%s returns %p\n", __func__, rsdp);
+	return (ACPI_PHYSICAL_ADDRESS) rsdp;
+}
+
+ACPI_STATUS
+AcpiOsPredefinedOverride (
+    const ACPI_PREDEFINED_NAMES *InitVal,
+    ACPI_STRING                 *NewVal)
+{
+	fprint(2,"%s\n", __func__);
+	*NewVal = nil;
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsTableOverride (
+    ACPI_TABLE_HEADER       *ExistingTable,
+    ACPI_TABLE_HEADER       **NewTable)
+{
+	fprint(2,"%s\n", __func__);
+	*NewTable = nil;
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsPhysicalTableOverride (
+    ACPI_TABLE_HEADER       *ExistingTable,
+    ACPI_PHYSICAL_ADDRESS   *NewAddress,
+    UINT32                  *NewTableLength)
+{
+	fprint(2,"%s\n", __func__);
+	*NewAddress = (ACPI_PHYSICAL_ADDRESS)nil;
+	return AE_OK;
+}
+
+/*
+ * Debug input
+ */
+ACPI_STATUS
+AcpiOsGetLine (
+    char                    *Buffer,
+    UINT32                  BufferLength,
+    UINT32                  *BytesRead)
+{
+	fprint(2,"%s\n", __func__);
+	*BytesRead = read(0, Buffer, BufferLength);
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsTerminate (
+    void)
+{
+	sysfatal("%s\n", __func__);
+}
+
+/* Another acpica failure of vision: code in libraries that depends on functions defined only
+ * in the compiler or other programs. Really! What to do?
+ * this is how the acpi tools do it. Save we add a print so we know the function is called, duh! */
+typedef void *ACPI_PARSE_OBJECT;
+typedef void *AML_RESOURCE;
+/* this is from acpiexec. */
+
+/* For AcpiExec only */
+void
+AeDoObjectOverrides (
+    void)
+{
+	fprint(2,"%s\n", __func__);
+}
+
+/* Stubs for the disassembler */
+
+void
+MpSaveGpioInfo (
+    ACPI_PARSE_OBJECT       *Op,
+    AML_RESOURCE            *Resource,
+    UINT32                  PinCount,
+    UINT16                  *PinList,
+    char                    *DeviceName)
+{
+	fprint(2,"%s\n", __func__);
+}
+
+void
+MpSaveSerialInfo (
+    ACPI_PARSE_OBJECT       *Op,
+    AML_RESOURCE            *Resource,
+    char                    *DeviceName)
+{
+	fprint(2,"%s\n", __func__);
+}
+
+int
+AcpiOsWriteFile (
+    ACPI_FILE               File,
+    void                    *Buffer,
+    ACPI_SIZE               Size,
+    ACPI_SIZE               Count)
+{
+	fprint(2,"%s(%p, %p, %d, %d);\n", File, Buffer, Size, Count);
+	return write(1, Buffer, Size*Count);
+}

--- a/sys/src/libacpi/harvey.c
+++ b/sys/src/libacpi/harvey.c
@@ -13,6 +13,7 @@
 static uint32_t rsdp;
 static char *name;
 
+#if 0
 static int xisprint(int c)
 {
 	return (c >= 32 && c <= 126);
@@ -49,6 +50,7 @@ static void hexdump(void *v, int length)
 		}
 	}
 }
+#endif
 
 static int rawfd(void){
 	if (name == nil)
@@ -235,7 +237,7 @@ AcpiOsMapMemory (
 		fprint(2,"%s: read %s: %r\n", __func__, name);
 		return nil;
 	}
-	hexdump(v, Length);
+	//hexdump(v, Length);
 	return v;
 }
 
@@ -337,6 +339,7 @@ struct handler {
 	void                    *Context;
 };
 
+#if 0
 /* The ACPI interrupt signature and the Harvey one are not compatible. So, we pass an arg to
  * intrenable that can in turn be used to this function to call the ACPI handler. */
 static void acpihandler(void*_, void *arg)
@@ -344,6 +347,7 @@ static void acpihandler(void*_, void *arg)
 	struct handler *h = arg;
 	h->ServiceRoutine(h->Context);
 }
+#endif
 
 ACPI_STATUS
 AcpiOsInstallInterruptHandler (
@@ -414,9 +418,11 @@ AcpiOsExecute (
     ACPI_OSD_EXEC_CALLBACK  Function,
     void                    *Context)
 {
+	ACPI_STATUS ret = AE_OK;
 	fprint(2,"%s\n", __func__);
-	sysfatal("%s", __func__);
-	return AE_OK;
+	Function(Context);
+	
+	return ret;
 }
 
 ACPI_STATUS

--- a/sys/src/libacpi/old.c
+++ b/sys/src/libacpi/old.c
@@ -1,0 +1,1175 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include	"u.h"
+#include	"../port/lib.h"
+#include	"mem.h"
+#include	"dat.h"
+#include	"fns.h"
+#include	"io.h"
+#include	"../port/error.h"
+#include "apic.h"
+#include "mp.h"
+#include <acpi/acpica/acpi.h>
+
+enum
+{
+
+	Sdthdrsz	= 36,	/* size of SDT header */
+	Qdir = 0,
+	Qctl,
+	Qtbl,
+	Qio,
+};
+
+#if 0
+static Cmdtab ctls[] =
+{
+	{CMregion,	"region",	6},
+	{CMgpe,		"gpe",		3},
+};
+#endif
+
+
+/* 
+ * This is the array of eyesores.
+ * An Eyesore is an Interrupt Source Over Ride, which maps from
+ * what they want to what it needs to be. You are not expected
+ * to understand this.
+ */
+static ACPI_MADT_INTERRUPT_OVERRIDE *eyesore;
+static int numeyesore;
+
+static Dirtab acpidir[]={
+	".",		{Qdir, 0, QTDIR},	0,	DMDIR|0555,
+	"acpictl",	{Qctl},			0,	0666,
+	"acpitbl",	{Qtbl},			0,	0444,
+	"acpiregio",	{Qio},			0,	0666,
+};
+
+#if 0
+static char* regnames[] = {
+	"mem", "io", "pcicfg", "embed",
+	"smb", "cmos", "pcibar",
+};
+#endif
+
+static void *rsd;
+/*
+ * we use mp->machno (or index in Mach array) as the identifier,
+ * but ACPI relies on the apic identifier.
+ */
+int
+corecolor(int core)
+{
+	Mach *m;
+	static int colors[32];
+
+	if(core < 0 || core >= MACHMAX)
+		return -1;
+	m = sys->machptr[core];
+	if(m == nil)
+		return -1;
+
+	if(core >= 0 && core < nelem(colors) && colors[core] != 0)
+		return colors[core] - 1;
+
+	return -1;
+}
+
+
+int
+pickcore(int mycolor, int index)
+{
+	return 0;
+}
+static void*
+rsdscan(uint8_t* addr, int len, char* signature)
+{
+	int sl;
+	uint8_t *e, *p;
+
+	e = addr+len;
+	sl = strlen(signature);
+	for(p = addr; p+sl < e; p += 16){
+		if(memcmp(p, signature, sl))
+			continue;
+		return p;
+	}
+
+	return nil;
+}
+
+
+static void*
+rsdsearch(char* signature)
+{
+	uintptr_t p;
+	uint8_t *bda;
+	void *rsd;
+
+	/*
+	 * Search for the data structure signature:
+	 * 1) in the first KB of the EBDA;
+	 * 2) in the BIOS ROM between 0xE0000 and 0xFFFFF.
+	 */
+	if(strncmp((char*)KADDR(0xFFFD9), "EISA", 4) == 0){
+		bda = BIOSSEG(0x40);
+		if((p = (bda[0x0F]<<8)|bda[0x0E])){
+			if(rsd = rsdscan(KADDR(p), 1024, signature))
+				return rsd;
+		}
+	}
+	return rsdscan(BIOSSEG(0xE000), 0x20000, signature);
+}
+
+
+static void
+acpirsdptr(void)
+{
+	rsd = rsdsearch("RSD PTR ");
+	if (rsd == nil) {
+		print("NO RSD PTR found\n");
+		return;
+	}
+	print("Found RST PTR ta %p\n", rsd);
+
+#if 0
+	assert(sizeof(Sdthdr) == 36);
+
+	DBG("acpi: RSD PTR@ %#p, physaddr %#ux length %u %#llux rev %d\n",
+		rsd, l32get(rsd->raddr), l32get(rsd->length),
+		l64get(rsd->xaddr), rsd->revision);
+
+	if(rsd->revision >= 2){
+		if(sdtchecksum(rsd, 36) == nil){
+			DBG("acpi: RSD: bad checksum\n");
+			return;
+		}
+		sdtpa = l64get(rsd->xaddr);
+		asize = 8;
+	}
+	else{
+		if(sdtchecksum(rsd, 20) == nil){
+			DBG("acpi: RSD: bad checksum\n");
+			return;
+		}
+		sdtpa = l32get(rsd->raddr);
+		asize = 4;
+	}
+
+	/*
+	 * process the RSDT or XSDT table.
+	 */
+	xsdt = malloc(sizeof(Xsdt));
+	if(xsdt == nil){
+		DBG("acpi: malloc failed\n");
+		return;
+	}
+	if((xsdt->p = sdtmap(sdtpa, &xsdt->len, 1)) == nil){
+		DBG("acpi: sdtmap failed\n");
+		return;
+	}
+	if((xsdt->p[0] != 'R' && xsdt->p[0] != 'X') || memcmp(xsdt->p+1, "SDT", 3) != 0){
+		DBG("acpi: xsdt sig: %c%c%c%c\n",
+			xsdt->p[0], xsdt->p[1], xsdt->p[2], xsdt->p[3]);
+		free(xsdt);
+		xsdt = nil;
+		vunmap(xsdt, xsdt->len);
+		return;
+	}
+	xsdt->p += sizeof(Sdthdr);
+	xsdt->len -= sizeof(Sdthdr);
+	xsdt->asize = asize;
+	DBG("acpi: XSDT %#p\n", xsdt);
+	acpixsdtload(nil);
+	/* xsdt is kept and not unmapped */
+#endif
+}
+
+static int
+acpigen(Chan *c, char* d, Dirtab *tab, int ntab, int i, Dir *dp)
+{
+	Qid qid;
+
+	if(i == DEVDOTDOT){
+		mkqid(&qid, Qdir, 0, QTDIR);
+		devdir(c, qid, ".", 0, eve, 0555, dp);
+		return 1;
+	}
+	i++; /* skip first element for . itself */
+	if(tab==0 || i>=ntab)
+		return -1;
+	tab += i;
+	qid = tab->qid;
+	qid.path &= ~Qdir;
+	qid.vers = 0;
+	devdir(c, qid, tab->name, tab->length, eve, tab->perm, dp);
+	return 1;
+}
+
+ACPI_STATUS
+AcpiOsInitialize(void)
+{
+	print("%s\n", __func__);
+	acpirsdptr();
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsTerminate (
+	void)
+{
+	print("%s\n", __func__);
+	return AE_OK;
+}
+
+/* run AML with one integer arg. */
+static int
+run_aml_arg(char *name, int val)
+{
+    ACPI_OBJECT arg1;
+    ACPI_OBJECT_LIST args;
+    ACPI_STATUS as;
+
+    arg1.Type = ACPI_TYPE_INTEGER;
+    arg1.Integer.Value = 1;
+    args.Count = 1;
+    args.Pointer = &arg1;
+
+    /* This does not work. Just leaving it here in case someone
+     * else thinks it will.
+	ACPI_STATUS as;
+	ACPI_OBJECT arg[] = {
+		{
+			.Type = ACPI_TYPE_INTEGER,
+			.Integer.Value = val
+		}
+	};
+	ACPI_OBJECT_LIST args = {
+		.Count = 1,
+		.Pointer = arg
+	};
+    */
+	as = AcpiEvaluateObject(ACPI_ROOT_OBJECT, name, &args, NULL);
+	print("run_aml_arg(%s, %d) returns %d\n", name, val, as);
+	return ACPI_SUCCESS(as);
+}
+
+static int
+set_machine_mode(void)
+{
+	/* we always enable the APIC. */
+	return run_aml_arg("_PIC", 1);
+}
+
+void pi(int indent)
+{
+	int i;
+	for(i = 0; i < indent; i++)
+		print(" ");
+}
+
+/* walk the whatever. Limited, right now. */
+static void
+objwalk(ACPI_OBJECT *p)
+{
+	static int indent;
+	int cnt;
+	ACPI_OBJECT *e;
+	pi(indent);
+	switch(p->Type) {
+	case 4: // ACPI_DESC_TYPE_STATE_PACKAGE:
+		print("Package:\n");
+		indent += 2;
+		e = p->Package.Elements;
+		for(cnt = 0; cnt < p->Package.Count; cnt++, e++){
+			objwalk(e);
+		}
+
+		indent -= 2;
+		print("\n");
+		break;
+	case 1:
+		print("Integer:0x%llx", p->Integer.Value);
+		break;
+	default:
+		print("Can't handle type %d\n", p->Type);
+		break;
+	}
+
+}
+
+static ACPI_STATUS
+resource(ACPI_RESOURCE *r, void *Context)
+{
+	ACPI_RESOURCE_IRQ *i = &r->Data.Irq;
+	print("\tACPI_RESOURCE_TYPE_%d: Length %d\n", r->Type, r->Length);
+	if (r->Type != ACPI_RESOURCE_TYPE_IRQ)
+		return 0;
+	print("\t\tIRQ Triggering %d Polarity %d Sharable %d InterruptCount %d: ", 
+	      i->Triggering, i->Polarity, i->Sharable, i->InterruptCount);
+	for(int j = 0; j < i->InterruptCount; j++)
+		print("%d,", i->Interrupts[j]);
+	print("\n");
+	/* assumptions: we assume apic 0 for now. This will need to be fixed.
+	 * We also just take the first interrupt. 
+	 */
+	uint32_t low = Im;
+	switch (i->Polarity){
+	case ACPI_ACTIVE_HIGH:
+		low |= IPhigh;
+		break;
+	case ACPI_ACTIVE_LOW:
+		low |= IPlow;
+		break;
+	case ACPI_ACTIVE_BOTH:
+		low |= IPlow | IPhigh;
+		break;
+	default:
+		print("BOTCH! i->Polarity is 0x%x and I don't do that\n", i->Polarity);
+		break;
+	}
+
+	switch (i->Triggering) {
+	case ACPI_LEVEL_SENSITIVE:
+		low |= TMlevel;
+		break;
+	case ACPI_EDGE_SENSITIVE:
+		low |= TMedge;
+		break;
+	default:
+		print("BOTCH! i->Triggering is 0x%x and I don't do that\n", i->Triggering);
+		break;
+	}
+	print("ACPICODE: ioapicintrinit(0xff, 0x%x, 0x%x, 0x%x, 0x%x\n", 1, i->Interrupts[0], i->Interrupts[0]<<2, low);
+	return 0;
+}
+ACPI_STATUS
+device(ACPI_HANDLE                     Object,
+    UINT32                          NestingLevel,
+    void                            *Context,
+    void                            **ReturnValue)
+
+{
+	ACPI_STATUS as;
+	ACPI_DEVICE_INFO *info;
+	as = AcpiGetObjectInfo(Object, &info);
+	print("as is %d\n", as);
+	if (!ACPI_SUCCESS(as))
+		return 0;
+	ACPI_BUFFER out;
+	out.Length = ACPI_ALLOCATE_BUFFER;
+	out.Pointer = nil;
+	char n[5];
+	memmove(n, &info->Name, sizeof(info->Name));
+	n[4] = 0;
+	print("%s\n", n);
+	as = AcpiGetIrqRoutingTable(Object, &out);
+	print("get the PRT: %d\n", as);
+	print("Length is %u ptr is %p\n", out.Length, out.Pointer);
+	if (ACPI_SUCCESS(as)) {
+		void *p = (void *)out.Pointer;
+		while(((ACPI_PCI_ROUTING_TABLE*)p)->Length > 0) {
+			ACPI_PCI_ROUTING_TABLE *t = p;
+			print("%s: ", t->Source);
+			print("Pin 0x%x, Address 0x%llx, SourceIndex 0x%x\n", 
+			      t->Address, t->SourceIndex);
+			p += t->Length;
+		}
+	}
+	as = AcpiWalkResources(Object, "_CRS", resource, nil);
+	print("Walk resources: as is %d\n", as);
+#if 0
+	out.Length = ACPI_ALLOCATE_BUFFER;
+	out.Pointer = nil;
+	as = AcpiGetPossibleResources(Object, &out);
+	print("get the possible resources: %d\n", as);
+	if (ACPI_SUCCESS(as)) {
+		void *p = (void *)out.Pointer;
+		hexdump(out.Pointer, out.Length);
+		while(((ACPI_RESOURCE*)p)->Type != ACPI_RESOURCE_TYPE_END_TAG) {
+			ACPI_RESOURCE *r = p;
+			ACPI_RESOURCE_IRQ *i = p + sizeof(r->Type);
+			print("\tACPI_RESOURCE_TYPE_%d: Length %d\n", r->Type, r->Length);
+			p += r->Length;
+			if (r->Type != ACPI_RESOURCE_TYPE_IRQ)
+				continue;
+			print("\t\tIRQ Triggering %d Polarity %d Sharable %d InterruptCount %d: ", 
+			      i->Triggering, i->Polarity, i->Sharable, i->InterruptCount);
+			for(int j = 0; j < i->InterruptCount; j++)
+				print("%d,", i->Interrupts[j]);
+			print("\n");
+
+
+		}
+		print("Length is %u ptr is %p\n", out.Length, out.Pointer);
+
+	}
+#endif
+	print("hi\n");
+
+	return 0;
+}
+
+int
+acpiinit(void)
+{
+	ACPI_STATUS as;
+	ACPI_TABLE_HEADER *h;
+	ACPI_BUFFER out;
+	int status;
+	int apiccnt = 1;
+	out.Length = ACPI_ALLOCATE_BUFFER;
+	out.Pointer = nil;
+	status = AcpiInitializeSubsystem();
+        if (ACPI_FAILURE(status))
+		panic("can't start acpi");
+
+
+        status = AcpiInitializeTables(NULL, 16, FALSE);
+        if (ACPI_FAILURE(status))
+		panic("can't set up acpi tables");
+
+        status = AcpiLoadTables();
+        if (ACPI_FAILURE(status))
+		panic("Can't load ACPI tables");
+
+        status = AcpiEnableSubsystem(0);
+        if (ACPI_FAILURE(status))
+		panic("Can't enable ACPI subsystem");
+
+        status = AcpiInitializeObjects(0);
+        if (ACPI_FAILURE(status))
+		panic("Can't Initialize ACPI objects");
+
+	int sublen;
+	uint8_t *p;
+	extern uint8_t *apicbase;
+	ACPI_TABLE_MADT *m;
+	status = AcpiGetTable(ACPI_SIG_MADT, apiccnt, &h);
+	if (ACPI_FAILURE(status))
+		panic("Can't find a MADT");
+	m = (ACPI_TABLE_MADT *)h;
+	print("APIC %d: %p 0x%x\n", apiccnt, (void *)(uint64_t)m->Address, m->Flags);
+	if(apicbase == nil){
+		if((apicbase = vmap((uintptr_t)m->Address, 1024)) == nil){
+			panic("%s: can't map apicbase\n", __func__);
+		}
+		print("%s: apicbase %#p -> %#p\n", __func__, (void *)(uint64_t)m->Address, apicbase);
+	}
+	if (! set_machine_mode()){
+		print("Set machine mode failed\n");
+		return 0;
+	}
+
+	p = (void*)&m[1];
+	sublen = m->Header.Length;
+	/* we only process the ones we're certain we need to. */
+	while (sublen > 0) {
+		switch(p[0]){
+		case ACPI_MADT_TYPE_LOCAL_APIC:
+		{
+			ACPI_MADT_LOCAL_APIC *l = (void *)p;
+			if (!l->LapicFlags)
+				break;
+			apicinit(l->Id, m->Address, apiccnt == 1);
+print("ACPICODE: apicinit(%d, %p, %d\n", l->Id, m->Address, apiccnt == 1);
+			apiccnt++;
+		}
+			break;
+		case ACPI_MADT_TYPE_IO_APIC:
+		{
+			ACPI_MADT_IO_APIC *io = (void *)p;
+			print("IOapic %d @ %p\n", io->Id, io->Address);
+			ioapicinit(io->Id, io->Address);
+print("ACPICODE: ioapicinit(%d, %p);\n", io->Id, (void*)(uint64_t)io->Address);
+		}
+			break;
+		case ACPI_MADT_TYPE_INTERRUPT_OVERRIDE:
+		{
+			ACPI_MADT_INTERRUPT_OVERRIDE *e = (void *)p;
+			print("What an eyesore. Bus %d, SourceIrq %d, GlobalIrq %d, InitFlags 0x%x\n",
+			      e->Bus, e->SourceIrq, e->GlobalIrq, e->IntiFlags);
+			eyesore = realloc(eyesore, numeyesore+1);
+			if (! eyesore)
+				panic("Ran out of eyesores");
+			eyesore[numeyesore] = *e;
+			numeyesore++;
+		}
+		break;
+		case ACPI_MADT_TYPE_LOCAL_APIC_NMI:
+		{
+			ACPI_MADT_LOCAL_APIC_NMI *nmi = (void *)p;
+			apicnmi(nmi->ProcessorId, nmi->Lint, nmi->IntiFlags);
+		}
+			break;
+		default:
+			print("%s: can't handle subtable type %d\n", __func__, p[0]);
+			break;
+		}
+		sublen -= p[1];
+		p += p[1];
+	}
+
+	/* Get the _PRT */
+	int i;
+	for(i = 0; i < 255; i++) {
+		static char path[255];
+		snprint(path, sizeof(path), "\\_SB.PCI%d._PRT", i);
+		as = AcpiEvaluateObject(ACPI_ROOT_OBJECT, path, NULL, &out);
+		if (!ACPI_SUCCESS(as))
+			continue;
+		print("------>GOT the PRT: %d\n", i);
+		print("Length is %u ptr is %p\n", out.Length, out.Pointer);
+		hexdump(out.Pointer, out.Length);
+		objwalk(out.Pointer);
+
+		as = AcpiGetDevices (nil, device, nil, nil);
+		print("acpigetdevices %d\n", as);
+	}
+
+/* per device code. Not useful yet.
+
+	as = AcpiGetIrqRoutingTable(some device, &out);
+	print("get the PRT: %d\n", as);
+	print("Length is %u ptr is %p\n", out.Length, out.Pointer);
+	hexdump(out.Pointer, out.Length);
+*/
+	/* PCI devices: Walk all devices. For those with interrupts, enable them. */
+	Pcidev*pci = nil;
+	for(pci = pcimatch(pci, 0, 0); pci; pci = pcimatch(pci, 0, 0)){
+		if (!pci->intl || pci->intl == 0xff)
+			continue;
+		print("Interrupt %d: \n", pci->intl);
+		pcishowdev(pci);
+		int bus = BUSBNO(pci->tbdf);
+		int apicno = 1; /* for now */
+		int low = 0x1a000; /* is PCI always this? */
+		print("ACPICODE: ioapicintrinit(%d, %d, %d, 0x%x, 0x%x);\n", bus, apicno, pci->intl, pci->tbdf, low);
+
+	}
+	print("ACPICODE: ioapicintrinit(0xff, DONE\n");
+	return 0;
+}
+
+static Chan*
+acpiattach(char *spec)
+{
+	return nil;
+//	return devattach(L'α', spec);
+}
+
+static Walkqid*
+acpiwalk(Chan *c, Chan *nc, char **name, int nname)
+{
+	return devwalk(c, nc, name, nname, acpidir, nelem(acpidir), acpigen);
+}
+
+static int32_t
+acpistat(Chan *c, uint8_t *dp, int32_t n)
+{
+	return devstat(c, dp, n, acpidir, nelem(acpidir), acpigen);
+}
+
+static Chan*
+acpiopen(Chan *c, int omode)
+{
+	return devopen(c, omode, acpidir, nelem(acpidir), acpigen);
+}
+
+static void
+acpiclose(Chan *c)
+{
+}
+
+#if 0
+static char*ttext;
+static int tlen;
+#endif
+
+static int32_t
+acpiread(Chan *c, void *a, int32_t n, int64_t off)
+{
+	uint64_t q;
+
+	q = c->qid.path;
+	switch(q){
+	case Qdir:
+		return devdirread(c, a, n, acpidir, nelem(acpidir), acpigen);
+	case Qtbl:
+		return -1; //readstr(off, a, n, ttext);
+	case Qio:
+		return -1; //regio(reg, a, n, off, 0);
+	}
+	error(Eperm);
+	return -1;
+}
+
+static int32_t
+acpiwrite(Chan *c, void *a, int32_t n, int64_t off)
+{
+	if(c->qid.path == Qio){
+		//if(reg == nil)
+		error("region not configured");
+	}
+	if(c->qid.path != Qctl)
+		error(Eperm);
+
+	error("NP");
+#if 0
+	cb = parsecmd(a, n);
+	if(waserror()){
+		free(cb);
+		nexterror();
+	}
+	ct = lookupcmd(cb, ctls, nelem(ctls));
+	DBG("acpi ctl %s\n", cb->f[0]);
+	switch(ct->index){
+	case CMregion:
+		r = reg;
+		if(r == nil){
+			r = smalloc(sizeof(Reg));
+			r->name = nil;
+		}
+		kstrdup(&r->name, cb->f[1]);
+		r->spc = acpiregid(cb->f[2]);
+		if(r->spc < 0){
+			free(r);
+			reg = nil;
+			error("bad region type");
+		}
+		if(r->spc == Rpcicfg || r->spc == Rpcibar){
+			rno = r->base>>Rpciregshift & Rpciregmask;
+			fun = r->base>>Rpcifunshift & Rpcifunmask;
+			dev = r->base>>Rpcidevshift & Rpcidevmask;
+			bus = r->base>>Rpcibusshift & Rpcibusmask;
+			r->tbdf = MKBUS(BusPCI, bus, dev, fun);
+			r->base = rno;	/* register ~ our base addr */
+		}
+		r->base = strtoull(cb->f[3], nil, 0);
+		r->len = strtoull(cb->f[4], nil, 0);
+		r->accsz = strtoul(cb->f[5], nil, 0);
+		if(r->accsz < 1 || r->accsz > 4){
+			free(r);
+			reg = nil;
+			error("bad region access size");
+		}
+		reg = r;
+		DBG("region %s %s %llux %llux sz%d",
+			r->name, acpiregstr(r->spc), r->base, r->len, r->accsz);
+		break;
+	case CMgpe:
+		i = strtoul(cb->f[1], nil, 0);
+		if(i >= ngpes)
+			error("gpe out of range");
+		kstrdup(&gpes[i].obj, cb->f[2]);
+		DBG("gpe %d %s\n", i, gpes[i].obj);
+		setgpeen(i, 1);
+		break;
+	default:
+		panic("acpi: unknown ctl");
+	}
+	poperror();
+	free(cb);
+	return n;
+#endif
+	return -1;
+}
+
+
+Dev acpidevtab = {
+	.dc = L'α',
+	.name = "acpi",
+
+	.reset = devreset,
+	.init = devinit,
+	.shutdown = devshutdown,
+	.attach = acpiattach,
+	.walk = acpiwalk,
+	.stat = acpistat,
+	.open = acpiopen,
+	.create = devcreate,
+	.close = acpiclose,
+	.read = acpiread,
+	.bread = devbread,
+	.write = acpiwrite,
+	.bwrite = devbwrite,
+	.remove = devremove,
+	.wstat = devwstat,
+};
+
+static int tbdf(ACPI_PCI_ID *p)
+{
+	return (p->Bus << 8) | (p->Device << 3) | (p->Function);
+}
+
+ACPI_STATUS
+AcpiOsReadPciConfiguration (
+    ACPI_PCI_ID             *PciId,
+    UINT32                  Reg,
+    UINT64                  *Value,
+    UINT32                  Width)
+{
+	Pcidev p;
+	p.tbdf = tbdf(PciId);
+	print("%s\n", __func__);
+	switch(Width) {
+	case 32:
+		*Value = pcicfgr32(&p, Reg);
+		break;
+	case 16:
+		*Value = pcicfgr16(&p, Reg);
+		break;
+	case 8:
+		*Value = pcicfgr8(&p, Reg);
+		break;
+	default:
+		panic("Can't read pci: bad width %d\n", Width);
+	}
+
+	return AE_OK;
+
+}
+
+ACPI_STATUS
+AcpiOsWritePciConfiguration (
+    ACPI_PCI_ID             *PciId,
+    UINT32                  Reg,
+    UINT64                  Value,
+    UINT32                  Width)
+{
+	Pcidev p;
+	p.tbdf = tbdf(PciId);
+	print("%s\n", __func__);
+	switch(Width) {
+	case 32:
+		pcicfgw32(&p, Reg, Value);
+		break;
+	case 16:
+		pcicfgw16(&p, Reg, Value);
+		break;
+	case 8:
+		pcicfgw8(&p, Reg, Value);
+		break;
+	default:
+		panic("Can't read pci: bad width %d\n", Width);
+	}
+
+	return AE_OK;
+}
+
+/*
+ * Miscellaneous
+ */
+BOOLEAN
+AcpiOsReadable (
+    void                    *Pointer,
+    ACPI_SIZE               Length)
+{
+	print("%s\n", __func__);
+	panic("%s", __func__);
+	return AE_OK;
+}
+
+
+BOOLEAN
+AcpiOsWritable (
+    void                    *Pointer,
+    ACPI_SIZE               Length)
+{
+	print("%s\n", __func__);
+	panic("%s", __func__);
+	return AE_OK;
+}
+
+
+UINT64
+AcpiOsGetTimer (
+    void)
+{
+	print("%s\n", __func__);
+	panic("%s", __func__);
+	return AE_OK;
+}
+
+
+ACPI_STATUS
+AcpiOsSignal (
+    UINT32                  Function,
+    void                    *Info)
+{
+	print("%s\n", __func__);
+	panic("%s", __func__);
+	return AE_OK;
+}
+
+void ACPI_INTERNAL_VAR_XFACE
+AcpiOsPrintf (
+    const char              *Format,
+    ...)
+{
+	va_list args;
+
+	va_start(args, Format);
+	print((char *)Format, args);
+	va_end(args);
+}
+
+void
+AcpiOsVprintf (
+    const char              *Format,
+    va_list                 Args)
+{
+	/* This is a leaf function, and this function is required to implement
+	 * the va_list argument. I couldn't find any other way to do this. */
+	static char buf[1024];
+	vseprint(buf, &buf[1023], (char *)Format, Args);
+	print(buf);
+}
+
+void
+AcpiOsFree (
+    void *                  Memory)
+{
+	//print("%s\n", __func__);
+	free(Memory);
+}
+
+void *
+AcpiOsAllocate (
+    ACPI_SIZE               Size)
+{
+	//print("%s\n", __func__);
+	return malloc(Size);
+}
+
+void *
+AcpiOsMapMemory (
+    ACPI_PHYSICAL_ADDRESS   Where,
+    ACPI_SIZE               Length)
+{
+	void *v = vmap(Where, Length);
+	print("%s %p = vmap(%p,0x%x)\n", __func__, v, (void*)Where, Length);
+	print("Val @ %p is 0x%x\n", v, *(int *)v);
+	return v;
+}
+
+void
+AcpiOsUnmapMemory (
+    void                    *LogicalAddress,
+    ACPI_SIZE               Size)
+{
+	print("%s %p %d \n", __func__, LogicalAddress, Size);
+	vunmap(LogicalAddress, Size);
+}
+
+ACPI_STATUS
+AcpiOsGetPhysicalAddress (
+    void                    *LogicalAddress,
+    ACPI_PHYSICAL_ADDRESS   *PhysicalAddress)
+{
+	ACPI_PHYSICAL_ADDRESS ret = mmuphysaddr((uintptr_t)LogicalAddress);
+	print("%s %p = mmyphysaddr(%p)", __func__, (void *)ret, LogicalAddress);
+	*PhysicalAddress = ret;
+	return AE_OK;
+}
+
+/* This is the single threaded version of
+ * these functions. This is now NetBSD does it. */
+ACPI_STATUS
+AcpiOsCreateSemaphore (
+    UINT32                  MaxUnits,
+    UINT32                  InitialUnits,
+    ACPI_SEMAPHORE          *OutHandle)
+{
+	//print("%s\n", __func__);
+	*OutHandle = (ACPI_SEMAPHORE) 1;
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsDeleteSemaphore (
+    ACPI_SEMAPHORE          Handle)
+{
+	//print("%s\n", __func__);
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsWaitSemaphore (
+    ACPI_SEMAPHORE          Handle,
+    UINT32                  Units,
+    UINT16                  Timeout)
+{
+	//print("%s\n", __func__);
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsSignalSemaphore (
+    ACPI_SEMAPHORE          Handle,
+    UINT32                  Units)
+{
+	//print("%s\n", __func__);
+	return AE_OK;
+}
+
+/* this is the single threaded case and as minix shows there is nothing to do. */
+ACPI_STATUS
+AcpiOsCreateLock (
+    ACPI_SPINLOCK           *OutHandle)
+{
+	//print("%s\n", __func__);
+	*OutHandle = nil;
+	return AE_OK;
+}
+
+void
+AcpiOsDeleteLock (
+    ACPI_SPINLOCK           Handle)
+{
+	//print("%s\n", __func__);
+}
+
+ACPI_CPU_FLAGS
+AcpiOsAcquireLock (
+    ACPI_SPINLOCK           Handle)
+{
+	//print("%s\n", __func__);
+	return 0;
+}
+
+void
+AcpiOsReleaseLock (
+    ACPI_SPINLOCK           Handle,
+    ACPI_CPU_FLAGS          Flags)
+{
+	//print("%s\n", __func__);
+}
+
+struct handler {
+	ACPI_OSD_HANDLER        ServiceRoutine;
+	void                    *Context;
+};
+
+/* The ACPI interrupt signature and the Harvey one are not compatible. So, we pass an arg to
+ * intrenable that can in turn be used to this function to call the ACPI handler. */
+static void acpihandler(Ureg *_, void *arg)
+{
+	struct handler *h = arg;
+	h->ServiceRoutine(h->Context);
+}
+
+ACPI_STATUS
+AcpiOsInstallInterruptHandler (
+    UINT32                  InterruptNumber,
+    ACPI_OSD_HANDLER        ServiceRoutine,
+    void                    *Context)
+{
+	/* minix says "don't do it". So we don't, yet. */
+	return AE_OK;
+	struct handler *h = malloc(sizeof(*h));
+	if (! h)
+		return AE_NO_MEMORY;
+	h->ServiceRoutine = ServiceRoutine;
+	h->Context = Context;
+	print("%s %d %p %p \n", __func__, InterruptNumber, ServiceRoutine, Context);
+	/* once enabled, can't be disabled; ignore the return value unless it's nil. */
+	intrenable(InterruptNumber, acpihandler, h, 0x5, "ACPI interrupt handler");
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsRemoveInterruptHandler (
+    UINT32                  InterruptNumber,
+    ACPI_OSD_HANDLER        ServiceRoutine)
+{
+	print("%s\n", __func__);
+	panic("%s", __func__);
+	return AE_OK;
+}
+
+void
+AcpiOsWaitEventsComplete (
+	void)
+{
+	print("%s\n", __func__);
+	panic("%s", __func__);
+}
+
+void
+AcpiOsSleep (
+    UINT64                  Milliseconds)
+{
+	print("%s\n", __func__);
+	panic("%s", __func__);
+}
+
+void
+AcpiOsStall(
+    UINT32                  Microseconds)
+{
+	print("%s\n", __func__);
+	panic("%s", __func__);
+}
+
+ACPI_THREAD_ID
+AcpiOsGetThreadId (
+    void)
+{
+	/* What to do here? ACPI won't take 0 for an answer.
+	 * I guess tell it we're 1? What do we do? */
+	return 1;
+	//print("%s\n", __func__);
+	Proc *up = externup();
+	return up->pid;
+}
+
+ACPI_STATUS
+AcpiOsExecute (
+    ACPI_EXECUTE_TYPE       Type,
+    ACPI_OSD_EXEC_CALLBACK  Function,
+    void                    *Context)
+{
+	print("%s\n", __func__);
+	panic("%s", __func__);
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsReadPort (
+    ACPI_IO_ADDRESS         Address,
+    UINT32                  *Value,
+    UINT32                  Width)
+{
+	/* Ooooooookay ... ACPI specifies the IO width in *bits*. */
+	switch(Width) {
+	case 4*8:
+		*Value = inl(Address);
+		break;
+	case 2*8:
+		*Value = ins(Address);
+		break;
+	case 1*8:
+		*Value = inb(Address);
+		break;
+	default:
+		panic("%s, bad width %d", __func__, Width);
+		break;
+	}
+	print("%s 0x%x 0x%x\n", __func__, Address, *Value);
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsWritePort (
+    ACPI_IO_ADDRESS         Address,
+    UINT32                  Value,
+    UINT32                  Width)
+{
+	switch(Width) {
+	case 4*8:
+		outl(Address, Value);
+		break;
+	case 2*8:
+		outs(Address, Value);
+		break;
+	case 1*8:
+		outb(Address, Value);
+		break;
+	default:
+		panic("%s, bad width %d", __func__, Width);
+		break;
+	}
+	print("%s 0x%x 0x%x\n", __func__, Address, Value);
+	return AE_OK;
+}
+
+/*
+ * Platform and hardware-independent physical memory interfaces
+ */
+ACPI_STATUS
+AcpiOsReadMemory (
+    ACPI_PHYSICAL_ADDRESS   Address,
+    UINT64                  *Value,
+    UINT32                  Width)
+{
+	print("%s\n", __func__);
+	panic("%s", __func__);
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsWriteMemory (
+    ACPI_PHYSICAL_ADDRESS   Address,
+    UINT64                  Value,
+    UINT32                  Width)
+{
+	print("%s\n", __func__);
+	panic("%s", __func__);
+	return AE_OK;
+}
+
+/*
+ * ACPI Table interfaces
+ */
+ACPI_PHYSICAL_ADDRESS
+AcpiOsGetRootPointer (
+    void)
+{
+	print("%s returns %p\n", __func__, rsd);
+	return (ACPI_PHYSICAL_ADDRESS) PADDR(rsd);
+}
+
+ACPI_STATUS
+AcpiOsPredefinedOverride (
+    const ACPI_PREDEFINED_NAMES *InitVal,
+    ACPI_STRING                 *NewVal)
+{
+	print("%s\n", __func__);
+	*NewVal = nil;
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsTableOverride (
+    ACPI_TABLE_HEADER       *ExistingTable,
+    ACPI_TABLE_HEADER       **NewTable)
+{
+	print("%s\n", __func__);
+	*NewTable = nil;
+	return AE_OK;
+}
+
+ACPI_STATUS
+AcpiOsPhysicalTableOverride (
+    ACPI_TABLE_HEADER       *ExistingTable,
+    ACPI_PHYSICAL_ADDRESS   *NewAddress,
+    UINT32                  *NewTableLength)
+{
+	print("%s\n", __func__);
+	*NewAddress = (ACPI_PHYSICAL_ADDRESS)nil;
+	return AE_OK;
+}
+
+/*
+ * Debug input
+ */
+ACPI_STATUS
+AcpiOsGetLine (
+    char                    *Buffer,
+    UINT32                  BufferLength,
+    UINT32                  *BytesRead)
+{
+	print("%s\n", __func__);
+	panic("%s", __func__);
+	return AE_OK;
+}
+

--- a/sys/src/libs.json
+++ b/sys/src/libs.json
@@ -2,7 +2,7 @@
 	"libs.json": {
 		"Projects": [
 			"/sys/src/lib9p/lib9p.json",
-			"/sys/src/libacpi/acpica/libacpi.json",
+			"/sys/src/libacpi",
 			"/sys/src/libc/libc.json",
 			"/sys/src/libip/libip.json",
 			"/sys/src/libdraw/libdraw.json",


### PR DESCRIPTION
It's going to work something like this:
when the kernel has an IRQ it can not compute, i.e. needs to run AML, 
it will save information about it in devacpi.

devapic will export a new file, called acpiirq or somesuch. When programs
read that file, it will provide info like this:
t b d f line pin
i.e. the tbdf (broken out) and line and pin. This will avoid any need of
the program to do pci config space ops to find things out.

The program, given this info, will find out the correct ioapic and pin
on ioapic, and write this info back.
t b d f ioapic pin

Note the format of the read and write is the same, just the info is different.