### PR TITLE
Rewrite cistrcmp and strcmp.

### DIFF
--- a/sys/src/libc/port/cistrcmp.c
+++ b/sys/src/libc/port/cistrcmp.c
@@ -9,27 +9,25 @@
 
 #include <u.h>
 #include <libc.h>
+#include <ctype.h>
 
 int
 cistrcmp(const char *s1, const char *s2)
 {
-	int c1, c2;
+	unsigned int c1, c2;
 
-	while(*s1){
+	do{
 		c1 = *(uint8_t*)s1++;
 		c2 = *(uint8_t*)s2++;
-
 		if(c1 == c2)
 			continue;
+		c1 = tolower(c1);
+		c2 = tolower(c2);
+		if(c1 < c2)
+			return -1;
+		if(c1 > c2)
+			return 1;
+	}while(c1 != 0);
 
-		if(c1 >= 'A' && c1 <= 'Z')
-			c1 -= 'A' - 'a';
-
-		if(c2 >= 'A' && c2 <= 'Z')
-			c2 -= 'A' - 'a';
-
-		if(c1 != c2)
-			return c1 - c2;
-	}
-	return -*s2;
+	return 0;
 }

--- a/sys/src/libc/port/runestrcmp.c
+++ b/sys/src/libc/port/runestrcmp.c
@@ -15,15 +15,14 @@ runestrcmp(const Rune *s1, const Rune *s2)
 {
 	Rune c1, c2;
 
-	for(;;) {
+	do{
 		c1 = *s1++;
 		c2 = *s2++;
-		if(c1 != c2) {
-			if(c1 > c2)
-				return 1;
+		if(c1 < c2)
 			return -1;
-		}
-		if(c1 == 0)
-			return 0;
-	}
+		if(c1 > c2)
+			return 1;
+	}while(c1 != 0);
+
+	return 0;
 }

--- a/sys/src/libc/port/strcmp.c
+++ b/sys/src/libc/port/strcmp.c
@@ -13,17 +13,16 @@
 int
 strcmp(const char *s1, const char *s2)
 {
-	unsigned c1, c2;
+	unsigned int c1, c2;
 
-	for(;;) {
+	do{
 		c1 = *s1++;
 		c2 = *s2++;
-		if(c1 != c2) {
-			if(c1 > c2)
-				return 1;
+		if(c1 < c2)
 			return -1;
-		}
-		if(c1 == 0)
-			return 0;
-	}
+		if(c1 > c2)
+			return 1;
+	}while(c1 != 0);
+
+	return 0;
 }


### PR DESCRIPTION
Make strcmp and cistrcmp more straight-forward.  I believe
the originals were correct, but these are more obvious.
Note: Please review these *very* carefully.

Signed-off-by: Dan Cross <cross@gajendra.net>