### PR TITLE
riscv: use the SBI call to set mtime compare (mtimecmp)

### DIFF
--- a/sys/src/9/riscv/assembly.S
+++ b/sys/src/9/riscv/assembly.S
@@ -193,3 +193,7 @@ touser:
 	LD a0, 104(a0)
 	.long 0x10200073
 	sret
+
+.globl sbi_set_mtimecmp
+sbi_set_mtimecmp:
+	tail -1888

--- a/sys/src/9/riscv/build.json
+++ b/sys/src/9/riscv/build.json
@@ -56,28 +56,28 @@
 					"pci"
 				]
 			},
-		        "#RamFiles": [
-				"boot: /$ARCH/bin/kiss"
-			    ],
+		        "#RamFiles": {
+				"ipconfig": "/$ARCH/bin/ip/ipconfig",
+				"longjmp": "/$ARCH/bin/regress/longjmp",
+				"empty": "/$ARCH/bin/regress/empty",
+				"factotum": "/$ARCH/bin/auth/factotum",
+				"getcallerpc": "/$ARCH/bin/regress/getcallerpc",
+				"pipering": "/$ARCH/bin/regress/pipering",
+				"privates": "/$ARCH/bin/regress/privates",
+				"ratrace": "/$ARCH/bin/ratrace",
+				"cat": "/$ARCH/bin/cat",
+				"cow": "/$ARCH/bin/regress/cow",
+				"boot" : "/$ARCH/bin/kiss"
+			    },
 			"Ramfiles": {
 				"alarm": "/$ARCH/bin/regress/alarm",
 				"bind": "/$ARCH/bin/bind",
 				"boot": "/sys/src/9/boot/bootcpu.elf.out",
-				"cat": "/$ARCH/bin/cat",
-				"cow": "/$ARCH/bin/regress/cow",
 				"date": "/$ARCH/bin/date",
 				"echo": "/$ARCH/bin/echo",
-				"empty": "/$ARCH/bin/regress/empty",
-				"factotum": "/$ARCH/bin/auth/factotum",
-				"getcallerpc": "/$ARCH/bin/regress/getcallerpc",
-				"ipconfig": "/$ARCH/bin/ip/ipconfig",
-				"longjmp": "/$ARCH/bin/regress/longjmp",
 				"ls": "/$ARCH/bin/ls",
 				"mount": "/$ARCH/bin/mount",
 				"nvram": "/util/nvram",
-				"pipering": "/$ARCH/bin/regress/pipering",
-				"privates": "/$ARCH/bin/regress/privates",
-				"ratrace": "/$ARCH/bin/ratrace",
 				"rc": "/$ARCH/bin/rc",
 				"ps": "/$ARCH/bin/ps",
 				"ed": "/$ARCH/bin/ed",

--- a/sys/src/9/riscv/devarch.c
+++ b/sys/src/9/riscv/devarch.c
@@ -603,7 +603,6 @@ ms(void)
 void
 timerset(uint64_t x)
 {
-	extern uint64_t *mtimecmp;
 	extern uint64_t *mtime;
 	uint64_t now;
 	int64_t delta;
@@ -618,14 +617,14 @@ timerset(uint64_t x)
 	//print("now 0x%llx timerset to 0x%llx\n", now , x);
 	delta = x - now;
 	//print("delta is %llx\n", delta);
-	delta /= 200;
+	delta /= 1000;
 	if (delta < 1) {
 		if (++bust == 0)
 			print("timerset: delta was < 1 256 times\n");
 		delta = 10 /* one microsecond */ * 1000 /* one millisecond */ ;
 	}
 	//print("adjest x to timer ticks, divide by 500 ... 0x%llx %llx %llx \n", *mtime , delta, *mtime + delta);
-	*mtimecmp = *mtime + delta; //+ 10 /* one microsecond */ * 1000 /* one millisecond */ * 100; /* 100 milliseconds */
+	sbi_set_mtimecmp(*mtime + delta);
 }
 
 void

--- a/sys/src/9/riscv/fns.h
+++ b/sys/src/9/riscv/fns.h
@@ -278,3 +278,6 @@ int slim_setlabel(Label*) __attribute__((returns_twice));
                     err = slim_setlabel(label);                                     \
                     err;})
 
+
+/* sbi calls. They are all too different to bother with a typedef. */
+void sbi_set_mtimecmp(uint64_t t);

--- a/sys/src/9/riscv/trap.c
+++ b/sys/src/9/riscv/trap.c
@@ -317,6 +317,7 @@ nmienable(void)
 
 static void riscvtimer(struct Ureg *u, void *_)
 {
+	if (0) print("R");
 	timerintr(u, 0);
 }
 


### PR DESCRIPTION
Due to a bug in the RISCV simulator we were able to set
mtimecmp (still allowed) and also able to clear the
Supervisor Timer Interrupt Pending (STIP) bit. That bit
can only be cleared in M-mode but SPIKE let us do it.

We had to change timerset to do an mcall.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

Conflicts:
	sys/src/9/riscv/devarch.c