### PR TITLE
Break apart malloc interface and implementation

### DIFF
--- a/sys/src/9/amd64/BUILD
+++ b/sys/src/9/amd64/BUILD
@@ -41,6 +41,7 @@ CORE_SRCS = [
 	"physalloc.c",
 	"pmcio.c",
 	"qmalloc.c",
+	"malloc.c",
 	"sipi.c",
 	"syscall.c",
 	"systab.c",

--- a/sys/src/9/amd64/core.json
+++ b/sys/src/9/amd64/core.json
@@ -132,6 +132,7 @@
 			"physalloc.c",
 			"pmcio.c",
 			"qmalloc.c",
+			"malloc.c",
 			"sipi.c",
 			"syscall.c",
 			"systab.c",

--- a/sys/src/9/amd64/malloc.c
+++ b/sys/src/9/amd64/malloc.c
@@ -1,0 +1,91 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+/*
+ * malloc
+ *
+ * Externally facing functions are thin wrappers for internal malloc functions.
+ * The aim is to make it easier to swap out malloc implementations.
+ */
+
+#include "u.h"
+#include "../port/lib.h"
+#include "mem.h"
+#include "dat.h"
+
+#include "malloc.h"
+
+static Allocator* _allocator = nil;
+
+// Initialise memory system
+void
+mallocinitallocator(Allocator* allocator)
+{
+	_allocator = allocator;
+	_allocator->init();
+}
+
+uint32_t
+msize(void* ap)
+{
+	return _allocator->msize(ap);
+}
+
+int32_t
+mallocreadsummary(Chan* c, void* a, int32_t n, int32_t offset)
+{
+	return _allocator->mallocreadsummary(c, a, n, offset);
+}
+
+void
+mallocsummary(void)
+{
+	_allocator->mallocsummary();
+}
+
+void
+free(void* ap)
+{
+	_allocator->free(ap);
+}
+
+void*
+malloc(uint32_t size)
+{
+	return _allocator->malloc(size);
+}
+
+void*
+mallocz(uint32_t size, int clr)
+{
+	return _allocator->mallocz(size, clr);
+}
+
+void*
+mallocalign(uint32_t nbytes, uint32_t align, int32_t offset, uint32_t span)
+{
+	return _allocator->mallocalign(nbytes, align, offset, span);
+}
+
+void*
+smalloc(uint32_t size)
+{
+	return _allocator->smalloc(size);
+}
+
+void*
+realloc(void* ap, uint32_t size)
+{
+	return _allocator->realloc(ap, size);
+}
+
+void
+setmalloctag(void* v, uint32_t i)
+{
+}

--- a/sys/src/9/amd64/malloc.c
+++ b/sys/src/9/amd64/malloc.c
@@ -31,30 +31,6 @@ mallocinitallocator(Allocator* allocator)
 	_allocator->init();
 }
 
-uint32_t
-msize(void* ap)
-{
-	return _allocator->msize(ap);
-}
-
-int32_t
-mallocreadsummary(Chan* c, void* a, int32_t n, int32_t offset)
-{
-	return _allocator->mallocreadsummary(c, a, n, offset);
-}
-
-void
-mallocsummary(void)
-{
-	_allocator->mallocsummary();
-}
-
-void
-free(void* ap)
-{
-	_allocator->free(ap);
-}
-
 void*
 malloc(uint32_t size)
 {
@@ -75,6 +51,12 @@ mallocalign(uint32_t nbytes, uint32_t align, int32_t offset, uint32_t span)
 }
 
 void*
+realloc(void* ap, uint32_t size)
+{
+	return _allocator->realloc(ap, size);
+}
+
+void*
 smalloc(uint32_t size)
 {
 	Proc* up = externup();
@@ -85,10 +67,28 @@ smalloc(uint32_t size)
 	return v;
 }
 
-void*
-realloc(void* ap, uint32_t size)
+void
+free(void* ap)
 {
-	return _allocator->realloc(ap, size);
+	_allocator->free(ap);
+}
+
+uint32_t
+msize(void* ap)
+{
+	return _allocator->msize(ap);
+}
+
+int32_t
+mallocreadsummary(Chan* c, void* a, int32_t n, int32_t offset)
+{
+	return _allocator->mallocreadsummary(c, a, n, offset);
+}
+
+void
+mallocsummary(void)
+{
+	_allocator->mallocsummary();
 }
 
 void

--- a/sys/src/9/amd64/malloc.c
+++ b/sys/src/9/amd64/malloc.c
@@ -18,6 +18,7 @@
 #include "../port/lib.h"
 #include "mem.h"
 #include "dat.h"
