### PR TITLE
bldy: remove the sys/src/9/amd64 specific compiler flags

### DIFF
--- a/amd64/x86_64-elf-gcc.BUILD
+++ b/amd64/x86_64-elf-gcc.BUILD
@@ -1,0 +1,4 @@
+COMPILER_FLAGS=[
+  "-Wno-frame-address",
+  "-fno-pie",
+]

--- a/sys/src/9/amd64/BUILD
+++ b/sys/src/9/amd64/BUILD
@@ -269,7 +269,7 @@ STD_COMPILER_OPTIONS = [
 	"-fasm",
 ]
 
-load("//sys/src/9/amd64/${CC}.BUILD", "COMPILER_FLAGS")
+load("//amd64/${CC}.BUILD", "COMPILER_FLAGS")
 
 cc_binary(
 	name="harvey",

--- a/sys/src/9/amd64/clang-3.7.BUILD
+++ b/sys/src/9/amd64/clang-3.7.BUILD
@@ -1,3 +1,0 @@
-COMPILER_FLAGS = [
-  "-mno-implicit-float"
-]

--- a/sys/src/9/amd64/clang-3.8.BUILD
+++ b/sys/src/9/amd64/clang-3.8.BUILD
@@ -1,3 +1,0 @@
-COMPILER_FLAGS = [
-  "-mno-implicit-float"
-]

--- a/sys/src/9/amd64/clang-3.9.BUILD
+++ b/sys/src/9/amd64/clang-3.9.BUILD
@@ -1,3 +1,0 @@
-COMPILER_FLAGS = [
-  "-mno-implicit-float"
-]

--- a/sys/src/9/amd64/clang.BUILD
+++ b/sys/src/9/amd64/clang.BUILD
@@ -1,3 +1,0 @@
-COMPILER_FLAGS = [
-  "-mno-implicit-float"
-]

--- a/sys/src/9/amd64/gcc-4.8.BUILD
+++ b/sys/src/9/amd64/gcc-4.8.BUILD
@@ -1,6 +1,0 @@
-COMPILER_FLAGS = [
-	"-Wno-frame-address",
-	"-fno-pie",
-	"-fvar-tracking",
-	"-fvar-tracking-assignments",
-]

--- a/sys/src/9/amd64/gcc-5.BUILD
+++ b/sys/src/9/amd64/gcc-5.BUILD
@@ -1,4 +1,0 @@
-COMPILER_FLAGS = [
-	"-Wno-frame-address",
-	"-fno-pie",
-]

--- a/sys/src/9/amd64/gcc-6.BUILD
+++ b/sys/src/9/amd64/gcc-6.BUILD
@@ -1,4 +1,0 @@
-COMPILER_FLAGS = [
-	"-Wno-frame-address",
-	"-fno-pie",
-]

--- a/sys/src/9/amd64/gcc.BUILD
+++ b/sys/src/9/amd64/gcc.BUILD
@@ -1,7 +1,0 @@
-# Assumes gcc-4.8 is the default compiler for gcc.
-COMPILER_FLAGS = [
-	"-Wno-frame-address",
-	"-fno-pie",
-	"-fvar-tracking",
-	"-fvar-tracking-assignments",
-]


### PR DESCRIPTION
now using the amd64/$CC.BUILD flags for everything

R=rminnich
R=elbing

Signed-off-by: Sevki Hasirci <s@sevki.org>