### PR TITLE
bldy: envinroment variables can now be used in paths

### DIFF
--- a/.build
+++ b/.build
@@ -1,4 +1,5 @@
 CC = gcc
+ARCH=amd64
 [darwin]
 TOOLPREFIX = x86_64-elf-
 [harvey]

--- a/sys/src/9/amd64/BUILD
+++ b/sys/src/9/amd64/BUILD
@@ -191,21 +191,21 @@ strip(
 mk_sys(
 	name="error",
 	mode="error.h",
-	arch="amd64",
+	arch=env("ARCH"),
 	sysconf="//sys/src/sysconf.json",
 )
 
 mk_sys(
 	name="sys",
 	mode="sys.h",
-	arch="amd64",
+	arch=env("ARCH"),
 	sysconf="//sys/src/sysconf.json",
 )
 
 mk_sys(
 	name="systab",
 	mode="systab.c",
-	arch="amd64",
+	arch=env("ARCH"),
 	sysconf="//sys/src/sysconf.json",
 )
 

--- a/sys/src/libc/BUILD
+++ b/sys/src/libc/BUILD
@@ -230,17 +230,17 @@ LIBC_SRCS = [
     "port/u16.c",
     "port/u32.c",
     "port/u64.c",
-    "amd64/notejmp.c",
-    "amd64/cycles.c",
-    "amd64/argv0.c",
+    "${ARCH}/notejmp.c",
+    "${ARCH}/cycles.c",
+    "${ARCH}/argv0.c",
     "port/getcallerpc.c",
     "port/getcallstack.c",
-    "amd64/rdpmc.c",
-    "amd64/setjmp.s",
-    "amd64/sqrt.s",
-    "amd64/tas.s",
-    "amd64/atom.S",
-    "amd64/main9.S"
+    "${ARCH}/rdpmc.c",
+    "${ARCH}/setjmp.s",
+    "${ARCH}/sqrt.s",
+    "${ARCH}/tas.s",
+    "${ARCH}/atom.S",
+    "${ARCH}/main9.S"
 ]
 
 KLIBC_SRCS = [
@@ -433,17 +433,17 @@ KLIBC_SRCS = [
     "port/u16.c",
     "port/u32.c",
     "port/u64.c",
-    "amd64/notejmp.c",
-    "amd64/cycles.c",
-    "amd64/argv0.c",
+    "${ARCH}/notejmp.c",
+    "${ARCH}/cycles.c",
+    "${ARCH}/argv0.c",
     "port/getcallerpc.c",
     "port/getcallstack.c",
-    "amd64/rdpmc.c",
-    "amd64/setjmp.s",
-    "amd64/sqrt.s",
-    "amd64/tas.s",
-    "amd64/atom.S",
-    "amd64/main9.S"
+    "${ARCH}/rdpmc.c",
+    "${ARCH}/setjmp.s",
+    "${ARCH}/sqrt.s",
+    "${ARCH}/tas.s",
+    "${ARCH}/atom.S",
+    "${ARCH}/main9.S"
 ]
 
 
@@ -452,7 +452,7 @@ cc_library(
     copts=KLIB_COMPILER_FLAGS,
     includes=[
         "//sys/include",
-        "//amd64/include",
+        "//${ARCH}/include",
         "//sys/src/libc"
     ],
     srcs=KLIBC_SRCS,
@@ -468,7 +468,7 @@ cc_library(
     copts=LIB_COMPILER_FLAGS,
     includes=[
         "//sys/include",
-        "//amd64/include",
+        "//${ARCH}/include",
         "//sys/src/libc"
     ],
     srcs=LIBC_SRCS,
@@ -481,13 +481,13 @@ cc_library(
 mk_sys(
     name="syscallheader",
     mode="sys.h",
-    arch="amd64",
+    arch=env("ARCH"),
     sysconf="//sys/src/sysconf.json",
 )
 
 mk_sys(
     name="9syscall",
     mode="syscallfiles",
-    arch="amd64",
+    arch=env("ARCH"),
     sysconf="//sys/src/sysconf.json",
 )

--- a/sys/src/libthread/BUILD
+++ b/sys/src/libthread/BUILD
@@ -8,7 +8,7 @@ cc_library(
             "//amd64/include",
         ],
 	srcs = [
-		"amd64.c",
+		"$ARCH.c",
 		"channel.c",
 		"chanprint.c",
 		"create.c",


### PR DESCRIPTION
related to bldy/build#45

Signed-off-by: Sevki <s@sevki.org>