### PR TITLE
libc/amd64/main9.S: force it to code64

### DIFF
--- a/sys/src/libc/amd64/main9.S
+++ b/sys/src/libc/amd64/main9.S
@@ -1,4 +1,5 @@
 #define NPRIVATES 16
+.code64
 
 .text
 


### PR DESCRIPTION
llvm on OSX seems to default to 32-bit, which is stupid, but
easy to fix.

Tested to booting on linux.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>