### PR TITLE
Add acpi flag to disable GCC macros on BSD systems

### DIFF
--- a/sys/src/libacpi/acpica/acpiflags.json
+++ b/sys/src/libacpi/acpica/acpiflags.json
@@ -11,6 +11,7 @@
 		        "-D__HARVEY__",
 		        "-U_LINUX",
 		        "-U__linux__",
+                "-U__FreeBSD__",
 			"-Wno-unused-function",
 			"-Wno-unused-variable",
 			"-Wno-unused-const-variable",

--- a/sys/src/libacpi/acpica/acpiflags.json
+++ b/sys/src/libacpi/acpica/acpiflags.json
@@ -11,7 +11,7 @@
 		        "-D__HARVEY__",
 		        "-U_LINUX",
 		        "-U__linux__",
-                "-U__FreeBSD__",
+                        "-U__FreeBSD__",
 			"-Wno-unused-function",
 			"-Wno-unused-variable",
 			"-Wno-unused-const-variable",
@@ -19,7 +19,7 @@
 			"-Wno-unused-variable",
 			"-Wall", 
 			"-nostdlib",
-		    "-fno-builtin",
+		        "-fno-builtin",
 			"-include", "u.h",
 			"-include", "libc.h",
 			"-include", "ctype.h",
@@ -33,5 +33,5 @@
 		"IncludeCanNotUsedWUnusedYet": [
 			"../../lib.json"
 		]
-		}
+	}
 }


### PR DESCRIPTION
Should work on all systems using the FreeBSD kernel, only
certain for FreeBSD.

Signed-off-by: Aaron Hudson <aaron.hudson@student.nmt.edu>