### PR TITLE
Line and 9p mode of virtconsole transfer

### DIFF
--- a/sys/src/9/port/devvcon.c
+++ b/sys/src/9/port/devvcon.c
@@ -31,6 +31,7 @@ enum
 	Qtopdir = 0,			// top directory
 	Qvirtcon,				// virtcon directory under the top where all consoles live
 	Qvcpipe,				// console pipe for reading/writing
+	Qvcctl,					// control file (one for all consoles)
 };
 
 static Dirtab topdir[] = {
@@ -40,11 +41,101 @@ static Dirtab topdir[] = {
 
 extern Dev vcondevtab;
 
+// Private per-console data (shared between both queues)
+
+enum
+{
+	Vcmraw = 0,				// raw buffer transfer mode
+	Vcmdelim = 1,			// prefilled/delimited buffer receive mode
+	Vcm9p = 2,				// 9p-aware buffer receive mode
+};
+
+typedef struct vcondata 
+{
+	uint8_t prefill;		// prefill the receiving buffer with this octet
+	uint8_t delim;			// determine input length as index of this octet (or full buffer length)
+	uint16_t vcmode;		// virtual console mode (enum above)
+	int32_t maxbuf;			// maximum buffer length
+} VconData;
+
 // Array of defined virtconsoles and their number
 
 static uint32_t nvcon;
 
 static Vqctl **vcons;
+
+// Handle control file writes. The ctl file accepts command lines in the format
+// name<space>param<space>value. Name is the console name (vconsN), param is one of mode|prefill|delim|maxbuf,
+// value for mode is one of raw|9p|delim, values for maxbuf, prefill and delim are strings representing
+// numeric values. A buffer should contain whole command line. Tokens should be delimited with exactly one space.
+// If a command line cannot be parsed, error will be raised.
+
+#define NEXTSPACE for(idxp = idx; idx < n; idx++) if(buf[idx] <= ' ') break
+#define IFENDBUF(msg) if(idx == n) {error(msg); return -1;}
+#define TOKEN(tk) tkl = idx - idxp; uint8_t tk[tkl + 1]; memmove(tk, buf + idxp, tkl); tk[tkl] = 0; idx++
+#define IFPARAM(p) if(!strcmp((char *)param, p))
+#define IFVALUE(v) if(!strcmp((char *)value, v))
+#define IFINVAL if(!valval) { error("numeric conversion error"); return -1;}
+
+static int
+ctl(void *va, int32_t n) 
+{
+	Vqctl *vctl = nil;
+	uint8_t *buf = va;
+	int idx = 0, idxp, tkl;
+	NEXTSPACE;
+	IFENDBUF("devvcon: cannot extract console name");
+	TOKEN(name);
+	NEXTSPACE;
+	IFENDBUF("devvcon: value are not provided");
+	TOKEN(param);
+	NEXTSPACE;
+	TOKEN(value);
+	for(int i = 0; i < nvcon; i++) {
+		if(!strcmp((char *)name, (char *)vcons[i]->devname)) {
+			vctl = vcons[i];
+			break;
+		}
+	}
+	if(vctl == nil) {
+		error(Enonexist);
+		return -1;
+	}
+	VconData *vc = vctl->vqs[0]->pqdata;
+	if(vc == nil) {
+		error("devvcon: private data was not allocated");
+		return -1;
+	}
+	char *cptr;
+	long nvalue = strtol((char *)value, &cptr, 0);
+	int valval = (*cptr == 0);
+	IFPARAM("mode") {
+		IFVALUE("9p") {
+			vc->vcmode = Vcm9p;
+		} else IFVALUE("delim") {
+			vc->vcmode = Vcmdelim;
+		} else IFVALUE("raw") {
+			vc->vcmode = Vcmraw;
+		} else {
+			error("devvcon: unrecognized mode");
+			return -1;
+		}
+	} else IFPARAM("delim") {
+		IFINVAL;
+		vc->delim = nvalue & 0xFF;
+	} else IFPARAM("prefill") {
+		IFINVAL;
+		vc->prefill = nvalue & 0xFF;
+	} else IFPARAM("maxbuf") {
+		IFINVAL;
+		vc->maxbuf = nvalue;
+	} else {
+		error("devvcon: unrecognized parameter");
+		return -1;
+	}
+
+	return n;
+}
 
 // Read-write common code
 
@@ -53,6 +144,11 @@ rwcommon(Vqctl *d, void *va, int32_t n, int qidx)
 {
 	uint16_t descr[1];
 	Virtq *vq = d->vqs[qidx];
+	VconData *vc = vq->pqdata;
+	if(n > ((vc!=nil)?vc->maxbuf:32768)) {
+		error(Etoobig);
+		return -1;
+	}
 	int nd = getdescr(vq, 1, descr);
 	if(nd < 1)
 	{
@@ -62,6 +158,9 @@ rwcommon(Vqctl *d, void *va, int32_t n, int qidx)
 	uint8_t buf[n];
 	if(qidx) {
 		memmove(buf, va, n);
+	} else {
+		if(vc && vc->vcmode == Vcmdelim)
+			memset(buf, vc->prefill, n);
 	}
 	q2descr(vq, descr[0])->addr = PADDR(buf);
 	q2descr(vq, descr[0])->len = n;	
@@ -70,6 +169,21 @@ rwcommon(Vqctl *d, void *va, int32_t n, int qidx)
 	}
 	int rc = queuedescr(vq, 1, descr);
 	if(!qidx) {
+		int32_t nlen;
+		if(vc != nil)
+		{
+			switch(vc->vcmode) {
+			case Vcmdelim:
+				for(nlen = 0; nlen < n; nlen++) {
+					if(buf[nlen] == vc->delim)
+						break;
+				}
+			default:
+				nlen = n;
+			}
+		} else {
+			nlen = n;
+		}
 		memmove(va, buf, n);
 	}
 	reldescr(vq, 1, descr);
@@ -101,9 +215,15 @@ vcongen(Chan *c, char *d, Dirtab* dir, int i, int s, Dir *dp)
 			devdir(c, q, up->genbuf, 0, eve, DMDIR|0555, dp);
 			return 1;
 		}
-		if(s >= nvcon)
+		if(s > nvcon)
 			return -1;
-		snprint(up->genbuf, sizeof up->genbuf, "vcons%d", s);
+		if(s == nvcon) {
+			snprint(up->genbuf, sizeof up->genbuf, "ctl", s);
+			q = (Qid) {QID(0, Qvcctl), 0, 0};
+			devdir(c, q, up->genbuf, 0, eve, 0222, dp);
+			return 1;
+		}
+		snprint(up->genbuf, sizeof up->genbuf, vcons[s]->devname);
 		q = (Qid) {QID(s, Qvcpipe), 0, 0};
 		devdir(c, q, up->genbuf, 0, eve, 0666, dp);
 		return 1;
@@ -157,6 +277,8 @@ vconread(Chan *c, void *va, int32_t n, int64_t offset)
 		return devdirread(c, va, n, (Dirtab *)0, 0L, vcongen);
 	case Qvcpipe:
 		return rwcommon(vcons[vdidx], va, n, 0);
+	case Qvcctl:
+		error(Eperm);
 	}
 	return -1;
 }
