### PR TITLE
9p proxy over virtqueue

### DIFF
--- a/sys/src/9/port/devvcon.c
+++ b/sys/src/9/port/devvcon.c
@@ -59,7 +59,11 @@ rwcommon(Vqctl *d, void *va, int32_t n, int qidx)
 		error("virtcon: queue low");
 		return -1;
 	}
-	uint8_t buf[n];
+	uint8_t *buf = malloc(n);
+	if(buf==nil) {
+		error("devvcon: no memory to allocate the exchange buffer");
+		return -1;
+	}
 	if(qidx) {
 		memmove(buf, va, n);
 	}
@@ -73,6 +77,7 @@ rwcommon(Vqctl *d, void *va, int32_t n, int qidx)
 		memmove(va, buf, n);
 	}
 	reldescr(vq, 1, descr);
+	free(buf);
 	return (rc >= 0)?n:rc;
 }
 
@@ -103,7 +108,7 @@ vcongen(Chan *c, char *d, Dirtab* dir, int i, int s, Dir *dp)
 		}
 		if(s >= nvcon)
 			return -1;
-		snprint(up->genbuf, sizeof up->genbuf, "vcons%d", s);
+		snprint(up->genbuf, sizeof up->genbuf, vcons[s]->devname);
 		q = (Qid) {QID(s, Qvcpipe), 0, 0};
 		devdir(c, q, up->genbuf, 0, eve, 0666, dp);
 		return 1;

--- a/sys/src/9/port/devvcon.c
+++ b/sys/src/9/port/devvcon.c
@@ -53,6 +53,9 @@ rwcommon(Vqctl *d, void *va, int32_t n, int qidx)
 {
 	uint16_t descr[1];
 	Virtq *vq = d->vqs[qidx];
+	if(vq == nil) {
+		error("virtcon: no virtqueue");
+	}
 	int nd = getdescr(vq, 1, descr);
 	if(nd < 1)
 	{

--- a/sys/src/cmd/9pvpxy.c
+++ b/sys/src/cmd/9pvpxy.c
@@ -1,0 +1,77 @@
+/*
+ * This file is part of the Harvey operating system.  It is subject to the
+ * license terms of the GNU GPL v2 in LICENSE.gpl found in the top-level
+ * directory of this distribution and at http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * No part of Harvey operating system, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.gpl file.
+ */
+
+// 9pvpxy.c A 9p proxy over virtqueue. Read 9p messages from standard input, send them to the virtqueue.
+// Read responses from the virtqueue, send them to the standard output.
+// The operation is single-threaded: write to virtqueue is expected to complete before the response can be read.
+
+#include <u.h>
+#include <libc.h>
+#include <fcall.h>
+
+#define BUFLEN 256*1024
+
+static uint8_t ibuf[BUFLEN], obuf[BUFLEN];
+
+void
+exerr(char *s)
+{
+	char err[200];
+	err[0] = 0;
+	errstr(err, 199);
+	fprint(2, "%s: %s\n", s, err);
+	exits(err);
+}
+
+void
+exerr2(char *s, char *err)
+{
+	fprint(2, "%s: %s\n", s, err);
+	exits(err);
+}
+
+void
+main(int argc, char *argv[])
+{
+	if(argc == 0) {
+		fprint(2, "usage: %s file\n", argv[0]);
+		exits("usage");
+	}
+	int fd = open(argv[1], ORDWR);
+	if(fd < 0)
+		exerr(argv[0]);
+	while(1) {
+		int rc = read9pmsg(0, obuf, BUFLEN);
+		if(rc < 0)
+		{
+			close(fd);
+			exerr(argv[0]);
+		}
+		int rc2 = write(fd, obuf, rc);
+		if(rc2 < rc)
+		{
+			close(fd);
+			exerr2(argv[0], "short write to vq");
+		}
+		rc = read(fd, ibuf, BUFLEN);
+		if(rc < BUFLEN)
+		{
+			close(fd);
+			exerr(argv[0]);
+		}
+		uint32_t ml = GBIT32(ibuf);
+		rc = write(1, ibuf, ml);
+		if(rc < 0)
+		{
+			close(fd);
+			exerr2(argv[0], "short write to stdout");
+		}
+	}
+}

--- a/sys/src/cmd/build.json
+++ b/sys/src/cmd/build.json
@@ -7,6 +7,7 @@
 		],
 		"Install": "/$ARCH/bin/",
 		"SourceFilesCmd": [
+			"9pvpxy.c",
 			"aan.c",
 			"archfs.c",
 			"ascii.c",


### PR DESCRIPTION
I previously proposed to add 9p support to the virtio-serial-pci driver (aka virtconsole) but this was not accepted. Here I am proposing a similar solution, but using an userspace proxy program. The program (9pvpxy) simply reads 9p messages from its std input and sends to the virtqueue, receiving buffers from the virtqueue and minimally massaging them to write 9p messages of proper length to its std output.

Example usage:

```
srv -e '9pvpxy /dev/virtcon/virtio-console-2' vc2
mount -c -n /srv/vc2 /mnt/xxx
```

The proxy was tested same way as the 9p virtio was tested (dd file read-write). It showed lower speeds and less stability than the 9p native virtio, but it allows to have arbitrary 9p servers on the host (ufs is just an example) while native 9p does not allow that (cannot be connected to a pipe, only to a FS device).

Hopefully this approach is more acceptable.

Thanks.