### PR TITLE
keyboard: move devkbmap to the architecture

### DIFF
--- a/sys/src/9/amd64/core.json
+++ b/sys/src/9/amd64/core.json
@@ -83,6 +83,7 @@
 			"devarch.c",
 			"../port/devdraw.c",
 			"../port/devether.c",
+			"../port/devkbmap.c",
 			"../port/devmouse.c",
 			"../port/devpci.c",
 			"../port/devvcon.c",

--- a/sys/src/9/port/port.json
+++ b/sys/src/9/port/port.json
@@ -24,7 +24,6 @@
 			"../port/devfdmux.c",
 			"../port/devkprof.c",
 			"../port/devkbin.c",
-			"../port/devkbmap.c",
 			"../port/devmnt.c",
 			"../port/devmntn.c",
 			"../port/devpipe.c",


### PR DESCRIPTION
It's portable code but needs some non-portable support.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>