### PR TITLE
Remove line 335 in syscall.c which caused unneeded console output

### DIFF
--- a/sys/src/9/amd64/syscall.c
+++ b/sys/src/9/amd64/syscall.c
@@ -332,7 +332,6 @@ syscall(unsigned int scallnr, Ureg *ureg)
 	}
 	else{
 		/* failure: save the error buffer for errstr */
-print("waserror errstr '%s' syserrstr '%s'\n", up->errstr, up->syserrstr);
 		e = up->syserrstr;
 		up->syserrstr = up->errstr;
 		up->errstr = e;


### PR DESCRIPTION
The line was likely left by mistake.

Signed-off-by: golubovsky <golubovsky@gmail.com>