### PR TITLE
Add another tool path to these build rules.

### DIFF
--- a/amd64/include/cflags.json
+++ b/amd64/include/cflags.json
@@ -22,6 +22,9 @@
 			"/usr/bin/gcc": [
 				"-Wno-frame-address"
 			],
+			"/opt/gnu/bin/x86_64-none-elf-gcc": [
+				"-Wno-frame-address"
+			],
 			"/usr/bin/gcc-6": [
 				"-Wno-frame-address"
 			]

--- a/amd64/include/klib.json
+++ b/amd64/include/klib.json
@@ -7,6 +7,9 @@
 			"/usr/bin/gcc": [
 				"-Wno-frame-address"
 			],
+			"/opt/gnu/bin/x86_64-none-elf-gcc": [
+				"-Wno-frame-address"
+			],
 			"/usr/bin/gcc-6": [
 				"-Wno-frame-address"
 			]

--- a/sys/src/9/amd64/core.json
+++ b/sys/src/9/amd64/core.json
@@ -19,6 +19,9 @@
 			"/usr/bin/gcc": [
 				"-Wno-frame-address"
 			],
+			"/opt/gnu/bin/x86_64-none-elf-gcc": [
+				"-Wno-frame-address"
+			],
 			"/usr/bin/gcc-6": [
 				"-Wno-frame-address"
 			]


### PR DESCRIPTION
In lieu of coming up with a cleaner mechanism,
add yet another compiler pathname to these files.

We need a better way.

Signed-off-by: Dan Cross <cross@gajendra.net>