### PR TITLE
Don’t try to stop process on gdbserver connection

### DIFF
--- a/sys/src/cmd/gdbserver/gdbstub.c
+++ b/sys/src/cmd/gdbserver/gdbstub.c
@@ -853,7 +853,6 @@ gdb_serial_stub(struct state *ks, int port)
 	    exits("accept");
 	}
 	print("Connected\n");
-	sendctl(ks->threadid , "stop");
 
 	/* Initialize comm buffer and globals. */
 	memset(remcom_out_buffer, 0, sizeof(remcom_out_buffer));


### PR DESCRIPTION
This is because the process may be blocked on a syscall.  Perhaps we can move this to a child process in the future, but for now, since it's blocking the gdb connection and causing a timeout, just remove it.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>