### PR TITLE
Compile minimal aarch64 kernel.

### DIFF
--- a/sys/src/9/aarch64/BUILDME.trivial
+++ b/sys/src/9/aarch64/BUILDME.trivial
@@ -1,0 +1,5 @@
+ARCH=aarch64  \
+STRIP=aarch64-none-elf-strip \
+CC=aarch64-none-elf-gcc \
+LD=aarch64-none-elf-ld \
+../../../../util/build trivial.json

--- a/sys/src/9/aarch64/cpu.json
+++ b/sys/src/9/aarch64/cpu.json
@@ -73,7 +73,8 @@
 		},
 		"Program": "harvey",
 		"SourceFiles": [
-			"aarch64cpu.c"
+			"l.S",
+			"main.c"
 		]
 	}
 }

--- a/sys/src/9/aarch64/l.S
+++ b/sys/src/9/aarch64/l.S
@@ -4,4 +4,5 @@
 
 .globl _start
 _start:
+_main:
 		WFI

--- a/sys/src/9/aarch64/main.c
+++ b/sys/src/9/aarch64/main.c
@@ -8,7 +8,9 @@
  * contained in the LICENSE.gpl file.
  */
 
+#include <u.h>
+
 void
-main(uint32_t mbmagic, uint32_t mbaddress)
+main(uint64_t mbmagic, uintptr_t mbaddress)
 {
 }

--- a/sys/src/9/aarch64/trivial.json
+++ b/sys/src/9/aarch64/trivial.json
@@ -1,0 +1,12 @@
+{
+	"aarch64cpu": {
+		"Env": [
+			"CONF=aarch64cpu"
+		],
+		"Program": "harvey",
+		"SourceFiles": [
+			"l.S",
+			"main.c"
+		]
+	}
+}


### PR DESCRIPTION
Where 'kernel' is defined as a single 'WFI' instruction.

Signed-off-by: Dan Cross <cross@gajendra.net>