### PR TITLE
riscv: booting to a bsp boot function

### DIFF
--- a/sys/src/9/riscv/core.json
+++ b/sys/src/9/riscv/core.json
@@ -19,7 +19,7 @@
 			"-I", "/sys/src/9/riscv",
 			"-I", "/sys/src/9/port"
 		],
-		"NoLibs": [
+	    "Libs": [
 			"/$ARCH/lib/klibc.a"
 		],
 		"Oflags": [
@@ -55,6 +55,7 @@
 			"trap.c"
 		],
 		"SourceFiles": [
+			"asm.S",
 			"ctype.c",
 			"main.c",
 			"uart.c"

--- a/sys/src/9/riscv/fns.h
+++ b/sys/src/9/riscv/fns.h
@@ -8,6 +8,12 @@
  */
 
 #include "../port/portfns.h"
+
+/* assembly code support from asm.S */
+void startmach(void (*f)(void), void *m);
+Mach *machp(void);
+
+/* other functions */
 void	intrac(Proc*);
 void	acinit(void);
 int	acpiinit(void);
@@ -135,7 +141,7 @@ uint64_t	spllo(void);
 void	splx(uint64_t);
 void	splxpc(uint64_t);
 void	kstackok(void); /* panic if kstack guards garbaged, works with and without externup */
-Stackframe	*stackframe(void); /* l64v.S */
+Stackframe	*stackframe(void); /* asm.S */
 void	stacksnippet(void);
 void	stopac(void);
 void	syncclock(void);

--- a/sys/src/9/riscv/main.c
+++ b/sys/src/9/riscv/main.c
@@ -18,13 +18,61 @@
 
 void testPrint(uint8_t c);
 
-void fuck(char *s)
+void msg(char *s)
 {
 	while (*s)
 		testPrint(*s++);
 }
+void die(char *s)
+{
+	msg(s);
+	while (1);
+}
 
 static int x = 0x123456;
+
+/* mach struct for hart 0. */
+/* in many plan 9 implementations this stuff is all reserved in early assembly.
+ * we don't have to do that. */
+static uint64_t m0stack[4096];
+static Mach m0;
+
+/* general purpose hart startup. We call this via startmach.
+ * When we enter here, the machp() function is usable.
+ */
+
+void hart(void)
+{
+	//Mach *mach = machp();
+	die("not yet");
+}
+
+void bsp(void)
+{
+	Mach *mach = machp();
+	if (mach != &m0)
+		die("MACH NOT MATCH");
+	msg("memset mach\n");
+	memset(mach, 0, sizeof(Mach));
+	msg("done that\n");
+
+	mach->self = (uintptr_t)mach;
+	msg("SET SELF OK\n");
+	mach->machno = 0;
+	mach->online = 1;
+	mach->NIX.nixtype = NIXTC;
+	mach->stack = PTR2UINT(m0stack);
+	*(uintptr_t*)mach->stack = STACKGUARD;
+	mach->externup = nil;
+	active.nonline = 1;
+	active.exiting = 0;
+	active.nbooting = 0;
+
+	msg("call asminit\n");
+	/* TODO: can the asm code be made portable? A lot of it looks like it can. */
+	//asminit();
+	die("Completed hart for bsp OK!\n");
+}
 
 void
 main(uint32_t mbmagic, uint32_t mbaddress)
@@ -32,9 +80,8 @@ main(uint32_t mbmagic, uint32_t mbaddress)
 
 	testPrint('0');
 	if (x != 0x123456)
-		fuck("Data is not set up correctly\n");
+		die("Data is not set up correctly\n");
 	//memset(edata, 0, end - edata);
-	fuck("got somewhere");
-	while (1);
-
+	msg("got somewhere");
+	startmach(bsp, &m0);
 }


### PR DESCRIPTION
A lot more is working. We can link with klibc and use memset.

We can set up initial mach pointer and stack in C, not assembly, which
avoids lots of nastiness.

Next step: split amd64/asm.c in arch and port parts, so we can use that code.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>