### PR TITLE
Fix bug in libmach where mapped data segment didn't include stack

### DIFF
--- a/sys/src/9/port/devproc.c
+++ b/sys/src/9/port/devproc.c
@@ -1141,12 +1141,12 @@ print("Qgdbregs: va %p, rptr +offset %p, n %d\n", va, rptr+offset, n);
 			sg = p->seg[i];
 			if(sg == 0)
 				continue;
-			j += sprint(statbuf+j, "%-6s %c%c%c %c %p %p %4d\n",
+			j += sprint(statbuf+j, "%-6s %c%c%c%c %p %p %4d\n",
 				segtypes[sg->type&SG_TYPE],
 				(sg->type&SG_READ) != 0 ? 'r' : '-',
 				(sg->type&SG_WRITE) != 0 ? 'w' : '-',
 				(sg->type&SG_EXEC) != 0 ? 'x' : '-',
-				sg->profile ? 'P' : ' ',
+				sg->profile ? 'P' : '-',
 				sg->base, sg->top, sg->r.ref);
 		}
 		psdecref(p);


### PR DESCRIPTION
The format of /proc/pid/segment changed in commit 121208f.  Originally, if a segment was read-only, 'R' would be shown after the segment name.  In the case of the stack, this would be absent.  After that commit, there would always be a token displaying the segment permissions, therefore changing the format.  Also, due to the optional 'P' token, it is difficult to parse reliably.

The symptom was that any mapped data segment didn't include the stack.  This was because the change in format to segment meant when creating the map, we were reading the lower address for the stack, rather than the top.  This showed up when trying to view the stack in gdbserver -
 e.g. displaying backtrace.

This commit also combines the 'P' token with the permission section so we always know which tokens are where.  Segment doesn't seem to be pa
rsed anywhere else that I can find, so should be safe.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>