### PR TITLE
Cleaned up warnings in libfreetype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,16 +7,24 @@
 386/pbslba
 386/pbsraw
 
+aarch64/9*
+aarch64/bin
+aarch64/init
+aarch64/lib
+
 amd64/9*
 amd64/bin
 amd64/init
 amd64/lib
+
 riscv/9*
 riscv/bin
 riscv/init
 riscv/lib
 
+acme/bin/aarch64
 acme/bin/amd64
+acme/bin/riscv
 
 sys/log
 

--- a/sys/src/libfreetype/src/base/ftstroker.c
+++ b/sys/src/libfreetype/src/base/ftstroker.c
@@ -1398,14 +1398,11 @@
     FT_Int   n;         /* index of contour in outline     */
     FT_UInt  first;     /* index of first point in contour */
     FT_Int   tag;       /* current point's state           */
-    FT_Int   in_path;
 
     if ( !outline || !stroker )
       return FT_Err_Invalid_Argument;
 
     first = 0;
-
-    in_path = 0;
 
     for ( n = 0; n < outline->n_contours; n++ )
     {
@@ -1455,8 +1452,6 @@
       error = FT_Stroker_BeginSubPath( stroker, &v_start, opened );
       if ( error )
         goto Exit;
-
-      in_path = 1;
 
       while ( point < limit )
       {

--- a/sys/src/libfreetype/src/bdf/bdflib.c
+++ b/sys/src/libfreetype/src/bdf/bdflib.c
@@ -641,7 +641,7 @@
   {
     _bdf_line_func_t  cb;
     unsigned long     lineno;
-    int               n, res, done, refill, bytes, hold;
+    int               n, done, refill, bytes, hold;
     char              *ls, *le, *pp, *pe, *hp;
     char              *buf = 0;
     FT_Memory         memory = stream->memory;
@@ -661,7 +661,7 @@
     lineno = 1;
     buf[0] = 0;
 
-    res = done = 0;
+    done = 0;
     pp = ls = le = buf;
 
     bytes = 65536L;
@@ -1443,7 +1443,6 @@
     unsigned char*     bp;
     unsigned long      i, slen, nibbles;
 
-    _bdf_line_func_t*  next;
     _bdf_parse_t*      p;
     bdf_glyph_t*       glyph;
     bdf_font_t*        font;
@@ -1453,8 +1452,6 @@
 
     FT_UNUSED( lineno );        /* only used in debug mode */
 
-
-    next = (_bdf_line_func_t *)call_data;
     p    = (_bdf_parse_t *)    client_data;
 
     font   = p->font;

--- a/sys/src/libfreetype/src/cache/ftlru.c
+++ b/sys/src/libfreetype/src/cache/ftlru.c
@@ -130,7 +130,6 @@
     FT_Error          error = 0;
     FT_LruNode        node, *pnode;
     FT_LruList_Class  clazz;
-    FT_LruNode*       plast;
     FT_LruNode        result = NULL;
     FT_Memory         memory;
 
@@ -139,7 +138,6 @@
       return FTC_Err_Invalid_Argument;
 
     pnode  = &list->nodes;
-    plast  = pnode;
     node   = NULL;
     clazz  = list->clazz;
     memory = list->memory;
@@ -155,7 +153,6 @@
         if ( clazz->node_compare( node, key, list->data ) )
           break;
 
-        plast = pnode;
         pnode = &(*pnode)->next;
       }
     }
@@ -170,7 +167,6 @@
         if ( node->key == key )
           break;
 
-        plast = pnode;
         pnode = &(*pnode)->next;
       }
     }