+#include "fns.h"
 
 #include "malloc.h"
 
@@ -57,7 +58,8 @@ free(void* ap)
 void*
 malloc(uint32_t size)
 {
-	return _allocator->malloc(size);
+	// Default implementation of malloc always clears
+	return _allocator->mallocz(size, 1);
 }
 
 void*
@@ -75,7 +77,12 @@ mallocalign(uint32_t nbytes, uint32_t align, int32_t offset, uint32_t span)
 void*
 smalloc(uint32_t size)
 {
-	return _allocator->smalloc(size);
+	Proc* up = externup();
+	void* v;
+
+	while((v = _allocator->mallocz(size, 1)) == nil)
+		tsleep(&up->sleep, return0, 0, 100);
+	return v;
 }
 
 void*

--- a/sys/src/9/amd64/malloc.c
+++ b/sys/src/9/amd64/malloc.c
@@ -23,7 +23,6 @@
 
 static Allocator* _allocator = nil;
 
-// Initialise memory system
 void
 mallocinitallocator(Allocator* allocator)
 {

--- a/sys/src/9/amd64/malloc.c
+++ b/sys/src/9/amd64/malloc.c
@@ -10,8 +10,8 @@
 /*
  * malloc
  *
- * Externally facing functions are thin wrappers for internal malloc functions.
- * The aim is to make it easier to swap out malloc implementations.
+ * Wrap malloc functions an Allocator struct to make it easier to test and
+ * replace the implementation.
  */
 
 #include "u.h"

--- a/sys/src/9/amd64/malloc.h
+++ b/sys/src/9/amd64/malloc.h
@@ -9,16 +9,16 @@
 
 typedef struct Allocator {
 	void (*init)(void);
+
+	void* (*mallocz)(uint32_t, int);
+	void* (*mallocalign)(uint32_t, uint32_t, int32_t, uint32_t);
+	void* (*realloc)(void*, uint32_t);
+
+	void (*free)(void*);
+
 	uint32_t (*msize)(void*);
 	int32_t (*mallocreadsummary)(Chan*, void*, int32_t, int32_t);
 	void (*mallocsummary)(void);
-
-	void (*free)(void*);
-	void* (*malloc)(uint32_t);
-	void* (*mallocz)(uint32_t, int);
-	void* (*mallocalign)(uint32_t, uint32_t, int32_t, uint32_t);
-	void* (*smalloc)(uint32_t);
-	void* (*realloc)(void*, uint32_t);
 
 } Allocator;
 

--- a/sys/src/9/amd64/malloc.h
+++ b/sys/src/9/amd64/malloc.h
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+typedef struct Allocator {
+	void (*init)(void);
+	uint32_t (*msize)(void*);
+	int32_t (*mallocreadsummary)(Chan*, void*, int32_t, int32_t);
+	void (*mallocsummary)(void);
+
+	void (*free)(void*);
+	void* (*malloc)(uint32_t);
+	void* (*mallocz)(uint32_t, int);
+	void* (*mallocalign)(uint32_t, uint32_t, int32_t, uint32_t);
+	void* (*smalloc)(uint32_t);
+	void* (*realloc)(void*, uint32_t);
+
+} Allocator;
+
+void
+mallocinitallocator(Allocator* allocator);

--- a/sys/src/9/amd64/qmalloc.c
+++ b/sys/src/9/amd64/qmalloc.c
@@ -20,7 +20,8 @@
 #include "mem.h"
 #include "dat.h"
 #include "fns.h"
-#include	<pool.h>
+#include <pool.h>
+#include "malloc.h"
 
 typedef double Align;
 typedef union Header Header;
@@ -28,38 +29,37 @@ typedef struct Qlist Qlist;
 
 union Header {
 	struct {
-		Header*	next;
-		uint	size;
+		Header* next;
+		uint size;
 	} s;
-	Align	al;
+	Align al;
 };
 
 struct Qlist {
-	Lock	lk;
-	Header*	first;
+	Lock lk;
+	Header* first;
 
-	uint	nalloc;
+	uint nalloc;
 };
 
 enum {
-	Unitsz		= sizeof(Header),	/* 16 bytes on amd64 */
+	Unitsz = sizeof(Header), /* 16 bytes on amd64 */
 };
 
-#define	NUNITS(n)	(HOWMANY(n, Unitsz) + 1)
-#define	NQUICK		((512/Unitsz)+1)	/* 33 on amd64 */
+#define NUNITS(n) (HOWMANY(n, Unitsz) + 1)
+#define NQUICK ((512 / Unitsz) + 1) /* 33 on amd64 */
 
-static	Qlist	quicklist[NQUICK+1];
-static	Header	misclist;
-static	Header	*rover;
-static	unsigned tailsize;
-static	unsigned tailnunits;
-static	Header	*tailbase;
-static	Header	*tailptr;
-static	Header	checkval;
-static	int	morecore(unsigned);
+static Qlist quicklist[NQUICK + 1];
+static Header misclist;
+static Header* rover;
+static unsigned tailsize;
+static unsigned tailnunits;
+static Header* tailbase;
+static Header* tailptr;
+static Header checkval;
+static int morecore(unsigned);
 
-enum
-{
+enum {
 	QSmalign = 0,
 	QSmalignquick,
 	QSmalignrover,
@@ -78,48 +78,48 @@ enum
 	QSmax
 };
 
-static	void	qfreeinternal(void*);
-static	int	qstats[QSmax];
-static	char*	qstatstr[QSmax] = {
-[QSmalign] = "malign",
-[QSmalignquick] = "malignquick",
-[QSmalignrover] = "malignrover",
-[QSmalignfront] = "malignfront",
-[QSmalignback] = "malignback",
-[QSmaligntail] = "maligntail",
-[QSmalignnottail] = "malignnottail",
-[QSmalloc] = "malloc",
-[QSmallocrover] = "mallocrover",
-[QSmalloctail] = "malloctail",
-[QSfree] = "free",
-[QSfreetail] = "freetail",
-[QSfreequick] = "freequick",
-[QSfreenext] = "freenext",
-[QSfreeprev] = "freeprev",
+static void qfreeinternal(void*);
+static int qstats[QSmax];
+static char* qstatstr[QSmax] = {
+        [QSmalign] = "malign",
+        [QSmalignquick] = "malignquick",
+        [QSmalignrover] = "malignrover",
+        [QSmalignfront] = "malignfront",
+        [QSmalignback] = "malignback",
+        [QSmaligntail] = "maligntail",
+        [QSmalignnottail] = "malignnottail",
+        [QSmalloc] = "malloc",
+        [QSmallocrover] = "mallocrover",
+        [QSmalloctail] = "malloctail",
+        [QSfree] = "free",
+        [QSfreetail] = "freetail",
+        [QSfreequick] = "freequick",
+        [QSfreenext] = "freenext",
+        [QSfreeprev] = "freeprev",
 };
 
-static	Lock		mainlock;
+static Lock mainlock;
 
-#define	MLOCK		ilock(&mainlock)
-#define	MUNLOCK		iunlock(&mainlock)
-#define QLOCK(l)	ilock(l)
-#define QUNLOCK(l)	iunlock(l)
+#define MLOCK ilock(&mainlock)
+#define MUNLOCK iunlock(&mainlock)
+#define QLOCK(l) ilock(l)
+#define QUNLOCK(l) iunlock(l)
 
-#define	tailalloc(p, n)	((p)=tailptr, tailsize -= (n), tailptr+=(n),\
-			 (p)->s.size=(n), (p)->s.next = &checkval)
+#define tailalloc(p, n) ((p) = tailptr, tailsize -= (n), tailptr += (n), \
+                         (p)->s.size = (n), (p)->s.next = &checkval)
 
-#define ISPOWEROF2(x)	(/*((x) != 0) && */!((x) & ((x)-1)))
-#define ALIGNHDR(h, a)	(Header*)((((uintptr)(h))+((a)-1)) & ~((a)-1))
+#define ISPOWEROF2(x) (/*((x) != 0) && */ !((x) & ((x)-1)))
+#define ALIGNHDR(h, a) (Header*)((((uintptr)(h)) + ((a)-1)) & ~((a)-1))
 
 /*
  * From libc malloc.c to *draw devices
  */
 
-typedef struct Private	Private;
+typedef struct Private Private;
 struct Private {
-	Lock		lk;
-	char*		end;
-	char		msg[256];	/* a rock for messages to be printed at unlock */
+	Lock lk;
+	char* end;
+	char msg[256]; /* a rock for messages to be printed at unlock */
 };
 
 /*
@@ -131,12 +131,12 @@ struct Private {
  * using quicklist[machp()->machno] runs out of memory soon.
  * using quicklist[machp()->machno%4] yields times worse than using quicklist!
  */
-#define QLIST	quicklist
+#define QLIST quicklist
 
 static void*
 qmallocalign(usize nbytes, uintptr_t align, int32_t offset, usize span)
 {
-	Qlist *qlist;
+	Qlist* qlist;
 	uintptr_t aligned;
 	Header **pp, *p, *q, *r;
 	uint naligned, nunits, n;
@@ -149,7 +149,7 @@ qmallocalign(usize nbytes, uintptr_t align, int32_t offset, usize span)
 
 	qstats[QSmalign]++;
 	nunits = NUNITS(nbytes);
-	if(nunits <= NQUICK){
+	if(nunits <= NQUICK) {
 		/*
 		 * Look for a conveniently aligned block
 		 * on one of the quicklists.
@@ -157,13 +157,13 @@ qmallocalign(usize nbytes, uintptr_t align, int32_t offset, usize span)
 		qlist = &QLIST[nunits];
 		QLOCK(&qlist->lk);
 		pp = &qlist->first;
-		for(p = *pp; p != nil; p = p->s.next){
-			if(ALIGNED(p+1, align)){
+		for(p = *pp; p != nil; p = p->s.next) {
+			if(ALIGNED(p + 1, align)) {
 				*pp = p->s.next;
 				p->s.next = &checkval;
 				QUNLOCK(&qlist->lk);
 				qstats[QSmalignquick]++;
-				return p+1;
+				return p + 1;
 			}
 			pp = &p->s.next;
 		}
@@ -173,14 +173,14 @@ qmallocalign(usize nbytes, uintptr_t align, int32_t offset, usize span)
 	MLOCK;
 	if(nunits > tailsize) {
 		/* hard way */
-		if((q = rover) != nil){
+		if((q = rover) != nil) {
 			do {
 				p = q->s.next;
 				if(p->s.size < nunits)
 					continue;
-				aligned = ALIGNED(p+1, align);
-				naligned = NUNITS(align)-1;
-				if(!aligned && p->s.size < nunits+naligned)
+				aligned = ALIGNED(p + 1, align);
+				naligned = NUNITS(align) - 1;
+				if(!aligned && p->s.size < nunits + naligned)
 					continue;
 
 				/*
@@ -194,56 +194,55 @@ qmallocalign(usize nbytes, uintptr_t align, int32_t offset, usize span)
 				/*
 				 * Free any runt in front of the alignment.
 				 */
-				if(!aligned){
+				if(!aligned) {
 					r = p;
-					p = ALIGNHDR(p+1, align) - 1;
+					p = ALIGNHDR(p + 1, align) - 1;
 					n = p - r;
 					p->s.size = r->s.size - n;
 
 					r->s.size = n;
 					r->s.next = &checkval;
-					qfreeinternal(r+1);
+					qfreeinternal(r + 1);
 					qstats[QSmalignfront]++;
 				}
 
 				/*
 				 * Free any residue after the aligned block.
 				 */
-				if(p->s.size > nunits){
-					r = p+nunits;
+				if(p->s.size > nunits) {
+					r = p + nunits;
 					r->s.size = p->s.size - nunits;
 					r->s.next = &checkval;
 					qstats[QSmalignback]++;
-					qfreeinternal(r+1);
+					qfreeinternal(r + 1);
 
 					p->s.size = nunits;
 				}
 
 				p->s.next = &checkval;
 				MUNLOCK;
-				return p+1;
+				return p + 1;
 			} while((q = p) != rover);
 		}
-		if((n = morecore(nunits)) == 0){
+		if((n = morecore(nunits)) == 0) {
 			MUNLOCK;
 			return nil;
 		}
 		tailsize += n;
 	}
 
-	q = ALIGNHDR(tailptr+1, align);
-	if(q == tailptr+1){
+	q = ALIGNHDR(tailptr + 1, align);
+	if(q == tailptr + 1) {
 		tailalloc(p, nunits);
 		qstats[QSmaligntail]++;
-	}
-	else{
-		naligned = NUNITS(align)-1;
-		if(tailsize < nunits+naligned){
+	} else {
+		naligned = NUNITS(align) - 1;
+		if(tailsize < nunits + naligned) {
 			/*
 			 * There are at least nunits,
 			 * get enough for alignment.
 			 */
-			if((n = morecore(naligned)) == 0){
+			if((n = morecore(naligned)) == 0) {
 				MUNLOCK;
 				return nil;
 			}
@@ -254,40 +253,40 @@ qmallocalign(usize nbytes, uintptr_t align, int32_t offset, usize span)
 		 * and free it after the tail pointer has been bumped
 		 * for the main allocation.
 		 */
-		n = q-tailptr - 1;
+		n = q - tailptr - 1;
 		tailalloc(r, n);
 		tailalloc(p, nunits);
 		qstats[QSmalignnottail]++;
-		qfreeinternal(r+1);
+		qfreeinternal(r + 1);
 	}
 	MUNLOCK;
 
-	return p+1;
+	return p + 1;
 }
 
 static void*
 qmalloc(usize nbytes)
 {
-	Qlist *qlist;
+	Qlist* qlist;
 	Header *p, *q;
 	uint nunits, n;
 
-///* FIXME: (ignore for now)
+	///* FIXME: (ignore for now)
 	if(nbytes == 0)
 		return nil;
-//*/
+	//*/
 
 	qstats[QSmalloc]++;
 	nunits = NUNITS(nbytes);
-	if(nunits <= NQUICK){
+	if(nunits <= NQUICK) {
 		qlist = &QLIST[nunits];
 		QLOCK(&qlist->lk);
-		if((p = qlist->first) != nil){
+		if((p = qlist->first) != nil) {
 			qlist->first = p->s.next;
 			qlist->nalloc++;
 			QUNLOCK(&qlist->lk);
 			p->s.next = &checkval;
-			return p+1;
+			return p + 1;
 		}
 		QUNLOCK(&qlist->lk);
 	}
@@ -295,7 +294,7 @@ qmalloc(usize nbytes)
 	MLOCK;
 	if(nunits > tailsize) {
 		/* hard way */
-		if((q = rover) != nil){
+		if((q = rover) != nil) {
 			do {
 				p = q->s.next;
 				if(p->s.size >= nunits) {
@@ -309,11 +308,11 @@ qmalloc(usize nbytes)
 					rover = q;
 					qstats[QSmallocrover]++;
 					MUNLOCK;
-					return p+1;
+					return p + 1;
 				}
 			} while((q = p) != rover);
 		}
-		if((n = morecore(nunits)) == 0){
+		if((n = morecore(nunits)) == 0) {
 			MUNLOCK;
 			return nil;
 		}
@@ -323,13 +322,13 @@ qmalloc(usize nbytes)
 	tailalloc(p, nunits);
 	MUNLOCK;
 
-	return p+1;
+	return p + 1;
 }
 
 static void
 qfreeinternal(void* ap)
 {
-	Qlist *qlist;
+	Qlist* qlist;
 	Header *p, *q;
 	uint nunits;
 
@@ -340,7 +339,7 @@ qfreeinternal(void* ap)
 	p = (Header*)ap - 1;
 	if((nunits = p->s.size) == 0 || p->s.next != &checkval)
 		panic("malloc: corrupt allocation arena\n");
-	if(tailptr != nil && p+nunits == tailptr) {
+	if(tailptr != nil && p + nunits == tailptr) {
 		/* block before tail */
 		tailptr = p;
 		tailsize += nunits;
@@ -364,13 +363,13 @@ qfreeinternal(void* ap)
 	for(; !(p > q && p < q->s.next); q = q->s.next)
 		if(q >= q->s.next && (p > q || p < q->s.next))
 			break;
-	if(p+p->s.size == q->s.next) {
+	if(p + p->s.size == q->s.next) {
 		p->s.size += q->s.next->s.size;
 		p->s.next = q->s.next->s.next;
 		qstats[QSfreenext]++;
 	} else
 		p->s.next = q->s.next;
-	if(q+q->s.size == p) {
+	if(q + q->s.size == p) {
 		q->s.size += p->s.size;
 		q->s.next = p->s.next;
 		qstats[QSfreeprev]++;
@@ -379,10 +378,10 @@ qfreeinternal(void* ap)
 	rover = q;
 }
 
-uint32_t
-msize(void* ap)
+static uint32_t
+qm_msize(void* ap)
 {
-	Header *p;
+	Header* p;
 	uint nunits;
 
 	if(ap == nil)
@@ -392,60 +391,60 @@ msize(void* ap)
 	if((nunits = p->s.size) == 0 || p->s.next != &checkval)
 		panic("malloc: corrupt allocation arena\n");
 
-	return (nunits-1) * sizeof(Header);
+	return (nunits - 1) * sizeof(Header);
 }
 
 static void
 mallocreadfmt(char* s, char* e)
 {
-	char *p;
-	Header *q;
+	char* p;
+	Header* q;
 	int i, n, t;
-	Qlist *qlist;
+	Qlist* qlist;
 
 	p = seprint(s, e,
-		"%llu memory\n"
-		"%d pagesize\n"
-		"%llu kernel\n",
-		(uint64_t)conf.npage*PGSZ,
-		PGSZ,
-		(uint64_t)conf.npage-conf.upages);
+	            "%llu memory\n"
+	            "%d pagesize\n"
+	            "%llu kernel\n",
+	            (uint64_t)conf.npage * PGSZ,
+	            PGSZ,
+	            (uint64_t)conf.npage - conf.upages);
 
 	t = 0;
 	for(i = 0; i <= NQUICK; i++) {
 		n = 0;
 		qlist = &QLIST[i];
 		QLOCK(&qlist->lk);
-		for(q = qlist->first; q != nil; q = q->s.next){
-//			if(q->s.size != i)
-//				p = seprint(p, e, "q%d\t%#p\t%u\n",
-//					i, q, q->s.size);
+		for(q = qlist->first; q != nil; q = q->s.next) {
+			//			if(q->s.size != i)
+			//				p = seprint(p, e, "q%d\t%#p\t%u\n",
+			//					i, q, q->s.size);
 			n++;
 		}
 		QUNLOCK(&qlist->lk);
 
-//		if(n != 0)
-//			p = seprint(p, e, "q%d %d\n", i, n);
-		t += n * i*sizeof(Header);
+		//		if(n != 0)
+		//			p = seprint(p, e, "q%d %d\n", i, n);
+		t += n * i * sizeof(Header);
 	}
 	p = seprint(p, e, "quick: %u bytes total\n", t);
 
 	MLOCK;
-	if((q = rover) != nil){
+	if((q = rover) != nil) {
 		i = t = 0;
 		do {
 			t += q->s.size;
 			i++;
-//			p = seprint(p, e, "m%d\t%#p\n", q->s.size, q);
+			//			p = seprint(p, e, "m%d\t%#p\n", q->s.size, q);
 		} while((q = q->s.next) != rover);
 
 		p = seprint(p, e, "rover: %d blocks %u bytes total\n",
-			i, t*sizeof(Header));
+		            i, t * sizeof(Header));
 	}
 	p = seprint(p, e, "total allocated %lu, %u remaining\n",
-		(tailptr-tailbase)*sizeof(Header), tailnunits*sizeof(Header));
+	            (tailptr - tailbase) * sizeof(Header), tailnunits * sizeof(Header));
 
-	for(i = 0; i < nelem(qstats); i++){
+	for(i = 0; i < nelem(qstats); i++) {
 		if(qstats[i] == 0)
 			continue;
 		p = seprint(p, e, "%s %u\n", qstatstr[i], qstats[i]);
@@ -453,44 +452,44 @@ mallocreadfmt(char* s, char* e)
 	MUNLOCK;
 }
 
-int32_t
-mallocreadsummary(Chan* c, void *a, int32_t n, int32_t offset)
+static int32_t
+qm_mallocreadsummary(Chan* c, void* a, int32_t n, int32_t offset)
 {
-	char *alloc;
+	char* alloc;
 
-	alloc = malloc(16*READSTR);
-	mallocreadfmt(alloc, alloc+16*READSTR);
+	alloc = malloc(16 * READSTR);
+	mallocreadfmt(alloc, alloc + 16 * READSTR);
 	n = readstr(offset, a, n, alloc);
 	free(alloc);
 
 	return n;
 }
 
-void
-mallocsummary(void)
+static void
+qm_mallocsummary(void)
 {
-	Header *q;
+	Header* q;
 	int i, n, t;
-	Qlist *qlist;
+	Qlist* qlist;
 
 	t = 0;
 	for(i = 0; i <= NQUICK; i++) {
 		n = 0;
 		qlist = &QLIST[i];
 		QLOCK(&qlist->lk);
-		for(q = qlist->first; q != nil; q = q->s.next){
+		for(q = qlist->first; q != nil; q = q->s.next) {
 			if(q->s.size != i)
 				DBG("q%d\t%#p\t%u\n", i, q, q->s.size);
 			n++;
 		}
 		QUNLOCK(&qlist->lk);
 
-		t += n * i*sizeof(Header);
+		t += n * i * sizeof(Header);
 	}
 	print("quick: %u bytes total\n", t);
 
 	MLOCK;
-	if((q = rover) != nil){
+	if((q = rover) != nil) {
 		i = t = 0;
 		do {
 			t += q->s.size;
@@ -499,30 +498,30 @@ mallocsummary(void)
 	}
 	MUNLOCK;
 
-	if(i != 0){
+	if(i != 0) {
 		print("rover: %d blocks %u bytes total\n",
-			i, t*sizeof(Header));
+		      i, t * sizeof(Header));
 	}
 	print("total allocated %lu, %u remaining\n",
-		(tailptr-tailbase)*sizeof(Header), tailnunits*sizeof(Header));
+	      (tailptr - tailbase) * sizeof(Header), tailnunits * sizeof(Header));
 
-	for(i = 0; i < nelem(qstats); i++){
+	for(i = 0; i < nelem(qstats); i++) {
 		if(qstats[i] == 0)
 			continue;
 		print("%s %u\n", qstatstr[i], qstats[i]);
 	}
 }
 
-void
-free(void* ap)
+static void
+qm_free(void* ap)
 {
 	MLOCK;
 	qfreeinternal(ap);
 	MUNLOCK;
 }
 
-void*
-malloc(uint32_t size)
+static void*
+qm_malloc(uint32_t size)
 {
 	void* v;
 
@@ -532,10 +531,10 @@ malloc(uint32_t size)
 	return v;
 }
 
-void*
-mallocz(uint32_t size, int clr)
+static void*
+qm_mallocz(uint32_t size, int clr)
 {
-	void *v;
+	void* v;
 
 	if((v = malloc(size)) != nil && clr)
 		memset(v, 0, size);
@@ -543,10 +542,10 @@ mallocz(uint32_t size, int clr)
 	return v;
 }
 
-void*
-mallocalign(uint32_t nbytes, uint32_t align, int32_t offset, uint32_t span)
+static void*
+qm_mallocalign(uint32_t nbytes, uint32_t align, int32_t offset, uint32_t span)
 {
-	void *v;
+	void* v;
 
 	/*
 	 * Should this memset or should it be left to the caller?
@@ -557,22 +556,22 @@ mallocalign(uint32_t nbytes, uint32_t align, int32_t offset, uint32_t span)
 	return v;
 }
 
-void*
-smalloc(uint32_t size)
+static void*
+qm_smalloc(uint32_t size)
 {
-	Proc *up = externup();
-	void *v;
+	Proc* up = externup();
+	void* v;
 
 	while((v = mallocz(size, 1)) == nil)
 		tsleep(&up->sleep, return0, 0, 100);
 	return v;
 }
 
-void*
-realloc(void* ap, uint32_t size)
+static void*
+qm_realloc(void* ap, uint32_t size)
 {
-	void *v;
-	Header *p;
+	void* v;
+	Header* p;
 	uint32_t osize;
 	uint nunits, ounits;
 
@@ -584,7 +583,7 @@ realloc(void* ap, uint32_t size)
 	 * check for arena corruption;
 	 * do nothing if units are the same.
 	 */
-	if(size == 0){
+	if(size == 0) {
 		MLOCK;
 		qfreeinternal(ap);
 		MUNLOCK;
@@ -607,16 +606,16 @@ realloc(void* ap, uint32_t size)
 	 * adjust the tailptr.
 	 */
 	MLOCK;
-	if(tailptr != nil && p+ounits == tailptr){
-		if(ounits > nunits){
+	if(tailptr != nil && p + ounits == tailptr) {
+		if(ounits > nunits) {
 			p->s.size = nunits;
-			tailsize += ounits-nunits;
+			tailsize += ounits - nunits;
 			MUNLOCK;
 			return ap;
 		}
-		if(tailsize >= nunits-ounits){
+		if(tailsize >= nunits - ounits) {
 			p->s.size = nunits;
-			tailsize -= nunits-ounits;
+			tailsize -= nunits - ounits;
 			MUNLOCK;
 			return ap;
 		}
@@ -635,8 +634,8 @@ realloc(void* ap, uint32_t size)
 	 * allocate, copy and free.
 	 * What does the standard say for failure here?
 	 */
-	if((v = qmalloc(size)) != nil){
-		osize = (ounits-1)*sizeof(Header);
+	if((v = qmalloc(size)) != nil) {
+		osize = (ounits - 1) * sizeof(Header);
 		if(size < osize)
 			osize = size;
 		memmove(v, ap, osize);
@@ -648,13 +647,26 @@ realloc(void* ap, uint32_t size)
 	return v;
 }
 
-void
-setmalloctag(void* v, uint32_t i)
+static int
+morecore(uint nunits)
 {
+	/*
+	 * First (simple) cut.
+	 * Pump it up when you don't really need it.
+	 * Pump it up until you can feel it.
+	 */
+	if(nunits < NUNITS(128 * KiB))
+		nunits = NUNITS(128 * KiB);
+	if(nunits > tailnunits)
+		nunits = tailnunits;
+	tailnunits -= nunits;
+
+	return nunits;
 }
 
-void
-mallocinit(void)
+// Initialise memory system
+static void
+qm_init(void)
 {
 	if(tailptr != nil)
 		return;
@@ -665,19 +677,23 @@ mallocinit(void)
 	print("base %#p ptr %#p nunits %u\n", tailbase, tailptr, tailnunits);
 }
 
-static int
-morecore(uint nunits)
-{
-	/*
-	 * First (simple) cut.
-	 * Pump it up when you don't really need it.
-	 * Pump it up until you can feel it.
-	 */
-	if(nunits < NUNITS(128*KiB))
-		nunits = NUNITS(128*KiB);
-	if(nunits > tailnunits)
-		nunits = tailnunits;
-	tailnunits -= nunits;
+// TODO Change names to qm_*?
+static struct Allocator _qmallocAllocator = {
+    .init = qm_init,
+    .msize = qm_msize,
+    .mallocreadsummary = qm_mallocreadsummary,
+    .mallocsummary = qm_mallocsummary,
 
-	return nunits;
+    .free = qm_free,
+    .malloc = qm_malloc,
+    .mallocz = qm_mallocz,
+    .mallocalign = qm_mallocalign,
+    .smalloc = qm_smalloc,
+    .realloc = qm_realloc,
+};
+
+void
+mallocinit()
+{
+	mallocinitallocator(&_qmallocAllocator);
 }

--- a/sys/src/9/amd64/qmalloc.c
+++ b/sys/src/9/amd64/qmalloc.c
@@ -403,17 +403,6 @@ qm_free(void* ap)
 }
 
 static void*
-qm_malloc(uint32_t size)
-{
-	void* v;
-
-	if((v = qmalloc(size)) != nil)
-		memset(v, 0, size);
-
-	return v;
-}
-
-static void*
 qm_mallocz(uint32_t size, int clr)
 {
 	void* v;
@@ -435,17 +424,6 @@ qm_mallocalign(uint32_t nbytes, uint32_t align, int32_t offset, uint32_t span)
 	if((v = qmallocalign(nbytes, align, offset, span)) != nil)
 		memset(v, 0, nbytes);
 
-	return v;
-}
-
-static void*
-qm_smalloc(uint32_t size)
-{
-	Proc* up = externup();
-	void* v;
-
-	while((v = qm_mallocz(size, 1)) == nil)
-		tsleep(&up->sleep, return0, 0, 100);
 	return v;
 }
 
@@ -609,7 +587,7 @@ qm_mallocreadsummary(Chan* c, void* a, int32_t n, int32_t offset)
 {
 	char* alloc;
 
-	alloc = qm_malloc(16 * READSTR);
+	alloc = qm_mallocz(16 * READSTR, 1);
 	mallocreadfmt(alloc, alloc + 16 * READSTR);
 	n = readstr(offset, a, n, alloc);
 	qm_free(alloc);
@@ -680,11 +658,9 @@ qm_init(void)
 static struct Allocator _qmallocAllocator = {
     .init = qm_init,
 
-    .malloc = qm_malloc,
     .mallocz = qm_mallocz,
     .mallocalign = qm_mallocalign,
     .realloc = qm_realloc,
-    .smalloc = qm_smalloc,
 
     .free = qm_free,
 

--- a/sys/src/9/amd64/qmalloc.c
+++ b/sys/src/9/amd64/qmalloc.c
@@ -612,7 +612,7 @@ qm_mallocreadsummary(Chan* c, void* a, int32_t n, int32_t offset)
 	alloc = qm_malloc(16 * READSTR);
 	mallocreadfmt(alloc, alloc + 16 * READSTR);
 	n = readstr(offset, a, n, alloc);
-	free(alloc);
+	qm_free(alloc);
 
 	return n;
 }

--- a/sys/src/9/amd64/qmalloc.c
+++ b/sys/src/9/amd64/qmalloc.c
@@ -536,7 +536,7 @@ qm_mallocz(uint32_t size, int clr)
 {
 	void* v;
 
-	if((v = malloc(size)) != nil && clr)
+	if((v = qmalloc(size)) != nil && clr)
 		memset(v, 0, size);
 
 	return v;
@@ -677,7 +677,6 @@ qm_init(void)
 	print("base %#p ptr %#p nunits %u\n", tailbase, tailptr, tailnunits);
 }
 
-// TODO Change names to qm_*?
 static struct Allocator _qmallocAllocator = {
     .init = qm_init,
     .msize = qm_msize,


### PR DESCRIPTION
This should make it easier to replace the allocator implementation, and also to test and analyze.