### PR TITLE
gdbserver - improvements when hitting a breakpoint

### DIFF
--- a/sys/src/cmd/gdbserver/gdb.h
+++ b/sys/src/cmd/gdbserver/gdb.h
@@ -25,7 +25,6 @@ extern int			cpu_doing_single_step;
 extern struct task_struct	*usethread;
 extern struct task_struct	*contthread;
 extern char breakpoint[], ebreakpoint[];
-extern int bpsize;
 
 enum bptype {
 	BP_BREAKPOINT = 0,


### PR DESCRIPTION
- wmem and rmem now use put1 and get1, so access process text and data via the map.
- dbg_remove_sw_break handles removal of active breakpoints.  When a breakpoint is hit, gdb will request that the breakpoint is removed via z0, and then reinserted when continue is requested, via Z0.  This change now behaves correctly (I think).
- Removed some unused code

The next step is to remove the breakpoint note to stop the process suiciding before we continue.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>