### PR TITLE
gdbserver - continue after hitting breakpoint

### DIFF
--- a/sys/src/libmach/access.c
+++ b/sys/src/libmach/access.c
@@ -276,6 +276,6 @@ reloc(Map *map, uint64_t addr, int64_t *offp)
 			return &map->seg[i];
 		}
 	}
-	werrstr("can't translate address %llux", addr);
+	werrstr("can't translate address %p", addr);
 	return 0;
 }


### PR DESCRIPTION
When the breakpoint has been hit, we read the process note to stop it from suiciding.  This could probably be improved a bit by handling the case where there are multiple notes.

Also fix some logging formatting issues.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>