### PR TITLE
Apply TOOLPREFIX to objcopy

### DIFF
--- a/sys/src/9/amd64/core.json
+++ b/sys/src/9/amd64/core.json
@@ -48,7 +48,7 @@
 			"kernel.ld"
 		],
 		"Post": [
-			"objcopy -I elf64-x86-64 -O elf32-i386 harvey harvey.32bit",
+			"${TOOLPREFIX}objcopy -I elf64-x86-64 -O elf32-i386 harvey harvey.32bit",
 			"cp harvey.32bit /cfg/pxe/tftpboot"
 		],
 		"Pre": [


### PR DESCRIPTION
Final change required to get harvey building with macosx/gcc/build.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>