### PR TITLE
Fixing bldy building with GCC

### DIFF
--- a/sys/src/9/amd64/BUILD
+++ b/sys/src/9/amd64/BUILD
@@ -235,6 +235,7 @@ cc_binary(
 		"-mno-red-zone",
 		"-ffreestanding",
 		"-fno-builtin",
+		"-fno-pie",
 		"-DKERNDATE=1433623937",
 		"-g",
 		"-Wall",

--- a/sys/src/FLAGS
+++ b/sys/src/FLAGS
@@ -43,6 +43,7 @@ KLIB_COMPILER_FLAGS=[
 	"-mno-red-zone",
 	"-ffreestanding",
 	"-fno-builtin",
+    "-fno-pie",
 	"-Wall",
 	"-Wno-missing-braces",
 	"-Wno-parentheses",

--- a/sys/src/libc/BUILD
+++ b/sys/src/libc/BUILD
@@ -73,6 +73,7 @@ LIBC_SRCS = [
     "9syscall/pipe.s",
     "9syscall/pread.s",
     "9syscall/pwrite.s",
+    "9syscall/r0.s",
     "9syscall/remove.s",
     "9syscall/rendezvous.s",
     "9syscall/rfork.s",


### PR DESCRIPTION
For no clang fans. Avoiding PIC error in kernel mode.
Added option is not a conflict for clang.