### PR TITLE
Remove weird $HARVEY check in build

### DIFF
--- a/util/src/harvey/cmd/build/paths.go
+++ b/util/src/harvey/cmd/build/paths.go
@@ -11,9 +11,6 @@ import (
 
 func init() {
 	harvey = os.Getenv("HARVEY")
-	if harvey != "" {
-		return
-	}
 	// git is purely optional, for lazy people.
 	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
 	if err == nil {

--- a/util/src/harvey/cmd/build/paths.go
+++ b/util/src/harvey/cmd/build/paths.go
@@ -11,11 +11,14 @@ import (
 
 func init() {
 	harvey = os.Getenv("HARVEY")
-	// git is purely optional, for lazy people.
-	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-	if err == nil {
-		harvey = strings.TrimSpace(string(out))
+	if harvey == "" {
+		// Try figuring it out from git instead
+		out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+		if err == nil {
+			harvey = strings.TrimSpace(string(out))
+		}
 	}
+	// If we still haven't found the path, bail out.
 	if harvey == "" {
 		log.Fatal("Set the HARVEY environment variable or run from a git checkout.")
 	}


### PR DESCRIPTION
build was checking if you have HARVEY set and, if so, *not*
adding util/ to your PATH. Fix that because it caused weird
problems.

Signed-off-by: John Floren <john@jfloren.net>