### PR TITLE
Remove personal copyrights

### DIFF
--- a/sys/src/9/port/portclock.c
+++ b/sys/src/9/port/portclock.c
@@ -1,6 +1,4 @@
 /*
- * Copyright (C) 2015 Giacomo Tesio <giacomo@tesio.it>
- *
  * This file is part of the UCB release of Plan 9. It is subject to the license
  * terms in the LICENSE file found in the top-level directory of this
  * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No

--- a/sys/src/9/port/sysproc.c
+++ b/sys/src/9/port/sysproc.c
@@ -1,6 +1,4 @@
 /*
- * Copyright (C) 2015 Giacomo Tesio <giacomo@tesio.it>
- *
  * This file is part of the UCB release of Plan 9. It is subject to the license
  * terms in the LICENSE file found in the top-level directory of this
  * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No


### PR DESCRIPTION
Now that we have an official HarveyOS organization, we can have a more formal copyright policy.
The policy from here on out is as follows:

- we don't remove personal copyrights from imported code
- when we create code, the copyright is HarveyOS
- we don't add personal copyrights to code
- if needed, when substantial changes are made, we'll add a HarveyOS copyright notice.
  We expect this to be infrequent.

If we find other places where we have added personal copyrights since the
Harvey project began, we will remove them as well.

This policy accords with modern practice on projects such as Harvey.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>