### PR TITLE
When writing to text segments, handle both SG_TEXT and SG_LOAD

### DIFF
--- a/sys/src/9/port/devproc.c
+++ b/sys/src/9/port/devproc.c
@@ -1928,7 +1928,7 @@ procctlmemio(Proc *p, uintptr_t offset, int n, void *va, int read)
 		if(offset+n >= s->top)
 			n = s->top-offset;
 
-		if(!read && (s->type&SG_TYPE) == SG_TEXT)
+		if(!read && ((s->type&SG_TYPE) == SG_TEXT || (s->type&SG_TYPE) == SG_LOAD))
 			s = txt2data(p, s);
 
 		s->steal++;
@@ -1988,7 +1988,7 @@ txt2data(Proc *p, Segment *s)
 	int i;
 	Segment *ps;
 
-	ps = newseg(SG_DATA, s->base, s->size);
+	ps = newseg(SG_DATA|SG_READ|SG_WRITE|SG_EXEC, s->base, s->size);
 	ps->image = s->image;
 	incref(&ps->image->r);
 	ps->ldseg = s->ldseg;
@@ -2015,7 +2015,7 @@ data2txt(Segment *s)
 {
 	Segment *ps;
 
-	ps = newseg(SG_TEXT, s->base, s->size);
+	ps = newseg(SG_TEXT|SG_READ|SG_EXEC, s->base, s->size);
 	ps->image = s->image;
 	incref(&ps->image->r);
 	ps->ldseg = s->ldseg;


### PR DESCRIPTION
When copying a text segment into a data segment for writing, setup permissions correctly.  Similarly when duplicating data as text.  These changes needed because SG_RONLY was replaced with SG_READ and SG_WRITE, and SG_LOAD seems to have been added as a replacement for SG_TEXT, but the work wasn’t completed.  We should either work out what was intended, or remove the change in the future.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>