### PR TITLE
GCC 6.2 has --enable-default-pie in Debian

### DIFF
--- a/amd64/include/klib.json
+++ b/amd64/include/klib.json
@@ -5,13 +5,15 @@
 				"-mno-implicit-float"
 			],
 			"/usr/bin/gcc": [
-				"-Wno-frame-address"
+				"-Wno-frame-address",
+				"-fno-pie"
 			],
 			"/opt/gnu/bin/x86_64-none-elf-gcc": [
 				"-Wno-frame-address"
 			],
 			"/usr/bin/gcc-6": [
-				"-Wno-frame-address"
+				"-Wno-frame-address",
+				"-fno-pie"
 			]
 		},
 		"Cflags": [

--- a/sys/src/9/amd64/core.json
+++ b/sys/src/9/amd64/core.json
@@ -17,13 +17,15 @@
 				"-mno-implicit-float"
 			],
 			"/usr/bin/gcc": [
-				"-Wno-frame-address"
+				"-Wno-frame-address",
+				"-fno-pie"
 			],
 			"/opt/gnu/bin/x86_64-none-elf-gcc": [
 				"-Wno-frame-address"
 			],
 			"/usr/bin/gcc-6": [
-				"-Wno-frame-address"
+				"-Wno-frame-address",
+				"-fno-pie"
 			]
 		},
 		"Cflags": [


### PR DESCRIPTION
It failed for me in Debian Testing
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77464

With this kernel builds again. Please, take it to bldy.

Signed-off-by: Álvaro Jurado <elbingmiss@gmail.com>