### PR TITLE
Move prototype of checkdc into portfns.h

### DIFF
--- a/sys/src/9/port/chan.c
+++ b/sys/src/9/port/chan.c
@@ -14,8 +14,6 @@
 #include	"fns.h"
 #include	"../port/error.h"
 
-int checkdc(int dc);
-
 enum
 {
 	PATHSLOP	= 20,

--- a/sys/src/9/port/portfns.h
+++ b/sys/src/9/port/portfns.h
@@ -61,6 +61,7 @@ void		copypage(Page*, Page*);
 void		cunmount(Chan*, Chan*);
 Segment*	data2txt(Segment*);
 uintptr_t		dbgpc(Proc*);
+int 		checkdc(int dc);
 int		decrypt(void*, void*, int);
 void		delay(int);
 Proc*		dequeueproc(Sched*, Schedq*, Proc*);


### PR DESCRIPTION
The function belongs to sysfile.c which is in port hence moved to portfns.h

Signed-off-by: golubovsky <golubovsky@gmail.com>