### PR TITLE
Create /mnt/plumb in case it does not exist

### DIFF
--- a/usr/harvey/lib/profile
+++ b/usr/harvey/lib/profile
@@ -8,6 +8,7 @@ fn cd { builtin cd $* && awd }  # for acme
 
 switch($service){
 case terminal
+	test ! -d /mnt/plumb && mkdir /mnt/plumb
 	plumber
 	echo -n accelerated > '#m/mousectl'
 	echo -n 'res 3' > '#m/mousectl'
@@ -26,6 +27,7 @@ case cpu
 	prompt=('cpu% ' '	')
 	fn cpu%{ $* }
 	if (! test -e /mnt/term/mnt/wsys) {	# cpu call from drawterm
+		test ! -d /mnt/plumb && mkdir /mnt/plumb
 		plumber
 		font=/lib/font/bit/pelm/latin1.8.font
 		exec rio


### PR DESCRIPTION
Plumber fails, and rio does not start if it does not exist.

Signed-off-by: golubovsky <golubovsky@gmail.com>