### PR TITLE
acpi: accomodate null pointers in ApciOsGetLine

### DIFF
--- a/sys/src/libacpi/harvey.c
+++ b/sys/src/libacpi/harvey.c
@@ -659,9 +659,12 @@ AcpiOsPhysicalTableOverride(ACPI_TABLE_HEADER * ExistingTable,
 ACPI_STATUS
 AcpiOsGetLine(char *Buffer, UINT32 BufferLength, UINT32 * BytesRead)
 {
+	int amt;
 	if (debug)
 		fprint(2, "%s\n", __func__);
-	*BytesRead = read(0, Buffer, BufferLength);
+	amt = read(0, Buffer, BufferLength);
+	if (BytesRead)
+		*BytesRead = amt;
 	return AE_OK;
 }
 


### PR DESCRIPTION
This is not documented in the ACPICA spec but the
returned pointer to bytes read can be nil.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>