### PR TITLE
Fix rune warnings in acme

### DIFF
--- a/sys/src/cmd/acme/cols.c
+++ b/sys/src/cmd/acme/cols.c
@@ -40,7 +40,7 @@ colinit(Column *c, Rectangle r)
 	r1.min.y = r1.max.y;
 	r1.max.y += Border;
 	draw(screen, r1, display->black, nil, ZP);
-	textinsert(t, 0, L"New Cut Paste Snarf Sort Zerox Delcol ", 38, TRUE);
+	textinsert(t, 0, (Rune*)L"New Cut Paste Snarf Sort Zerox Delcol ", 38, TRUE);
 	textsetselect(t, t->file->Buffer.nc, t->file->Buffer.nc);
 	draw(screen, t->scrollr, colbutton, nil, colbutton->r.min);
 	c->safe = TRUE;

--- a/sys/src/cmd/acme/dat.h
+++ b/sys/src/cmd/acme/dat.h
@@ -37,8 +37,8 @@ enum
 {
 	Blockincr =	256,
 	Maxblock = 	8*1024,
-	NRange =		10,
-	Infinity = 		0x7FFFFFFF,	/* huge value for regexp address */
+	NRange =	10,
+	Infinity = 	0x7FFFFFFF,	/* huge value for regexp address */
 };
 
 typedef	struct	Block Block;
@@ -77,52 +77,52 @@ struct Range
 
 struct Block
 {
-	unsigned int		addr;	/* disk address in bytes */
+	unsigned int	addr;		/* disk address in bytes */
 	union
 	{
-		unsigned int	n;		/* number of used runes in block */
-		Block	*next;	/* pointer to next in free list */
+		unsigned int	n;	/* number of used runes in block */
+		Block	*next;		/* pointer to next in free list */
 	};
 };
 
 struct Disk
 {
 	int		fd;
-	unsigned int		addr;	/* length of temp file */
+	unsigned int	addr;	/* length of temp file */
 	Block	*free[Maxblock/Blockincr+1];
 };
 
 Disk*	diskinit(void);
 Block*	disknewblock(Disk*, unsigned int);
-void		diskrelease(Disk*, Block*);
-void		diskread(Disk*, Block*, Rune*, unsigned int);
-void		diskwrite(Disk*, Block**, Rune*, unsigned int);
+void	diskrelease(Disk*, Block*);
+void	diskread(Disk*, Block*, Rune*, unsigned int);
+void	diskwrite(Disk*, Block**, Rune*, unsigned int);
 
 struct Buffer
 {
 	unsigned int	nc;
-	Rune	*c;			/* cache */
-	unsigned int	cnc;			/* bytes in cache */
+	Rune		*c;		/* cache */
+	unsigned int	cnc;		/* bytes in cache */
 	unsigned int	cmax;		/* size of allocated cache */
-	unsigned int	cq;			/* position of cache */
-	int		cdirty;	/* cache needs to be written */
-	unsigned int	cbi;			/* index of cache Block */
-	Block	**bl;		/* array of blocks */
-	unsigned int	nbl;			/* number of blocks */
+	unsigned int	cq;		/* position of cache */
+	int		cdirty;		/* cache needs to be written */
+	unsigned int	cbi;		/* index of cache Block */
+	Block		**bl;		/* array of blocks */
+	unsigned int	nbl;		/* number of blocks */
 };
 void		bufinsert(Buffer*, unsigned int, Rune*, unsigned int);
 void		bufdelete(Buffer*, unsigned int, unsigned int);
-unsigned int		bufload(Buffer*, unsigned int, int, int*);
+unsigned int	bufload(Buffer*, unsigned int, int, int*);
 void		bufread(Buffer*, unsigned int, Rune*, unsigned int);
 void		bufclose(Buffer*);
 void		bufreset(Buffer*);
 
 struct Elog
 {
-	short	type;		/* Delete, Insert, Filename */
-	unsigned int		q0;		/* location of change (unused in f) */
-	unsigned int		nd;		/* number of deleted characters */
-	unsigned int		nr;		/* # runes in string or file name */
+	short		type;		/* Delete, Insert, Filename */
+	unsigned int	q0;		/* location of change (unused in f) */
+	unsigned int	nd;		/* number of deleted characters */
+	unsigned int	nr;		/* # runes in string or file name */
 	Rune		*r;
 };
 void	elogterm(File*);
