### PR TITLE
Bind /apex/$cputype/bin to /bin by default. It won't hurt you

### DIFF
--- a/lib/namespace
+++ b/lib/namespace
@@ -29,6 +29,7 @@ mount -a /srv/factotum /mnt
 # standard bin
 bind /$cputype/bin /bin
 bind -a /rc/bin /bin
+bind -a /apex/$cputype/bin /bin
 
 # internal networks
 # mount -a /srv/ip /net


### PR DESCRIPTION
if you don't have /apex but if you do have apex it will give
you troff and awk etc.

Signed-off-by: John Floren <john@jfloren.net>