### PR TITLE
Implement get_reg for gdbserver

### DIFF
--- a/sys/src/cmd/gdbserver/gdb.h
+++ b/sys/src/cmd/gdbserver/gdb.h
@@ -93,6 +93,35 @@ enum regnames {
 	GDB_GS,			/* 23 */
 };
 
+// Again, this is very gdb-specific.  Order should be maintained the table above
+static const
+char* regstrs[] = {
+	"AX",
+	"BX",
+	"CX",
+	"DX",
+	"SI",
+	"DI",
+	"BP",
+	"SP",
+	"R8",
+	"R9",
+	"R10",
+	"R11",
+	"R12",
+	"R13",
+	"R14",
+	"R15",
+	"PC",
+	"PS",
+	"CS",
+	"SS",
+	"DS",
+	"ES",
+	"FS",
+	"GS",
+};
+
 #define GDB_ORIG_AX		57
 #define DBG_MAX_REG_NUM		24
 /* 17 64 bit regs and 5 32 bit regs */
@@ -182,7 +211,7 @@ char *mem2hex(unsigned char *mem, char *buf, int count);
 char *hex2mem(char *buf, unsigned char *mem, int count);
 void gdb_cmd_reg_get(struct state *ks);
 void gdb_cmd_reg_set(struct state *ks);
-
+uint64_t arch_get_reg(struct state *ks, int regnum);
 
 extern int isremovedbreak(unsigned long addr);
 extern void schedule_breakpoint(void);

--- a/sys/src/cmd/gdbserver/gdb.h
+++ b/sys/src/cmd/gdbserver/gdb.h
@@ -93,34 +93,8 @@ enum regnames {
 	GDB_GS,			/* 23 */
 };
 
-// Again, this is very gdb-specific.  Order should be maintained the table above
-static const
-char* regstrs[] = {
-	"AX",
-	"BX",
-	"CX",
-	"DX",
-	"SI",
-	"DI",
-	"BP",
-	"SP",
-	"R8",
-	"R9",
-	"R10",
-	"R11",
-	"R12",
-	"R13",
-	"R14",
-	"R15",
-	"PC",
-	"PS",
-	"CS",
-	"SS",
-	"DS",
-	"ES",
-	"FS",
-	"GS",
-};
+// Again, this is very gdb-specific.
+extern char* regstrs[];
 
 #define GDB_ORIG_AX		57
 #define DBG_MAX_REG_NUM		24

