### PR TITLE
Add binding for /dev/rtc

### DIFF
--- a/lib/namespace
+++ b/lib/namespace
@@ -17,6 +17,7 @@ bind -a #u /dev
 bind -b #P /dev
 bind -b '#$' /dev
 bind -a 'α' /dev
+bind -a '#r' /dev
 
 # screen console
 mount -b /srv/screenconsole /dev


### PR DESCRIPTION
Ensures /dev/rtc is available for both cpu and terminal.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>