### PR TITLE
bootstrap.sh: remove sources of error

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-echo Building the build tool...
-
+echo Building the 9p server from github.com/Harvey-OS/ninep/cmd/ufs
 GOBIN="$(pwd)/util" GOPATH="$(pwd)/util/third_party:$(pwd)/util" go get -u github.com/Harvey-OS/ninep/cmd/ufs
-GOBIN="$(pwd)/util" GOPATH="$(pwd)/util/third_party:$(pwd)/util" go get -u github.com/bldy/build/cmd/bldy
+
+echo Building the build tool...
 GOBIN="$(pwd)/util" GOPATH="$(pwd)/util/third_party:$(pwd)/util" go get harvey/cmd/...
 
 
@@ -17,7 +17,6 @@ export ARCH=amd64
 ./util/build
 # See \`build -h' for more information on the build tool.
 
-To build with bldy just type bldy //:kernel 
 To enable access to files, create a harvey and none user:
 sudo useradd harvey
 sudo useradd none


### PR DESCRIPTION
The bldy tool won't cleanly build and is also dependent on
obsolete packages.

Until it is fixed, remove the go get for it and any references to it.
We can't have a broken bootstrap script.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>