### PR TITLE
ACPI: only scan two things from irqmap, not 3.

### DIFF
--- a/sys/src/cmd/acpi/irq.c
+++ b/sys/src/cmd/acpi/irq.c
@@ -132,7 +132,7 @@ failed:
 	}
 
 	while (1) {
-		if (scanf("%x %x %x", &bus, &dev, &pin) < 0)
+		if (scanf("%x %x", &bus, &dev) < 0)
 			break;
 		ACPI_STATUS RouteIRQ(ACPI_PCI_ID* device, int pin, int* irq);
 		AcpiDbgLevel = 0;


### PR DESCRIPTION
This is *A* bug, but not *the* bug.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>