### PR TITLE
cflags: remove ToolOpts and just use include

### DIFF
--- a/amd64/include/cflags.json
+++ b/amd64/include/cflags.json
@@ -1,39 +1,8 @@
 {
 	"buildflags": {
-		"ToolOpts": {
-			"/usr/bin/clang": [
-				"-mno-implicit-float"
-			],
-			"/usr/bin/clang-3.4": [
-				"-mno-implicit-float"
-			],
-			"/usr/bin/clang-3.5": [
-				"-mno-implicit-float"
-			],
-			"/usr/bin/clang-3.6": [
-				"-mno-implicit-float"
-			],
-			"/usr/bin/clang-3.7": [
-				"-mno-implicit-float"
-			],
-			"/opt/intel/bin/icc": [
-				"-Wno-main"
-			],
-			"/usr/bin/gcc": [
-				"-Wno-frame-address",
-				"-fvar-tracking",
- 				"-fvar-tracking-assignments"
-			],
-			"/opt/gnu/bin/x86_64-none-elf-gcc": [
-				"-Wno-frame-address"
-			],
-			"/usr/local/bin/x86_64-elf-gcc": [
-				"-Wno-frame-address"
-			],
-			"/usr/bin/gcc-6": [
-				"-Wno-frame-address"
-			]
-		},
+		"Include": [
+			"/$ARCH/include/$CC.json"
+		],
 		"Cflags": [
 			"-ffreestanding",
 			"-fno-builtin",

--- a/amd64/include/clang-3.4.json
+++ b/amd64/include/clang-3.4.json
@@ -1,0 +1,7 @@
+{
+	"buildflags": {
+		"Cflags": [
+				"-mno-implicit-float"
+			]
+	}
+}

--- a/amd64/include/clang-3.5.json
+++ b/amd64/include/clang-3.5.json
@@ -1,0 +1,7 @@
+{
+	"buildflags": {
+		"Cflags": [
+				"-mno-implicit-float"
+			]
+	}
+}

--- a/amd64/include/clang-3.6.json
+++ b/amd64/include/clang-3.6.json
@@ -1,0 +1,7 @@
+{
+	"buildflags": {
+		"Cflags": [
+				"-mno-implicit-float"
+			]
+	}
+}

--- a/amd64/include/clang-3.7.json
+++ b/amd64/include/clang-3.7.json
@@ -1,0 +1,7 @@
+{
+	"buildflags": {
+		"Cflags": [
+				"-mno-implicit-float"
+			]
+	}
+}

--- a/amd64/include/clang-3.8.json
+++ b/amd64/include/clang-3.8.json
@@ -1,0 +1,7 @@
+{
+	"buildflags": {
+		"Cflags": [
+				"-mno-implicit-float"
+			]
+	}
+}

--- a/amd64/include/clang.json
+++ b/amd64/include/clang.json
@@ -1,0 +1,7 @@
+{
+	"buildflags": {
+		"Cflags": [
+				"-mno-implicit-float"
+			]
+	}
+}

--- a/amd64/include/gcc-4.8.json
+++ b/amd64/include/gcc-4.8.json
@@ -1,0 +1,9 @@
+{
+	"buildflags": {
+		"Cflags": [
+				"-Wno-frame-address",
+				"-fvar-tracking",
+ 				"-fvar-tracking-assignments"
+			]
+	}
+}

--- a/amd64/include/gcc-5.json
+++ b/amd64/include/gcc-5.json
@@ -1,0 +1,9 @@
+{
+	"buildflags": {
+		"Cflags": [
+				"-Wno-frame-address",
+				"-fvar-tracking",
+ 				"-fvar-tracking-assignments"
+			]
+	}
+}

--- a/amd64/include/gcc-6.json
+++ b/amd64/include/gcc-6.json
@@ -1,0 +1,9 @@
+{
+	"buildflags": {
+		"Cflags": [
+				"-Wno-frame-address",
+				"-fvar-tracking",
+ 				"-fvar-tracking-assignments"
+			]
+	}
+}

--- a/amd64/include/gcc.json
+++ b/amd64/include/gcc.json
@@ -1,0 +1,9 @@
+{
+	"buildflags": {
+		"Cflags": [
+				"-Wno-frame-address",
+				"-fvar-tracking",
+ 				"-fvar-tracking-assignments"
+			]
+	}
+}

--- a/amd64/include/icc.json
+++ b/amd64/include/icc.json
@@ -1,0 +1,7 @@
+{
+	"buildflags": {
+		"Cflags": [
+				"-Wno-main
+			]
+	}
+}

--- a/amd64/include/x86_64-elf-gcc.json
+++ b/amd64/include/x86_64-elf-gcc.json
@@ -1,0 +1,7 @@
+{
+	"buildflags": {
+		"Cflags": [
+				"-Wno-frame-address"
+			]
+	}
+}

--- a/amd64/include/x86_64-none-elf-gcc.json
+++ b/amd64/include/x86_64-none-elf-gcc.json
@@ -1,0 +1,7 @@
+{
+	"buildflags": {
+		"Cflags": [
+				"-Wno-frame-address"
+			]
+	}
+}


### PR DESCRIPTION
I should have done it this way in the first place.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>