### PR TITLE
acpi: don't enable gpes until acpiintr is opened

### DIFF
--- a/sys/src/9/amd64/devacpi.c
+++ b/sys/src/9/amd64/devacpi.c
@@ -1901,6 +1901,11 @@ static void initgpes(void)
 		gpes[i + n0].enbit = (n1 + i) & 7;
 		gpes[i + n0].enio = fadt->gpe1blk + ((n1 + i) >> 3);
 	}
+}
+
+static void startgpes(void)
+{
+	int i;
 	for (i = 0; i < ngpes; i++) {
 		setgpeen(i, 0);
 		clrgpests(i);
@@ -2117,6 +2122,7 @@ acpiintrread(Chan *c, void *a, int32_t n, int64_t off)
 {
 	if (acpienable())
 		error("Can't enable ACPI");
+	startgpes();
 	n = qread(acpiev, a, n);
 	if (acpidisable())
 		error("Can't disable ACPI");


### PR DESCRIPTION
macdonag reports getting a flood of interrupts on his hardware.
I am not sure that's supposed to happen, but this IS ACPI,
so all bets are off.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>