### PR TITLE
libstdio: fix malloc size. double -> bigint

### DIFF
--- a/sys/src/libstdio/dtoa.c
+++ b/sys/src/libstdio/dtoa.c
@@ -130,7 +130,7 @@ Balloc(int k)
 			rv = (Bigint * )pmem_next;
 			pmem_next += len;
 		} else
-			rv = (Bigint * )malloc(len * sizeof(double));
+			rv = (Bigint * )malloc(len * sizeof(Bigint));
 		rv->k = k;
 		rv->maxwds = x;
 	}


### PR DESCRIPTION
reported in https://scans.sevki.io/1567/report-af964f.html#EndPath

Signed-off-by: Sevki <s@sevki.org>