### PR TITLE
gdb: don't remove 9syscall source files, gdb gets confused.

### DIFF
--- a/sys/src/libc/libc.json
+++ b/sys/src/libc/libc.json
@@ -10,9 +10,6 @@
 	],
 	"Install": "/$ARCH/lib/",
 	"Library": "libc.a",
-	"Post": [
-		"rm -f 9syscall/*.s"
-	],
 	"Projects": [
 		"9syscall/9syscall.json"
 	],


### PR DESCRIPTION
Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>