@@ -134,32 +134,32 @@ void	elogapply(File*);
 
 struct File
 {
-	Buffer	Buffer;		/* the data */
-	Buffer	delta;	/* transcript of changes */
-	Buffer	epsilon;	/* inversion of delta for redo */
-	Buffer	*elogbuf;	/* log of pending editor changes */
+	Buffer		Buffer;		/* the data */
+	Buffer		delta;		/* transcript of changes */
+	Buffer		epsilon;	/* inversion of delta for redo */
+	Buffer		*elogbuf;	/* log of pending editor changes */
 	Elog		elog;		/* current pending change */
-	Rune		*name;	/* name of associated file */
-	int		nname;	/* size of name */
+	Rune		*name;		/* name of associated file */
+	int		nname;		/* size of name */
 	uint64_t	qidpath;	/* of file when read */
-	unsigned int		mtime;	/* of file when read */
+	unsigned int	mtime;		/* of file when read */
 	int		dev;		/* of file when read */
-	int		unread;	/* file has not been read from disk */
+	int		unread;		/* file has not been read from disk */
 	int		editclean;	/* mark clean after edit command */
 
 	int		seq;		/* if seq==0, File acts like Buffer */
 	int		mod;
 	Text		*curtext;	/* most recently used associated text */
-	Text		**text;	/* list of associated texts */
+	Text		**text;		/* list of associated texts */
 	int		ntext;
-	int		dumpid;	/* used in dumping zeroxed windows */
+	int		dumpid;		/* used in dumping zeroxed windows */
 };
 File*		fileaddtext(File*, Text*);
 void		fileclose(File*);
 void		filedelete(File*, unsigned int, unsigned int);
 void		filedeltext(File*, Text*);
 void		fileinsert(File*, unsigned int, Rune*, unsigned int);
-unsigned int		fileload(File*, unsigned int, int, int*);
+unsigned int	fileload(File*, unsigned int, int, int*);
 void		filemark(File*);
 void		filereset(File*);
 void		filesetname(File*, Rune*, int);
@@ -167,7 +167,7 @@ void		fileundelete(File*, Buffer*, unsigned int, unsigned int);
 void		fileuninsert(File*, Buffer*, unsigned int, unsigned int);
 void		fileunsetname(File*, Buffer*);
 void		fileundo(File*, int, unsigned int*, unsigned int*);
-unsigned int		fileredoseq(File*);
+unsigned int	fileredoseq(File*);
 
 enum	/* Text.what */
 {
@@ -202,8 +202,8 @@ struct Text
 	int	nofill;
 };
 
