### PR TITLE
syscall: fix Ar0->i to be intptr_t, not int.

### DIFF
--- a/amd64/include/u.h
+++ b/amd64/include/u.h
@@ -19,6 +19,7 @@ typedef	unsigned long long uint64_t;
 typedef	long long	int64_t;
 typedef uint64_t uintptr;
 typedef uint64_t uintptr_t;
+typedef int64_t intptr_t;
 typedef uint32_t	usize;
 typedef unsigned long size_t;
 typedef	uint32_t		Rune;

--- a/sys/src/9/port/portdat.h
+++ b/sys/src/9/port/portdat.h
@@ -765,7 +765,7 @@ struct Sched
 
 typedef union Ar0 Ar0;
 union Ar0 {
-	int	i;
+	intptr_t	i;
 	int32_t	l;
 	uintptr_t	p;
 	usize	u;


### PR DESCRIPTION
This broke Go because we returned 32 bits of -1, not 64 bits.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>