--- a/sys/src/cmd/gdbserver/gdbstub.c
+++ b/sys/src/cmd/gdbserver/gdbstub.c
@@ -1,4 +1,4 @@
-/*
+	/*
  * Kernel Debug Core
  *
  * Maintainer: Jason Wessel <jason.wessel@windriver.com>
@@ -55,6 +55,8 @@ int notefid;
 int debug = 0;
 int attached_to_existing_pid = 0;
 Map* cormap;
+
+static struct state ks;
 
 /* support crap */
 /*
@@ -604,14 +606,23 @@ int_to_threadref(unsigned char *id, int value)
 uint64_t
 get_reg(Map *map, char *reg)
 {
-	//uint64_t v;
-	//int ret = get8(map, reg, &v);
+	(void)map;
 
-	// TODO Not quite sure what do do here yet
-	syslog(0, "gdbserver", "get_reg: %s", reg);
+	int reg_idx = -1;
+	for (int i = 0; i < DBG_MAX_REG_NUM; i++) {
+		if (!strcmp(reg, regstrs[i])) {
+			reg_idx = i;
+			break;
+		}
+	}
 
-	return 0;
-	//return nil;
+	if (reg_idx == -1) {
+		syslog(0, "gdbserver", "get_reg: Unrecognised register %s.", reg);
+		return 0;
+	}
+
+	uint64_t value = arch_get_reg(&ks, reg_idx);
+	return value;
 }
 
 /*
@@ -1237,8 +1248,6 @@ wmem(uint64_t dest, int pid, void *addr, int size)
 
 	return nil;
 }
-
-static struct state ks;
 
 void
 main(int argc, char **argv)

--- a/sys/src/cmd/gdbserver/gdbstub.c
+++ b/sys/src/cmd/gdbserver/gdbstub.c
@@ -65,6 +65,34 @@ static struct state ks;
 
 static char *hex_asc = "0123456789abcdef";
 
+char* regstrs[] = {
+	[GDB_AX] = "AX",
+	[GDB_BX] = "BX",
+	[GDB_CX] = "CX",
+	[GDB_DX] = "DX",
+	[GDB_SI] = "SI",
+	[GDB_DI] = "DI",
+	[GDB_BP] = "BP",
+	[GDB_SP] = "SP",
+	[GDB_R8] = "R8",
+	[GDB_R9] = "R9",
+	[GDB_R10] = "R10",
+	[GDB_R11] = "R11",
+	[GDB_R12] = "R12",
+	[GDB_R13] = "R13",
+	[GDB_R14] = "R14",
+	[GDB_R15] = "R15",
+	[GDB_PC] = "PC",
+	[GDB_PS] = "PS",
+	[GDB_CS] = "CS",
+	[GDB_SS] = "SS",
+	[GDB_DS] = "DS",
+	[GDB_ES] = "ES",
+	[GDB_FS] = "FS",
+	[GDB_GS] = "GS",
+};
+
+
 // not reentrant, bla bla bla
 char *
 errstring(char *prefix)

--- a/sys/src/cmd/gdbserver/regsaarch64.c
+++ b/sys/src/cmd/gdbserver/regsaarch64.c
@@ -99,6 +99,12 @@ gdb_cmd_reg_set(struct state *ks)
 }
 
 uint64_t
+arch_get_reg(struct state *ks, int regnum)
+{
+	return 0;
+}
+
+uint64_t
 arch_get_pc(struct state *ks)
 {
 	// not yet.

--- a/sys/src/cmd/gdbserver/regsamd64.c
+++ b/sys/src/cmd/gdbserver/regsamd64.c
@@ -104,6 +104,21 @@ gdb_cmd_reg_set(struct state *ks)
 }
 
 uint64_t
+arch_get_reg(struct state *ks, int regnum) {
+	uint64_t value = 0;
+	if (regnum <= GDB_PC) {
+		value = ((uint64_t*)ks->gdbregs)[regnum];
+
+	} else if (regnum <= GDB_GS) {
+		uint32_t* reg32base = (uint32_t*)&(((uint64_t*)ks->gdbregs)[GDB_PS]);
+		int reg32idx = regnum - GDB_PS;
+		value = reg32base[reg32idx];
+	}
+
+	return value;
+}
+
+uint64_t
 arch_get_pc(struct state *ks)
 {
 	uint64_t pc = ((uint64_t*)ks->gdbregs)[GDB_PC];

--- a/sys/src/cmd/gdbserver/regsriscv.c
+++ b/sys/src/cmd/gdbserver/regsriscv.c
@@ -99,6 +99,12 @@ gdb_cmd_reg_set(struct state *ks)
 }
 
 uint64_t
+arch_get_reg(struct state *ks, int regnum)
+{
+	return 0;
+}
+
+uint64_t
 arch_get_pc(struct state *ks)
 {
 	// not yet.

--- a/sys/src/libmach/access.c
+++ b/sys/src/libmach/access.c
@@ -220,14 +220,14 @@ mget(Map *map, uint64_t addr, void *buf, int size)
 	for (i = j = 0; i < 2; i++) {	/* in case read crosses page */
 		k = spread(s, (void*)((uint8_t *)buf+j), size-j, off+j);
 		if (k < 0) {
-			werrstr("can't read address %llux: %r", addr);
+			werrstr("can't read address %p: %r", addr);
 			return -1;
 		}
 		j += k;
 		if (j == size)
 			return j;
 	}
-	werrstr("partial read at address %llux (size %d j %d)", addr, size, j);
+	werrstr("partial read at address %p (size %d j %d)", addr, size, j);
 	return -1;
 }
 
@@ -250,14 +250,14 @@ mput(Map *map, uint64_t addr, void *buf, int size)
 	for (i = j = 0; i < 2; i++) {	/* in case read crosses page */
 		k = write(s->fd, buf, size-j);
 		if (k < 0) {
-			werrstr("can't write address %llux: %r", addr);
+			werrstr("can't write address %p: %r", addr);
 			return -1;
 		}
 		j += k;
 		if (j == size)
 			return j;
 	}
-	werrstr("partial write at address %llux", addr);
+	werrstr("partial write at address %p", addr);
 	return -1;
 }
 


### PR DESCRIPTION
Rather important for getting the stack pointer to step out of functions.
Also tidy the formatting of some error messages that showed up alongside the bug.

Seems the list of registers is duplicated in sys/src/9/amd64/dat.h
We should probably pick one place for this to avoid the duplication.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>