-unsigned int		textbacknl(Text*, unsigned int, unsigned int);
-unsigned int		textbsinsert(Text*, unsigned int, Rune*,
+unsigned int	textbacknl(Text*, unsigned int, unsigned int);
+unsigned int	textbsinsert(Text*, unsigned int, Rune*,
 					 unsigned int, int, int*);
 int		textbswidth(Text*, Rune);
 int		textclickmatch(Text*, int, int, int, unsigned int*);
@@ -219,7 +219,7 @@ void		textframescroll(Text*, int);
 void		textinit(Text*, File*, Rectangle, Reffont*, Image**);
 void		textinsert(Text*, unsigned int, Rune*, unsigned int,
 			       int);
-unsigned int		textload(Text*, unsigned int, char*, int);
+unsigned int	textload(Text*, unsigned int, char*, int);
 Rune		textreadc(Text*, unsigned int);
 void		textredraw(Text*, Rectangle, Font*, Image*, int);
 void		textreset(Text*);
@@ -228,8 +228,7 @@ void		textscrdraw(Text*);
 void		textscroll(Text*, int);
 void		textselect(Text*);
 int		textselect2(Text*, unsigned int*, unsigned int*, Text**);
-int		textselect23(Text*, unsigned int*, unsigned int*, Image*,
-				int);
+int		textselect23(Text*, unsigned int*, unsigned int*, Image*, int);
 int		textselect3(Text*, unsigned int*, unsigned int*);
 void		textsetorigin(Text*, unsigned int, int);
 void		textsetselect(Text*, unsigned int, unsigned int);

--- a/sys/src/cmd/acme/ecmd.c
+++ b/sys/src/cmd/acme/ecmd.c
@@ -362,7 +362,7 @@ f_cmd(Text *t, Cmd *cp)
 
 	if(cp->text == nil){
 		empty.n = 0;
-		empty.r = L"";
+		empty.r = (Rune*)L"";
 		str = &empty;
 	}else
 		str = cp->text;

--- a/sys/src/cmd/acme/exec.c
+++ b/sys/src/cmd/acme/exec.c
@@ -65,41 +65,41 @@ struct Exectab
 {
 	Rune	*name;
 	void	(*fn)(Text*, Text*, Text*, int, int, Rune*, int);
-	int		mark;
-	int		flag1;
-	int		flag2;
+	int	mark;
+	int	flag1;
+	int	flag2;
 };
 
 Exectab exectab[] = {
-	{ L"Cut",		cut,		TRUE,	TRUE,	TRUE	},
-	{ L"Del",		del,		FALSE,	FALSE,	XXX		},
-	{ L"Delcol",	delcol,	FALSE,	XXX,		XXX		},
-	{ L"Delete",	del,		FALSE,	TRUE,	XXX		},
-	{ L"Dump",	dump,	FALSE,	TRUE,	XXX		},
-	{ L"Edit",		edit,		FALSE,	XXX,		XXX		},
-	{ L"Exit",		exit,		FALSE,	XXX,		XXX		},
-	{ L"Font",		fontx,	FALSE,	XXX,		XXX		},
-	{ L"Get",		get,		FALSE,	TRUE,	XXX		},
-	{ L"ID",		id,		FALSE,	XXX,		XXX		},
-	{ L"Incl",		incl,		FALSE,	XXX,		XXX		},
-	{ L"Indent",	indent,	FALSE,	XXX,		XXX		},
-	{ L"Kill",		kill,		FALSE,	XXX,		XXX		},
-	{ L"Load",		dump,	FALSE,	FALSE,	XXX		},
-	{ L"Local",		local,	FALSE,	XXX,		XXX		},
-	{ L"Look",		look,		FALSE,	XXX,		XXX		},
-	{ L"New",		new,		FALSE,	XXX,		XXX		},
-	{ L"Newcol",	newcol,	FALSE,	XXX,		XXX		},
-	{ L"Paste",		paste,	TRUE,	TRUE,	XXX		},
-	{ L"Put",		put,		FALSE,	XXX,		XXX		},
-	{ L"Putall",		putall,	FALSE,	XXX,		XXX		},
-	{ L"Redo",		undo,	FALSE,	FALSE,	XXX		},
-	{ L"Send",		sendx,	TRUE,	XXX,		XXX		},
-	{ L"Snarf",		cut,		FALSE,	TRUE,	FALSE	},
-	{ L"Sort",		sort,		FALSE,	XXX,		XXX		},
-	{ L"Tab",		tab,		FALSE,	XXX,		XXX		},
-	{ L"Undo",		undo,	FALSE,	TRUE,	XXX		},
-	{ L"Zerox",	zeroxx,	FALSE,	XXX,		XXX		},
-	{ nil, 			nil,		0,		0,		0		},
+	{ L"Cut",	cut,	TRUE,	TRUE,	TRUE	},
+	{ L"Del",	del,	FALSE,	FALSE,	XXX	},
+	{ L"Delcol",	delcol,	FALSE,	XXX,	XXX	},
+	{ L"Delete",	del,	FALSE,	TRUE,	XXX	},
+	{ L"Dump",	dump,	FALSE,	TRUE,	XXX	},
+	{ L"Edit",	edit,	FALSE,	XXX,	XXX	},
+	{ L"Exit",	exit,	FALSE,	XXX,	XXX	},
+	{ L"Font",	fontx,	FALSE,	XXX,	XXX	},
+	{ L"Get",	get,	FALSE,	TRUE,	XXX	},
+	{ L"ID",	id,	FALSE,	XXX,	XXX	},
+	{ L"Incl",	incl,	FALSE,	XXX,	XXX	},
+	{ L"Indent",	indent,	FALSE,	XXX,	XXX	},
+	{ L"Kill",	kill,	FALSE,	XXX,	XXX	},
+	{ L"Load",	dump,	FALSE,	FALSE,	XXX	},
+	{ L"Local",	local,	FALSE,	XXX,	XXX	},
+	{ L"Look",	look,	FALSE,	XXX,	XXX	},
+	{ L"New",	new,	FALSE,	XXX,	XXX	},
+	{ L"Newcol",	newcol,	FALSE,	XXX,	XXX	},
+	{ L"Paste",	paste,	TRUE,	TRUE,	XXX	},
+	{ L"Put",	put,	FALSE,	XXX,	XXX	},
+	{ L"Putall",	putall,	FALSE,	XXX,	XXX	},
+	{ L"Redo",	undo,	FALSE,	FALSE,	XXX	},
+	{ L"Send",	sendx,	TRUE,	XXX,	XXX	},
+	{ L"Snarf",	cut,	FALSE,	TRUE,	FALSE	},
+	{ L"Sort",	sort,	FALSE,	XXX,	XXX	},
+	{ L"Tab",	tab,	FALSE,	XXX,	XXX	},
+	{ L"Undo",	undo,	FALSE,	TRUE,	XXX	},
+	{ L"Zerox",	zeroxx,	FALSE,	XXX,	XXX	},
+	{ nil, 		nil,	0,	0,	0	},
 };
 
 Exectab*

--- a/sys/src/cmd/acme/exec.c
+++ b/sys/src/cmd/acme/exec.c
@@ -71,34 +71,34 @@ struct Exectab
 };
 
 Exectab exectab[] = {
-	{ L"Cut",	cut,	TRUE,	TRUE,	TRUE	},
-	{ L"Del",	del,	FALSE,	FALSE,	XXX	},
-	{ L"Delcol",	delcol,	FALSE,	XXX,	XXX	},
-	{ L"Delete",	del,	FALSE,	TRUE,	XXX	},
-	{ L"Dump",	dump,	FALSE,	TRUE,	XXX	},
-	{ L"Edit",	edit,	FALSE,	XXX,	XXX	},
-	{ L"Exit",	exit,	FALSE,	XXX,	XXX	},
-	{ L"Font",	fontx,	FALSE,	XXX,	XXX	},
-	{ L"Get",	get,	FALSE,	TRUE,	XXX	},
-	{ L"ID",	id,	FALSE,	XXX,	XXX	},
-	{ L"Incl",	incl,	FALSE,	XXX,	XXX	},
-	{ L"Indent",	indent,	FALSE,	XXX,	XXX	},
-	{ L"Kill",	kill,	FALSE,	XXX,	XXX	},
-	{ L"Load",	dump,	FALSE,	FALSE,	XXX	},
-	{ L"Local",	local,	FALSE,	XXX,	XXX	},
-	{ L"Look",	look,	FALSE,	XXX,	XXX	},
-	{ L"New",	new,	FALSE,	XXX,	XXX	},
-	{ L"Newcol",	newcol,	FALSE,	XXX,	XXX	},
-	{ L"Paste",	paste,	TRUE,	TRUE,	XXX	},
-	{ L"Put",	put,	FALSE,	XXX,	XXX	},
-	{ L"Putall",	putall,	FALSE,	XXX,	XXX	},
-	{ L"Redo",	undo,	FALSE,	FALSE,	XXX	},
-	{ L"Send",	sendx,	TRUE,	XXX,	XXX	},
-	{ L"Snarf",	cut,	FALSE,	TRUE,	FALSE	},
-	{ L"Sort",	sort,	FALSE,	XXX,	XXX	},
-	{ L"Tab",	tab,	FALSE,	XXX,	XXX	},
-	{ L"Undo",	undo,	FALSE,	TRUE,	XXX	},
-	{ L"Zerox",	zeroxx,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"Cut",	cut,	TRUE,	TRUE,	TRUE	},
+	{ (Rune*)L"Del",	del,	FALSE,	FALSE,	XXX	},
+	{ (Rune*)L"Delcol",	delcol,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"Delete",	del,	FALSE,	TRUE,	XXX	},
+	{ (Rune*)L"Dump",	dump,	FALSE,	TRUE,	XXX	},
+	{ (Rune*)L"Edit",	edit,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"Exit",	exit,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"Font",	fontx,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"Get",	get,	FALSE,	TRUE,	XXX	},
+	{ (Rune*)L"ID",	id,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"Incl",	incl,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"Indent",	indent,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"Kill",	kill,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"Load",	dump,	FALSE,	FALSE,	XXX	},
+	{ (Rune*)L"Local",	local,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"Look",	look,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"New",	new,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"Newcol",	newcol,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"Paste",	paste,	TRUE,	TRUE,	XXX	},
+	{ (Rune*)L"Put",	put,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"Putall",	putall,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"Redo",	undo,	FALSE,	FALSE,	XXX	},
+	{ (Rune*)L"Send",	sendx,	TRUE,	XXX,	XXX	},
+	{ (Rune*)L"Snarf",	cut,	FALSE,	TRUE,	FALSE	},
+	{ (Rune*)L"Sort",	sort,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"Tab",	tab,	FALSE,	XXX,	XXX	},
+	{ (Rune*)L"Undo",	undo,	FALSE,	TRUE,	XXX	},
+	{ (Rune*)L"Zerox",	zeroxx,	FALSE,	XXX,	XXX	},
 	{ nil, 		nil,	0,	0,	0	},
 };
 
