### PR TITLE
sys/src/9/amd64: change malloc size in tcore to ACVctl from Vctl

### DIFF
--- a/sys/src/9/amd64/tcore.c
+++ b/sys/src/9/amd64/tcore.c
@@ -336,7 +336,7 @@ actrapenable(int vno, char* (*f)(Ureg*, void*), void* a, char *name)
 
 	if(vno < 0 || vno >= 256)
 		panic("actrapenable: vno %d\n", vno);
-	v = malloc(sizeof(Vctl));
+	v = malloc(sizeof(ACVctl));
 	v->f = f;
 	v->a = a;
 	v->vno = vno;


### PR DESCRIPTION
reported in https://scans.sevki.io/1567/report-754299.html#EndPath

Signed-off-by: Sevki <s@sevki.org>