### PR TITLE
Solved little bug in dead key repetition

### DIFF
--- a/sys/src/9/386/i8042.c
+++ b/sys/src/9/386/i8042.c
@@ -302,6 +302,7 @@ processdeadkey(Rune c){
 		// We pressed a dead key before this
 		if (k->key == c){
 			// Press two times the same DeadKey = print the dead key
+			k=nil;
 			return c;
 		}
 		for (int i=0; i<MaxDKResults && k->baseKey[i]!=No; i++){
@@ -549,7 +550,7 @@ i8042intr(Ureg* u, void* v)
 	/*
 	 * Process dead keys
 	 */
-	if (hasdeadkeys()){
+	if (hasdeadkeys() && !keyup){
 		c = processdeadkey(c);
 	}
 


### PR DESCRIPTION
When you press twice a dead key it's like if you press it three times. This solve it.

Signed-off-by: fuchicar <rafita.fernandez@gmail.com>