### PR TITLE
Rewrite part of httpd to simplify some code.

### DIFF
--- a/sys/src/cmd/ip/httpd/httpd.c
+++ b/sys/src/cmd/ip/httpd/httpd.c
@@ -201,21 +201,17 @@ hashstr(char* key)
 static System *
 hashsys(char *rsys)
 {
-	int notme;
 	System *sys;
 
 	sys = syss + hashstr(rsys) % nelem(syss);
 	/* if the bucket is empty, just use it, else find or allocate ours */
 	if(sys->rsys != nil) {
 		/* find match or chain end */
-		for(; notme = (strcmp(sys->rsys, rsys) != 0) &&
-		    sys->next != nil; sys = sys->next)
-			;
-		if(notme) {
-			sys->next = malloc(sizeof *sys);  /* extend chain */
-			sys = sys->next;
-		} else
-			return sys;
+		for(; sys->next != nil; sys = sys->next)
+			if(strcmp(sys->rsys, rsys) == 0)
+				return sys;
+		sys->next = malloc(sizeof *sys);  /* extend chain */
+		sys = sys->next;
 	}
 	if(sys != nil) {
 		memset(sys, 0, sizeof *sys);


### PR DESCRIPTION
This change also removes a warning. It's interesting
how often warnings point out code that's not idiomatic,
or can be rewritten to make it simpler and clearer.

Signed-off-by: Dan Cross <cross@gajendra.net>