### PR TITLE
i8042.c: don't push the char twice

### DIFF
--- a/sys/src/9/386/i8042.c
+++ b/sys/src/9/386/i8042.c
@@ -379,9 +379,6 @@ i8042intr(Ureg* u, void* v)
 	if(s & Minready){
 		if(mouseq != nil)
 			qiwrite(mouseq, &c, 1);
-	} else {
-		if(keybq != nil)
-			qiwrite(keybq, &c, 1);
 	}
 
 	/*


### PR DESCRIPTION
It's not right for the kernel-based
console I think, since you interpret the char
below. With this one change in alvaros revertcons3 branch
things work. But this probably breaks the external console
so don't push it.

don't push this, I only tested it against PR 426 not
against upstream

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>