### PR TITLE
Adding mising syscall to bldy BUILD file in libc

### DIFF
--- a/sys/src/libc/BUILD
+++ b/sys/src/libc/BUILD
@@ -73,6 +73,7 @@ LIBC_SRCS = [
     "9syscall/pipe.s",
     "9syscall/pread.s",
     "9syscall/pwrite.s",
+    "9syscall/r0.s",
     "9syscall/remove.s",
     "9syscall/rendezvous.s",
     "9syscall/rfork.s",


### PR DESCRIPTION
Signed-off-by: Álvaro Jurado <elbingmiss@gmail.com>