### PR TITLE
Get ACPICA AcpiEnableSubSystem to work properly

### DIFF
--- a/sys/src/9/amd64/devacpi.c
+++ b/sys/src/9/amd64/devacpi.c
@@ -1915,6 +1915,7 @@ static void acpiinitonce(void)
 	 * We are not ready in this kernel for that.
 	 */
 	assert(fadt != nil);
+#if 0	/* These iomaps intefere with acpica library */
 	acpiioalloc(fadt->smicmd, 1);
 	acpiioalloc(fadt->pm1aevtblk, fadt->pm1evtlen);
 	acpiioalloc(fadt->pm1bevtblk, fadt->pm1evtlen);
@@ -1924,6 +1925,7 @@ static void acpiinitonce(void)
 	acpiioalloc(fadt->pmtmrblk, fadt->pmtmrlen);
 	acpiioalloc(fadt->gpe0blk, fadt->gpe0blklen);
 	acpiioalloc(fadt->gpe1blk, fadt->gpe1blklen);
+#endif
 
 	initgpes();
 #ifdef RON_SAYS_CONFIG_WE_ARE_NOT_WORTHY

--- a/sys/src/libacpi/harvey.c
+++ b/sys/src/libacpi/harvey.c
@@ -119,13 +119,13 @@ inb(uint16_t addr)
 {
 	uint64_t off = addr;
 	uint16_t b;
-	if (pread(iow, &b, 1, off) < 1)
+	if (pread(iob, &b, 1, off) < 1)
 		print("inb(0x%x): %r\n", addr);
 	return b;
 }
 
 void
-outl(uint32_t val, uint16_t addr)
+outl(uint16_t addr, uint32_t val)
 {
 	uint64_t off = addr;
 	if (pwrite(iol, &val, 4, off) < 4)
@@ -133,7 +133,7 @@ outl(uint32_t val, uint16_t addr)
 }
 
 void
-outs(uint16_t val, uint16_t addr)
+outs(uint16_t addr, uint16_t val)
 {
 	uint64_t off = addr;
 	if (pwrite(iow, &val, 2, off) < 2)
@@ -141,7 +141,7 @@ outs(uint16_t val, uint16_t addr)
 }
 
 void
-outb(uint8_t val, uint16_t addr)
+outb(uint16_t addr, uint8_t val)
 {
 	uint64_t off = addr;
 	if (pwrite(iob, &val, 1, off) < 1)


### PR DESCRIPTION
I am trying to get oriented around the acpi stuff and created a small test program that uses the acpica library according to the programmer's reference. In doing so, I found some small errors preventing the ACPICA library from working properly. The out pio functions in the custom part of libacpi had their arguments reversed. Also, devacpi had ioalloced the ACPI ports preventing userspace from accessing them.

The test program I used is as follows (built in /sys/src/cmd/acpi):
```
#include <acpi.h>

void main(int argc, char *argv[])
{
	ACPI_STATUS status;

	status = AcpiInitializeSubsystem();
	if (ACPI_FAILURE(status))
		exits("failed to init subsystem");
	status = AcpiInitializeTables(NULL, 4, 0);
	if (ACPI_FAILURE(status))
		exits("failed to init tables");
	status = AcpiLoadTables();
	if (ACPI_FAILURE(status))
		exits("failed to load tables");
	status = AcpiEnableSubsystem(ACPI_FULL_INITIALIZATION);
	if (ACPI_FAILURE(status))
		exits("failed to enable subsystem");
	status = AcpiTerminate();
	if (ACPI_FAILURE(status))
		exits("failed to terminate acpi");
	exits(0);
}
```

Signed-off-by: Justin Sanders <sanderssj@gmail.com>