### PR TITLE
amd64: fix clang booting

### DIFF
--- a/amd64/include/klib.json
+++ b/amd64/include/klib.json
@@ -4,6 +4,18 @@
 			"/usr/bin/clang": [
 				"-mno-implicit-float"
 			],
+			"/usr/bin/clang-3.4": [
+				"-mno-implicit-float"
+			],
+			"/usr/bin/clang-3.5": [
+				"-mno-implicit-float"
+			],
+			"/usr/bin/clang-3.6": [
+				"-mno-implicit-float"
+			],
+			"/usr/bin/clang-3.7": [
+				"-mno-implicit-float"
+			],
 			"/usr/bin/gcc": [
 				"-Wno-frame-address",
 				"-fno-pie"


### PR DESCRIPTION
I had not kept klib.json up to date.

clang-build amd64 kernels boot again.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>