### PR TITLE
devcap: undo a mistake

### DIFF
--- a/sys/src/9/port/devcap.c
+++ b/sys/src/9/port/devcap.c
@@ -236,9 +236,7 @@ capwrite(Chan *c, void *va, int32_t n, int64_t m)
 		if(key == nil)
 			error(Eshort);
 		*key++ = 0;
-		panic("need a sha256");
-		//hmac_sha1((uint8_t*)from, strlen(from), (uint8_t*)key,
-		//strlen(key), hash, nil);
+		hmac_sha1((uint8_t*)from, strlen(from), (uint8_t*)key, strlen(key), hash, nil);
 
 		p = remcap(hash);
 		if(p == nil){


### PR DESCRIPTION
I forgot we actually are using devcap, and made a mistaken
push to sha256. That's going to be a while on Harvey.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>