### PR TITLE
ACPI: create a file in #P for acpimem.

### DIFF
--- a/sys/src/9/amd64/build.json
+++ b/sys/src/9/amd64/build.json
@@ -94,6 +94,7 @@
 				"fossil": "/$ARCH/bin/fossil/fossil",
 				"grep": "/$ARCH/bin/grep",
 				"ipconfig": "/$ARCH/bin/ip/ipconfig",
+				"crs": "/$ARCH/bin/acpi/crs",
 				"irq": "/$ARCH/bin/acpi/irq",
 				"ls": "/$ARCH/bin/ls",
 				"mount": "/$ARCH/bin/mount",

--- a/sys/src/9/amd64/ioapic.c
+++ b/sys/src/9/amd64/ioapic.c
@@ -297,7 +297,7 @@ static int acpi_make_rdt(Vctl *v, int tbdf, int irq, int busno, int devno)
 			todo[(tbdf>>11)&0x1fff].v = *v;
 			todo[(tbdf>>11)&0x1fff].lo = lo | TMlevel | IPlow | Im;
 			todo[(tbdf>>11)&0x1fff].valid = 1;
-			print("Set TOOD[0x%x] to valid\n", (tbdf>>11)&0x1fff);
+			print("Set todo[0x%x] to valid\n", (tbdf>>11)&0x1fff);
 			return -1;
 		}
 	}

--- a/sys/src/9/amd64/main.c
+++ b/sys/src/9/amd64/main.c
@@ -54,7 +54,7 @@ static int numtcs = 32;		/* initial # of TCs */
 char dbgflg[256];
 static int vflag = 1;
 
-int nosmp = 1;
+int nosmp;
 int acpionly = 1;
 
 void*
@@ -605,7 +605,6 @@ main(uint32_t mbmagic, uint32_t mbaddress)
 if (1){	acpiinit(); hi("	acpiinit();\n");}
 
 	umeminit();
-	trapinit();
 
 	/*
 	 * This is necessary with GRUB and QEMU.
@@ -618,6 +617,7 @@ if (1){	acpiinit(); hi("	acpiinit();\n");}
 	procinit0();
 	print("before mpacpi, maxcores %d\n", maxcores);
 	mpacpi(maxcores);
+	trapinit();
 	apiconline();
 	/* Forcing to single core if desired */
 	if(!nosmp) {

--- a/sys/src/9/amd64/trap.c
+++ b/sys/src/9/amd64/trap.c
@@ -280,7 +280,7 @@ trapinit(void)
 	trapenable(VectorBPT, debugbpt, 0, "#BP");
 	trapenable(VectorPF, faultamd64, 0, "#PF");
 	trapenable(Vector2F, doublefault, 0, "#DF");
-	//intrenable(IdtIPI, expected, 0, BUSUNKNOWN, "#IPI");
+	intrenable(IdtIPI, expected, 0, BUSUNKNOWN, "#IPI");
 	trapenable(Vector15, unexpected, 0, "#15");
 	nmienable();
 

--- a/sys/src/cmd/acpi/build.json
+++ b/sys/src/cmd/acpi/build.json
@@ -13,6 +13,7 @@
 		    "alltables.c"
 		],
 		"SourceFilesCmd": [
+			"crs.c",
 			"irq.c"
 		]
 	}

--- a/sys/src/libacpi/harvey.c
+++ b/sys/src/libacpi/harvey.c
@@ -70,19 +70,18 @@ rawfd(void)
 {
 	int fd;
 	if (name == nil) {
-		name = smprint("#%C/raw", L'α');
+		name = "/dev/acpimem";
 		if (debug)
 			fprint(2, "Rawfd: open '%s'\n", name);
 		fd = open(name, OREAD);
 		if (fd > -1)
 			return fd;
-		name = smprint("#%C/raw", 'Z');
+		name = "#P/acpimem";
 		if (debug)
 			fprint(2, "Rawfd: open '%s'\n", name);
 		fd = open(name, OREAD);
 		if (fd > -1)
 			return fd;
-		/* try /dev paths here later. */
 	}
 	return open(name, OREAD);
 }

--- a/sys/src/libacpi/harvey.c
+++ b/sys/src/libacpi/harvey.c
@@ -337,7 +337,7 @@ AcpiOsMapMemory(ACPI_PHYSICAL_ADDRESS Where, ACPI_SIZE Length)
 		return nil;
 	}
 	//hexdump(v, Length);
-	hexdump(v, 36);
+	//hexdump(v, 36);
 	return v;
 }
 

--- a/util/GO9PCPU
+++ b/util/GO9PCPU
@@ -17,7 +17,7 @@ if [ "$(uname)" = "Linux" ] && [ -e /dev/kvm ]; then
 fi
 
 read -r cmd <<EOF
-$kvmdo qemu-system-x86_64 -s -cpu Opteron_G1 -smp 1 -m 2048 $kvmflag \
+$kvmdo qemu-system-x86_64 -s -cpu Opteron_G1 -smp 4 -m 2048 $kvmflag \
 -serial stdio \
 --machine $machineflag \
 -net nic,model=rtl8139 \


### PR DESCRIPTION
The way I did ACPI memory was not right. Qraw should be for the
raw data for one ACPI table and physical addresses should not be
used as offsets in it.

Create a new arch file, acpimem, that works like the old realmodemem
file, in that you can only read parts of it that correspond to the ACPI
tables.

This is the first in a sequence of changes making it possible to use the ACPICA tools
(e.g. acpidump) for debugging. I'm still trying to track down what broke in the VMWare
Fusion world and the story just keeps getting worse there (two different VMs on one
mac have very different ACPI behavior).

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>