@@ -174,6 +296,8 @@ vconwrite(Chan *c, void *va, int32_t n, int64_t offset)
 		return -1;
 	case Qvcpipe:
 		return rwcommon(vcons[vdidx], va, n, 1);
+	case Qvcctl:
+		return ctl(va, n);
 	}
 	return -1;
 }
@@ -214,6 +338,15 @@ vconinit(void)
 		print("config area size %d\n", rc);
 		print("cols=%d rows=%d ports=%d\n", vcfg.cols, vcfg.rows, vcfg.max_nr_ports);
 		finalinitvdev(vcons[i]);
+		VconData *vc = mallocz(sizeof(VconData), 1);
+		if(vc == nil) {
+			print("failed to allocate per-queue data for console %d, assuming raw mode only\n", i);
+			continue;
+		}
+		vc->maxbuf = 32768;
+		for(int j = 0; j < vcons[i]->nqs ; j++) {
+			vcons[i]->vqs[j]->pqdata = vc;
+		}
 	}
 }
 


### PR DESCRIPTION
I added a feature to the virtconsole to process the buffers received from the host so the actual length of data can be returned to the requesting process, rather than just the length of the whole buffer. In line mode (prefill + delimiter) the read buffer is prefilled with an octet that is not expected to be found in the input. By finding the first octet with that value, the driver can determine how much data was actually transferred by the host, and return the value accordingly from read. By prefillling the buffer with 0s and using 0 as delimiter, it becomes possible with certain limitations to run a shell over virtual console. Other mode supported is 9p where length of the message is extracted form the first 4 octets, and it is returned from read.

