### PR TITLE
bldy: let bldy take a vacation for a bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
   - PATH=$PATH:$HARVEY/util
   matrix:
   - OLD_BUILD=true
-  - OLD_BUILD=false
 addons:
   coverity_scan:
     project:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@
 echo Building the build tool...
 
 GOBIN="$(pwd)/util" GOPATH="$(pwd)/util/third_party:$(pwd)/util" go get -u github.com/Harvey-OS/ninep/cmd/ufs
-GOBIN="$(pwd)/util" GOPATH="$(pwd)/util/third_party:$(pwd)/util" go get -f -u bldy.build/bldy
+# GOBIN="$(pwd)/util" GOPATH="$(pwd)/util/third_party:$(pwd)/util" go get -f -u bldy.build/bldy
 GOBIN="$(pwd)/util" GOPATH="$(pwd)/util/third_party:$(pwd)/util" go get harvey/cmd/...
 
 
@@ -16,8 +16,6 @@ export ARCH=amd64
 # And build:
 ./util/build
 # See \`build -h' for more information on the build tool.
-
-To build with bldy just type bldy -r kernel 
 
 To enable access to files, create a harvey and none user:
 sudo useradd harvey


### PR DESCRIPTION
Bldy is a brilliant prototype but we want to rethink some aspects
of its implementation. Until we're sure how it's going to work
out, take it out of the test matrix (it's pushing our travis
times to 30 minutes) and don't get it or mention it in
bootstrap.sh. Do this in a way that lets us bring it back
when we're ready.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>