@@ -873,7 +873,7 @@ sendx(Text *et, Text *t, Text*a, int b, int c, Rune*d, int f)
 	textsetselect(t, t->file->Buffer.nc, t->file->Buffer.nc);
 	paste(t, t, nil, TRUE, TRUE, nil, 0);
 	if(textreadc(t, t->file->Buffer.nc-1) != '\n'){
-		textinsert(t, t->file->Buffer.nc, L"\n", 1, TRUE);
+		textinsert(t, t->file->Buffer.nc, (Rune*)L"\n", 1, TRUE);
 		textsetselect(t, t->file->Buffer.nc, t->file->Buffer.nc);
 	}
 }
@@ -1004,7 +1004,7 @@ fontx(Text *et, Text *t, Text *argt, int ia, int b, Rune *arg, int narg)
 			break;
 		r = runemalloc(narg-na+1);
 		runemove(r, arg, narg-na);
-		if(runeeq(r, narg-na, L"fix", 3) || runeeq(r, narg-na, L"var", 3)){
+		if(runeeq(r, narg-na, (Rune*)L"fix", 3) || runeeq(r, narg-na, (Rune*)L"var", 3)){
 			free(flag);
 			flag = r;
 		}else{
@@ -1016,7 +1016,7 @@ fontx(Text *et, Text *t, Text *argt, int ia, int b, Rune *arg, int narg)
 	}
 	getarg(argt, FALSE, TRUE, &r, &na);
 	if(r)
-		if(runeeq(r, na, L"fix", 3) || runeeq(r, na, L"var", 3)){
+		if(runeeq(r, na, (Rune*)L"fix", 3) || runeeq(r, na, (Rune*)L"var", 3)){
 			free(flag);
 			flag = r;
 		}else{
@@ -1026,7 +1026,7 @@ fontx(Text *et, Text *t, Text *argt, int ia, int b, Rune *arg, int narg)
 		}
 	fix = 1;
 	if(flag)
-		fix = runeeq(flag, runestrlen(flag), L"fix", 3);
+		fix = runeeq(flag, runestrlen(flag), (Rune*)L"fix", 3);
 	else if(file == nil){
 		newfont = rfget(FALSE, FALSE, FALSE, nil);
 		if(newfont)
@@ -1106,17 +1106,17 @@ indentval(Rune *s, int n)
 {
 	if(n < 2)
 		return IError;
-	if(runestrncmp(s, L"ON", n) == 0){
+	if(runestrncmp(s, (Rune*)L"ON", n) == 0){
 		globalautoindent = TRUE;
 		warning(nil, "Indent ON\n");
 		return IGlobal;
 	}
-	if(runestrncmp(s, L"OFF", n) == 0){
+	if(runestrncmp(s, (Rune*)L"OFF", n) == 0){
 		globalautoindent = FALSE;
 		warning(nil, "Indent OFF\n");
 		return IGlobal;
 	}
-	return runestrncmp(s, L"on", n) == 0;
+	return runestrncmp(s, (Rune*)L"on", n) == 0;
 }
 
 static void

--- a/sys/src/cmd/acme/look.c
+++ b/sys/src/cmd/acme/look.c
@@ -323,7 +323,7 @@ isfilec(Rune r)
 {
 	if(isalnum(r))
 		return TRUE;
-	if(runestrchr(L".-+/:", r))
+	if(runestrchr((Rune*)L".-+/:", r))
 		return TRUE;
 	return FALSE;
 }
@@ -392,7 +392,7 @@ includename(Text *t, Rune *r, int n)
 		file = includefile(w->incl[i], r, n);
 
 	if(file.r == nil)
-		file = includefile(L"/sys/include", r, n);
+		file = includefile((Rune*)L"/sys/include", r, n);
 	if(file.r==nil && objdir!=nil)
 		file = includefile(objdir, r, n);
 	if(file.r == nil)

--- a/sys/src/cmd/acme/rows.c
+++ b/sys/src/cmd/acme/rows.c
@@ -42,7 +42,7 @@ rowinit(Row *row, Rectangle r)
 	r1.min.y = r1.max.y;
 	r1.max.y += Border;
 	draw(screen, r1, display->black, nil, ZP);
-	textinsert(t, 0, L"Newcol Kill Putall Dump Exit ", 29, TRUE);
+	textinsert(t, 0, (Rune*)L"Newcol Kill Putall Dump Exit ", 29, TRUE);
 	textsetselect(t, t->file->Buffer.nc, t->file->Buffer.nc);
 }
 

--- a/sys/src/cmd/acme/text.c
+++ b/sys/src/cmd/acme/text.c
@@ -171,17 +171,17 @@ textcolumnate(Text *t, Dirlist **dlp, int ndl)
 				break;
 			w = dl->wid;
 			if(maxt-w%maxt < mint){
-				fileinsert(t->file, q1, L"\t", 1);
+				fileinsert(t->file, q1, (Rune*)L"\t", 1);
 				q1++;
 				w += mint;
 			}
 			do{
-				fileinsert(t->file, q1, L"\t", 1);
+				fileinsert(t->file, q1, (Rune*)L"\t", 1);
 				q1++;
 				w += maxt-(w%maxt);
 			}while(w < colw);
 		}
-		fileinsert(t->file, q1, L"\n", 1);
+		fileinsert(t->file, q1, (Rune*)L"\n", 1);
 		q1++;
 	}
 }
@@ -601,7 +601,7 @@ textcomplete(Text *t)
 		}
 		if(dir.nr == 0){
 			dir.nr = 1;
-			dir.r = runestrdup(L".");
+			dir.r = runestrdup((Rune*)L".");
 		}
 		runemove(tmp, dir.r, dir.nr);
 		tmp[dir.nr] = '/';

--- a/sys/src/cmd/acme/wind.c
+++ b/sys/src/cmd/acme/wind.c
@@ -297,9 +297,9 @@ winsetname(Window *w, Rune *name, int n)
 	if(runeeq(t->file->name, t->file->nname, name, n) == TRUE)
 		return;
 	w->isscratch = FALSE;
-	if(n>=6 && runeeq(L"/guide", 6, name+(n-6), 6))
+	if(n>=6 && runeeq((Rune*)L"/guide", 6, name+(n-6), 6))
 		w->isscratch = TRUE;
-	else if(n>=7 && runeeq(L"+Errors", 7, name+(n-7), 7))
+	else if(n>=7 && runeeq((Rune*)L"+Errors", 7, name+(n-7), 7))
 		w->isscratch = TRUE;
 	filesetname(t->file, name, n);
 	for(i=0; i<t->file->ntext; i++){


### PR DESCRIPTION
Having to cast these string literals to (Rune*) doesn't look great, but it does remove the warnings for now, as previously mentione in #14.