### PR TITLE
Bind devrtc to /dev/rtc by default

### DIFF
--- a/lib/namespace
+++ b/lib/namespace
@@ -17,6 +17,7 @@ bind -a #u /dev
 bind -b #P /dev
 bind -b '#$' /dev
 bind -a 'α' /dev
+bind -a 'r' /dev
 
 # screen console
 mount -b /srv/screenconsole /dev


### PR DESCRIPTION
Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>