### PR TITLE
Fix warnings exposed by clang>3.8.

### DIFF
--- a/sys/src/9/port/error.h
+++ b/sys/src/9/port/error.h
@@ -52,3 +52,4 @@ extern char Etoobig[]; /* read or write too large */
 extern char Etoosmall[]; /* read or write too small */
 extern char Eunion[]; /* not in union */
 extern char Eunmount[]; /* not mounted */
+

--- a/sys/src/cmd/ip/telnet.c
+++ b/sys/src/cmd/ip/telnet.c
@@ -499,9 +499,9 @@ echochange(Biobuf *bp, int cmd)
 int
 termsub(Biobuf *bp, uint8_t *sub, int n)
 {
-	char buf[64];
+	unsigned char buf[64];
 	char *term;
-	char *p = buf;
+	unsigned char *p = buf;
 
 	if(n < 1)
 		return 0;
@@ -513,9 +513,9 @@ termsub(Biobuf *bp, uint8_t *sub, int n)
 		term = getenv("TERM");
 		if(term == 0 || *term == 0)
 			term = "p9win";
-		strncpy(p, term, sizeof(buf) - (p - buf) - 2);
+		strncpy((char *)p, term, sizeof(buf) - (p - buf) - 2);
 		buf[sizeof(buf)-2] = 0;
-		p += strlen(p);
+		p += strlen((char *)p);
 		*p++ = Iac;
 		*p++ = Se;
 		return iwrite(Bfildes(bp), buf, p-buf);
@@ -529,9 +529,9 @@ termsub(Biobuf *bp, uint8_t *sub, int n)
 int
 xlocsub(Biobuf *bp, uint8_t *sub, int n)
 {
-	char buf[64];
+	unsigned char buf[64];
 	char *term;
-	char *p = buf;
+	unsigned char *p = buf;
 
 	if(n < 1)
 		return 0;
@@ -543,7 +543,7 @@ xlocsub(Biobuf *bp, uint8_t *sub, int n)
 		term = getenv("XDISP");
 		if(term == 0 || *term == 0)
 			term = "unknown";
-		strncpy(p, term, p - buf - 2);
+		strncpy((char *)p, term, p - buf - 2);
 		p += strlen(term);
 		*p++ = Iac;
 		*p++ = Se;

--- a/sys/src/cmd/ip/telnetd.c
+++ b/sys/src/cmd/ip/telnetd.c
@@ -485,8 +485,8 @@ out:
 int
 termchange(Biobuf *bp, int cmd)
 {
-	char buf[8];
-	char *p = buf;
+	unsigned char buf[8];
+	unsigned char *p = buf;
 
 	if(cmd != Will)
 		return 0;
@@ -519,8 +519,8 @@ termsub(Biobuf *bp, uint8_t *sub, int n)
 int
 xlocchange(Biobuf *bp, int cmd)
 {
-	char buf[8];
-	char *p = buf;
+	unsigned char buf[8];
+	unsigned char *p = buf;
 
 	if(cmd != Will)
 		return 0;

--- a/sys/src/cmd/tar.c
+++ b/sys/src/cmd/tar.c
@@ -741,7 +741,7 @@ mkhdr(Hdr *hp, Dir *dir, char *file)
 			printed = 1;
 			fprint(2, "%s: storing large sizes in \"base 256\"\n", argv0);
 		}
-		hp->size[0] = Binsize;
+		hp->size[0] = (char)Binsize;
 		/* emit so-called `base 256' representation of size */
 		putbe((unsigned char *)hp->size+1, dir->length, sizeof hp->size - 2);
 		hp->size[sizeof hp->size - 1] = ' ';

--- a/sys/src/libacpi/acpica/acpiflags.json
+++ b/sys/src/libacpi/acpica/acpiflags.json
@@ -8,6 +8,7 @@
 			"-U_LINUX",
 			"-U__linux__",
 			"-U__FreeBSD__",
+			"-U__NetBSD__",
 			"-Wno-unused-function",
 			"-Wno-unused-variable",
 			"-Wno-unused-const-variable",

--- a/sys/src/libstdio/dtoa.c
+++ b/sys/src/libstdio/dtoa.c
@@ -250,7 +250,7 @@ lo0bits(unsigned int *y)
 	if (!(x & 1)) {
 		k++;
 		x >>= 1;
-		if (!x & 1)
+		if (!(x & 1))
 			return 32;
 	}
 	*y = x;


### PR DESCRIPTION
Compiled with clang 4.0 on my dev machine.

Signed-off-by: Dan Cross <cross@gajendra.net>