### PR TITLE
Remove more personal copyrights.

### DIFF
--- a/sys/src/libmp/port/cnfield.c
+++ b/sys/src/libmp/port/cnfield.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2015 - 2017 cinap_lenrek <cinap_lenrek@felloff.net>
- * Copyright 2017 Rafael Fernández <rafita.fernandez@gmail.com>
+ * Copyright 2017 HarveyOS
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/sys/src/libmp/port/gmfield.c
+++ b/sys/src/libmp/port/gmfield.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2015 - 2017 cinap_lenrek <cinap_lenrek@felloff.net>
- * Copyright 2017 Rafael Fernández <rafita.fernandez@gmail.com>
+ * Copyright 2017 HarveyOS
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/sys/src/libmp/port/mpfield.c
+++ b/sys/src/libmp/port/mpfield.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2015 - 2017 cinap_lenrek <cinap_lenrek@felloff.net>
- * Copyright 2017 Rafael Fernández <rafita.fernandez@gmail.com>
+ * Copyright 2017 HarveyOS
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/sys/src/libmp/port/mpnrand.c
+++ b/sys/src/libmp/port/mpnrand.c
@@ -1,7 +1,7 @@
 /*
  * Copyright 2015 - 2017 cinap_lenrek <cinap_lenrek@felloff.net>
  * Copyright 2016 mischief <mischief@offblast.org>
- * Copyright 2017 Rafael Fernández <rafita.fernandez@gmail.com>
+ * Copyright 2017 HarveyOS
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/sys/src/libmp/port/mptober.c
+++ b/sys/src/libmp/port/mptober.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2015 - 2017 cinap_lenrek <cinap_lenrek@felloff.net>
- * Copyright 2017 Rafael Fernández <rafita.fernandez@gmail.com>
+ * Copyright 2017 HarveyOS
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/sys/src/libsec/port/ecc.c
+++ b/sys/src/libsec/port/ecc.c
@@ -2,7 +2,7 @@
  * Copyright 2012 - 2017 Julius Schmidt <aiju@phicode.de>
  * Copyright 2015 - 2017 cinap_lenrek <cinap_lenrek@felloff.net>
  * Copyright 2015 - 2017 mischief <mischief@offblast.org>
- * Copyright 2017 Rafael Fernández <rafita.fernandez@gmail.com>
+ * Copyright 2017 HarveyOS
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/sys/src/libsec/port/jacobian.c
+++ b/sys/src/libsec/port/jacobian.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2016 - 2017 cinap_lenrek <cinap_lenrek@felloff.net>
- * Copyright 2017 Rafael Fernández <rafita.fernandez@gmail.com>
+ * Copyright 2017 HarveyOS
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/sys/src/libsec/port/secp256r1.c
+++ b/sys/src/libsec/port/secp256r1.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2016 - 2017 cinap_lenrek <cinap_lenrek@felloff.net>
- * Copyright 2017 Rafael Fernández <rafita.fernandez@gmail.com>
+ * Copyright 2017 HarveyOS
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/sys/src/libsec/port/secp384r1.c
+++ b/sys/src/libsec/port/secp384r1.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2016 - 2017 cinap_lenrek <cinap_lenrek@felloff.net>
- * Copyright 2017 Rafael Fernández <rafita.fernandez@gmail.com>
+ * Copyright 2017 HarveyOS
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/sys/src/libsec/port/tsmemcmp.c
+++ b/sys/src/libsec/port/tsmemcmp.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2015 - 2017 cinap_lenrek <cinap_lenrek@felloff.net>
- * Copyright 2017 Rafael Fernández <rafita.fernandez@gmail.com>
+ * Copyright 2017 HarveyOS
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the


### PR DESCRIPTION
As Ron said:

Now that we have an official HarveyOS organization, we can have a more formal copyright policy.
The policy from here on out is as follows:

- we don't remove personal copyrights from imported code
- when we create code, the copyright is HarveyOS
- we don't add personal copyrights to code
- if needed, when substantial changes are made, we'll add a HarveyOS copyright notice.
  We expect this to be infrequent.

If we find other places where we have added personal copyrights since the
Harvey project began, we will remove them as well.

This policy accords with modern practice on projects such as Harvey.


Signed-off-by: fuchicar <rafita.fernandez@gmail.com>