--- a/sys/src/libfreetype/src/raster/ftraster.c
+++ b/sys/src/libfreetype/src/raster/ftraster.c
@@ -564,6 +564,8 @@
   static Bool
   New_Profile( RAS_ARGS TStates  aState )
   {
+    uint64_t cp = (uint64_t)ras.cProfile;
+
     if ( !ras.fProfile )
     {
       ras.cProfile  = (PProfile)ras.top;
@@ -581,12 +583,12 @@
     {
     case Ascending_State:
       ras.cProfile->flow = Flow_Up;
-      FT_TRACE6(( "New ascending profile = %lx\n", (int32_t)ras.cProfile ));
+      FT_TRACE6(( "New ascending profile = %lx\n", (int32_t)cp ));
       break;
 
     case Descending_State:
       ras.cProfile->flow = Flow_Down;
-      FT_TRACE6(( "New descending profile = %lx\n", (int32_t)ras.cProfile ));
+      FT_TRACE6(( "New descending profile = %lx\n", (int32_t)cp ));
       break;
 
     default:
@@ -628,6 +630,7 @@
   {
     Long      h;
     PProfile  oldProfile;
+    uint64_t cp = (uint64_t)ras.cProfile;;
 
 
     h = (Long)( ras.top - ras.cProfile->offset );
@@ -642,7 +645,7 @@
     if ( h > 0 )
     {
       FT_TRACE6(( "Ending profile %lx, start = %ld, height = %ld\n",
-                  (int32_t)ras.cProfile, ras.cProfile->start, h ));
+                  (int32_t)cp, ras.cProfile->start, h ));
 
       oldProfile           = ras.cProfile;
       ras.cProfile->height = h;

--- a/sys/src/libfreetype/src/sfnt/ttcmap0.c
+++ b/sys/src/libfreetype/src/sfnt/ttcmap0.c
@@ -1022,6 +1022,8 @@
     start  = TT_NEXT_USHORT( p );
     count  = TT_NEXT_USHORT( p );
 
+    (void)start;
+
     if ( table + length > valid->limit || length < 10 + count * 2 )
       FT_INVALID_TOO_SHORT;
 
@@ -1401,6 +1403,8 @@
     start  = TT_NEXT_ULONG( p );
     count  = TT_NEXT_ULONG( p );
 
+    (void)start;
+
     if ( table + length > valid->limit || length < 20 + count * 2 )
       FT_INVALID_TOO_SHORT;
 
@@ -1446,7 +1450,6 @@
                        FT_UInt32  *pchar_code )
   {
     FT_Byte*   table     = cmap->data;
-    FT_UInt32  result    = 0;
     FT_UInt32  char_code = *pchar_code + 1;
     FT_UInt    gindex    = 0;
     FT_Byte*   p         = table + 12;
@@ -1466,7 +1469,6 @@
       gindex = TT_NEXT_USHORT( p );
       if ( gindex != 0 )
       {
-        result = char_code;
         break;
       }
       char_code++;

--- a/sys/src/libfreetype/src/sfnt/ttload.c
+++ b/sys/src/libfreetype/src/sfnt/ttload.c
@@ -190,6 +190,8 @@
 
       if ( offset + 12 + num_tables*16 > stream->size )
         goto Bad_Format;
+
+      (void)format_tag;
     }
     else if ( FT_STREAM_SEEK( offset + 12 ) )
       goto Bad_Format;

--- a/sys/src/libfreetype/src/type1/t1gload.c
+++ b/sys/src/libfreetype/src/type1/t1gload.c
@@ -269,6 +269,8 @@
       goto Exit;
     glyph_data_loaded = 1;
 
+    FT_UNUSED( glyph_data_loaded );
+
     font_matrix = decoder.font_matrix;
     font_offset = decoder.font_offset;
 

--- a/sys/src/libfreetype/src/type1/t1objs.c
+++ b/sys/src/libfreetype/src/type1/t1objs.c
@@ -299,6 +299,7 @@
     face->pshinter = FT_Get_Module_Interface( FT_FACE_LIBRARY( face ),
                                               "pshinter" );
     pshinter = (PSHinter_Service)face->pshinter;
+    (void)pshinter;
 
     /* open the tokenizer, this will also check the font format */
     error = T1_Open_Face( face );


### PR DESCRIPTION
Mostly unused variables, or set-but-unused.

The unfortunate practice seems to be to define a variable,
initialize it to zero, and set it to one later.  Then, presumably,
someone could look at it with a debugger or something and see
that it had been set at some point (or not).  Perhaps this is
used as a rough signal to see that something has happened in a
function.

Unfortunately, an optimizing compiler will probably note that
the variable is set but unused and just remove it.  So we just
remove some of them ourselves.  Or whatever.

Signed-off-by: Dan Cross <cross@gajendra.net>