### PR TITLE
riscv: Bring in latest portability interfaces.

### DIFF
--- a/sys/src/libc/riscv/build.json
+++ b/sys/src/libc/riscv/build.json
@@ -4,6 +4,8 @@
 	    "$ARCH/notejmp.c",
 	    "$ARCH/argv0.c",
 	    "$ARCH/atomic.S",
+	    "$ARCH/getcallerpc.c",
+	    "$ARCH/getcallstack.c",
 	    "$ARCH/main9.S",
 	    "$ARCH/setjmp.S",
 	    "$ARCH/_spl.S",

--- a/sys/src/libc/riscv/getcallerpc.c
+++ b/sys/src/libc/riscv/getcallerpc.c
@@ -1,0 +1,17 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+
+uintptr_t
+getcallerpc(void)
+{
+	return (uintptr_t)__builtin_return_address(2);
+}

--- a/sys/src/libc/riscv/getcallstack.c
+++ b/sys/src/libc/riscv/getcallstack.c
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the Harvey operating system.  It is subject to the
+ * license terms of the GNU GPL v2 in LICENSE.gpl found in the top-level
+ * directory of this distribution and at http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * No part of Harvey operating system, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.gpl file.
+ */
+
+#include <u.h>
+#include <libc.h>
+
+void
+getcallstack(uintptr *pcs, size_t npcs)
+{
+	assert(npcs < 6);
+
+	if (npcs > 0)
+		pcs[0] = (uintptr)__builtin_return_address(2);
+	if (npcs > 1)
+		pcs[1] = (uintptr)__builtin_return_address(3);
+	if (npcs > 2)
+		pcs[2] = (uintptr)__builtin_return_address(4);
+	if (npcs > 3)
+		pcs[3] = (uintptr)__builtin_return_address(5);
+	if (npcs > 4)
+		pcs[4] = (uintptr)__builtin_return_address(6);
+	if (npcs > 5)
+		pcs[5] = (uintptr)__builtin_return_address(7);
+	if (npcs > 6)
+		sysfatal("getcallstack: stack size must be <= 6, got %zu", npcs);
+}


### PR DESCRIPTION
Implement getcallerpc, getcallstack, and gettls0 for
riscv.  Note, I don't have a riscv toolchain set up;
hopefully Ron can test this out.

Signed-off-by: Dan Cross <cross@gajendra.net>