### PR TITLE
sys/include/libc.h: remove a name

### DIFF
--- a/sys/include/libc.h
+++ b/sys/include/libc.h
@@ -1,6 +1,4 @@
 /*
- * Copyright (C) 2015 Giacomo Tesio <giacomo@tesio.it>
- *
  * This file is part of the UCB release of Plan 9. It is subject to the license
  * terms in the LICENSE file found in the top-level directory of this
  * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No

--- a/sys/src/libc/9sys/qlock.c
+++ b/sys/src/libc/9sys/qlock.c
@@ -1,6 +1,4 @@
 /*
- * Copyright (C) 2015 Giacomo Tesio <giacomo@tesio.it>
- *
  * This file is part of the UCB release of Plan 9. It is subject to the license
  * terms in the LICENSE file found in the top-level directory of this
  * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No

--- a/sys/src/libc/9sys/read.c
+++ b/sys/src/libc/9sys/read.c
@@ -1,8 +1,6 @@
 /*
  * This file is part of Harvey.
  *
- * Copyright (C) 2015 Giacomo Tesio <giacomo@tesio.it>
- *
  * Harvey is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, version 2 of the License.

--- a/sys/src/libc/9sys/write.c
+++ b/sys/src/libc/9sys/write.c
@@ -1,8 +1,6 @@
 /*
  * This file is part of Harvey.
  *
- * Copyright (C) 2015 Giacomo Tesio <giacomo@tesio.it>
- *
  * Harvey is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, version 2 of the License.

--- a/sys/src/libc/port/lock.c
+++ b/sys/src/libc/port/lock.c
@@ -1,6 +1,4 @@
 /*
- * Copyright (C) 2015 Giacomo Tesio <giacomo@tesio.it>
- *
  * This file is part of the UCB release of Plan 9. It is subject to the license
  * terms in the LICENSE file found in the top-level directory of this
  * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No


### PR DESCRIPTION
We don't put names in .h files. If we did, we'd have a lot
of names in here.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>