### PR TITLE
Check and respond to qT* packets correctly

### DIFF
--- a/sys/src/cmd/gdbserver/gdbstub.c
+++ b/sys/src/cmd/gdbserver/gdbstub.c
@@ -684,13 +684,12 @@ gdb_cmd_query(struct state *ks)
 			pack_threadid((char *)remcom_out_buffer + 2, (uint8_t *) & ks->threadid);
 			break;
 		case 'T':
-		    print("%s\n", remcom_in_buffer );
-		    if (memcmp(remcom_in_buffer, "Status", 6) == 0) {
-		        // TODO: proper status
-		        strcpy(remcom_out_buffer, "Tnotrun:0");
-		        break;
-		    }
-			error_packet(remcom_out_buffer, Einval);
+			if (memcmp(remcom_in_buffer+2, "Status", 6) == 0) {
+		        	// TODO: proper status
+		        	strcpy(remcom_out_buffer, "Tnotrun:0");
+		        	break;
+		    	}
+			strcpy((char *)remcom_out_buffer, "");
 			break;
 	}
 }


### PR DESCRIPTION
Status was checked incorrectly, and if we respond with Einval for qTsV, gdb will go into an infinite loop.  Return 0 for these qT* packets instead.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>