### PR TITLE
Can set and hit a breakpoint to a stopped process

### DIFF
--- a/sys/src/cmd/gdbserver/debug_core.c
+++ b/sys/src/cmd/gdbserver/debug_core.c
@@ -31,6 +31,9 @@
 #include <u.h>
 #include <libc.h>
 #include <ureg.h>
+#include <bio.h>
+#include <mach.h>
+
 #include "debug_core.h"
 #include "gdb.h"
 
@@ -66,13 +69,16 @@ int active = -1;
 char *
 arch_set_breakpoint(struct state *ks, struct bkpt *bpt)
 {
-	char *err;
+	//char *err;
 
-	err = rmem(bpt->saved_instr, ks->threadid, bpt->bpt_addr, bpsize);
-	if (err)
-		return err;
-	err = wmem(bpt->bpt_addr, ks->threadid, breakpoint, bpsize);
-	return err;
+	//err = rmem(bpt->saved_instr, ks->threadid, bpt->bpt_addr, bpsize);
+	//if (err)
+	//	return err;
+
+	setbp(bpt->bpt_addr, bpt->saved_instr);
+	//err = wmem(bpt->bpt_addr, ks->threadid, machdata->bpinst, machdata->bpsize);
+	//return err;
+	return nil;
 }
 
 char *


### PR DESCRIPTION
Once breakpoint has been hit, gdb fails because it can’t write back the instruction.  Still need to tidy up lots of this code, but at least it shows we can hit a breakpoint.  It's all very scrappy, but we're further down the path at least.

Some todos:
 - Close files
 - Modify rmem and wmem to go via map, then remove setbp call
 - Handle breakpoint note on behalf of process being debugged
 - Replace breakpoint instruction
 - Handle removal of breakpoints
etc...

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>