### PR TITLE
Skeletal 'gettls0' for aarch64.

### DIFF
--- a/sys/src/libc/aarch64/main9.S
+++ b/sys/src/libc/aarch64/main9.S
@@ -11,3 +11,8 @@
 .globl _main
 _main:
 	RET
+
+.globl gettls0
+gettls0:
+	MOV	x0, #0
+	RET


### PR DESCRIPTION
Want your TLS? It's nil kid; that's your TLS.
(This just makes regress build. Now all of Harvey
builds for aarch64.)

Signed-off-by: Dan Cross <cross@gajendra.net>