The following script works:

```
#! /bin/rc -x
echo virtio-console-0 mode 9p > /dev/virtcon/ctl
echo virtio-console-0 maxbuf 131096 > /dev/virtcon/ctl
mount -c -n /dev/virtcon/virtio-console-0 /mnt/xxx

ls -l /mnt/xxx/vc*

time dd -if /dev/random -of /mnt/xxx/txfer1 -bs 1024 -count 1024
time dd -if /dev/random -of /mnt/xxx/txfer1 -bs 1024 -count 10240
time dd -if /dev/random -of /mnt/xxx/txfer1 -bs 10240 -count 10240

ls -l /mnt/xxx/tx*

unmount /mnt/xxx

```

and its output:

```
. /rc/lib/rcmain /tmp/mtst
flag p
finit
flag i
. /tmp/mtst
echo virtio-console-0 mode 9p
echo virtio-console-0 maxbuf 131096
mount -c -n /dev/virtcon/virtio-console-0 /mnt/xxx
ls -l /mnt/xxx/vc00 /mnt/xxx/vc02
--rwxrwxr-x M 28 harvey harvey 0 Nov  9 23:49 /mnt/xxx/vc00
--rwxrwxr-x M 28 harvey harvey 0 Nov  9 23:49 /mnt/xxx/vc02
time dd -if /dev/random -of /mnt/xxx/txfer1 -bs 1024 -count 1024
1024+0 records in
1024+0 records out
0.01u 0.12s 0.50r        dd -if /dev/random -of /mnt/xxx/txfer1 ...
time dd -if /dev/random -of /mnt/xxx/txfer1 -bs 1024 -count 10240
10240+0 records in
10240+0 records out
0.01u 1.60s 4.23r        dd -if /dev/random -of /mnt/xxx/txfer1 ...
time dd -if /dev/random -of /mnt/xxx/txfer1 -bs 10240 -count 10240
10240+0 records in
10240+0 records out
0.01u 3.26s 7.77r        dd -if /dev/random -of /mnt/xxx/txfer1 ...
ls -l /mnt/xxx/txfer1
--rw-rw-r-- M 28 harvey harvey 104857600 Nov  9 23:50 /mnt/xxx/txfer1
unmount /mnt/xxx
exit ''

```

The whole thing is not very stable: repeated use of this script causes kernel fault. I could not test dd for reading from the mounted directory, it crashes the kernel as well.

Anyway, I see this as some progress. It might be interesting to use virtio console as the root filesystem when booting.

Everybody is welcome to test this script and compare their times with mine.

PS I order to access a host directory, ```ufs -ntype=unix -addr=/tmp/vc02 -root=/tmp``` was run; the virtconsole in client mode is redirected to the socket at /tmp/vc02

Thanks.