### PR TITLE
Fix #500 (acme crashes on arrow key down)

### DIFF
--- a/sys/src/cmd/acme/text.c
+++ b/sys/src/cmd/acme/text.c
@@ -671,15 +671,8 @@ texttype(Text *t, Rune r)
 		}
 		return;
 	case Kdown:
-		typecommit(t);
-		if(t->q1 < t->file->Buffer.nc){
-	    q0 = t->q0;
-			nnb = textbswidth(t, 0x15);
-	    while(q0<t->file->Buffer.nc && textreadc(t, q0)!='\n')
-	    	q0++;
-			textshow(t, q0 + nnb, q0+nnb, TRUE);
-		}
-		return;
+		n = t->Frame.maxlines/3;
+		goto case_Down;
 	case Kscrollonedown:
 		n = mousescrollsize(t->Frame.maxlines);
 		if(n <= 0)
@@ -692,17 +685,8 @@ texttype(Text *t, Rune r)
 		textsetorigin(t, q0, TRUE);
 		return;
 	case Kup:
-		typecommit(t);
-		nnb = 0;
-		if(t->q0>0 && textreadc(t, t->q0-1)!='\n')
-			nnb = textbswidth(t, 0x15);
-		if( t->q0-nnb > 1  && textreadc(t, t->q0-nnb-1)=='\n' ) nnb++;
-		textshow(t, t->q0-nnb, t->q0-nnb, TRUE);
-		linelen = textbswidth(t, 0x15);
-		if (linelen > nnb){
-			textshow(t, t->q0 - (linelen - nnb), t->q0 - (linelen - nnb), TRUE);
-		}
-		return;
+		n = t->Frame.maxlines/3;
+		goto case_Up;
 	case Kscrolloneup:
 		n = mousescrollsize(t->Frame.maxlines);
 		goto case_Up;


### PR DESCRIPTION
Fixes #500 and returns up/down arrow keys to the traditional
behavior. We can use zenith for experimentation and different
keyboard behavior.

Signed-off-by: John Floren <john@jfloren.net>