### PR TITLE
Fix assert() so that it doesn't warn

### DIFF
--- a/sys/include/libc.h
+++ b/sys/include/libc.h
@@ -10,7 +10,7 @@
 
 #define	nelem(x)	(sizeof(x)/sizeof((x)[0]))
 #define	offsetof(s, m)	(uintptr_t)(&(((s*)0)->m))
-#define	assert(x)	if(x){}else _assert(#x)
+#define	assert(x)	do{if(!(x))_assert(#x);}while(0)
 
 extern void (*_abort)(void);
 #define abort() {if(_abort){_abort();}else{while(*(volatile int*)0);}}

--- a/sys/src/9/port/lib.h
+++ b/sys/src/9/port/lib.h
@@ -13,7 +13,7 @@
  */
 #define nelem(x)	(sizeof(x)/sizeof((x)[0]))
 #define offsetof(s, m)	(uint64_t)(&(((s*)0)->m))
-#define assert(x)	if(x){}else _assert(#x)
+#define assert(x)	do{if(!(x))_assert(#x);}while(0)
 
 /* there's no reason to support _abort in the kernel */
 #define abort() while(*(int*)0);


### PR DESCRIPTION
Rewrite this macro so it doesn't cause a spurious
warning about braces.

Signed-off-by: Dan Cross <cross@gajendra.net>