### PR TITLE
Fix gdb writing to memory

### DIFF
--- a/sys/src/cmd/gdbserver/gdbstub.c
+++ b/sys/src/cmd/gdbserver/gdbstub.c
@@ -526,7 +526,7 @@ static  void
 ebin2mem(unsigned char *buf, unsigned char *mem, int count)
 {
 	int size = 0;
-	unsigned char *c = buf;
+	unsigned char *c = mem;
 
 	while (count-- > 0) {
 		c[size] = *buf++;


### PR DESCRIPTION
Setting a variable (e.g. 'set foo=123') was broken.  This is because ebin2mem was overwriting the src rather than the dest for some reason.  wmem would then copy the dest (which hadn't been touched since the malloc...)

The first commit is the actual fix, the second tidies some things up a bit.