### PR TITLE
Replace a call to `__builtin_return_address(0)` with `getcallerpc()`

### DIFF
--- a/sys/src/cmd/gdbserver/kdb/kdb_support.c
+++ b/sys/src/cmd/gdbserver/kdb/kdb_support.c
@@ -785,7 +785,7 @@ void *debug_kmalloc(size_t size, gfp_t flags)
 		h->next = best->next;
 	} else
 		h_offset = best->next;
-	best->caller = __builtin_return_address(0);
+	best->caller = getcallerpc();
 	dah_used += best->size;
 	dah_used_max = max(dah_used, dah_used_max);
 	if (bestprev)


### PR DESCRIPTION
Signed-off-by: Dan Cross <cross@gajendra.net>