### PR TITLE
bldy: make init9.c not relative

### DIFF
--- a/sys/src/9/amd64/BUILD
+++ b/sys/src/9/amd64/BUILD
@@ -427,7 +427,7 @@ cc_binary(
 		"-Ttext=0x200020",
 	],
 	srcs=[
-		"init9.c",
+		"//sys/src/9/amd64/init9.c",
 		"//sys/src/9/port/initcode.c",
 	]
 )


### PR DESCRIPTION
it won't build otherwise.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>