### PR TITLE
Use pragmas to turn off warnings about __builtin_return_address

### DIFF
--- a/amd64/include/gcc-6.json
+++ b/amd64/include/gcc-6.json
@@ -1,7 +1,6 @@
 {
 	"buildflags": {
 		"Cflags": [
-				"-Wno-frame-address",
 				"-fno-pie",
 				"-fvar-tracking",
  				"-fvar-tracking-assignments"

--- a/sys/src/9/amd64/main.c
+++ b/sys/src/9/amd64/main.c
@@ -101,7 +101,7 @@ machp_bad(void)
 	uintptr_t badpc;
 	int i;
 
-	badpc = (uintptr_t)__builtin_return_address(1);
+	badpc = (uintptr_t)getcallerpc();
 	for(i = 0; i < nelem(trace); i++){
 		if(trace[i] == badpc)
 			return;

--- a/sys/src/libc/port/getcallerpc.c
+++ b/sys/src/libc/port/getcallerpc.c
@@ -7,6 +7,8 @@
  * in the LICENSE file.
  */
 
+#pragma GCC diagnostic ignored "-Wframe-address"
+
 #include <u.h>
 #include <libc.h>
 

--- a/sys/src/libc/port/getcallstack.c
+++ b/sys/src/libc/port/getcallstack.c
@@ -8,6 +8,8 @@
  * contained in the LICENSE.gpl file.
  */
 
+#pragma GCC diagnostic ignored "-Wframe-address"
+
 #include <u.h>
 #include <libc.h>
 


### PR DESCRIPTION
We need to replace this code with assembler, I think.

Signed-off-by: Dan Cross <cross@gajendra.net>