### PR TITLE
Trying to get ufs_bmap.c to build (part 1)

### DIFF
--- a/sys/src/libufs/ufs/freebsd_util.h
+++ b/sys/src/libufs/ufs/freebsd_util.h
@@ -1,0 +1,60 @@
+/*-
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)queue.h	8.5 (Berkeley) 8/20/94
+ * $FreeBSD$
+ */
+
+#define	TAILQ_HEAD(name, type)						\
+struct name {								\
+	struct type *tqh_first;	/* first element */			\
+	struct type **tqh_last;	/* addr of last next element */		\
+}
+
+#define	TAILQ_ENTRY(type)						\
+struct {								\
+	struct type *tqe_next;	/* next element */			\
+	struct type **tqe_prev;	/* address of previous next element */	\
+}
+
+#define	LIST_HEAD(name, type)						\
+struct name {								\
+	struct type *lh_first;	/* first element */			\
+}
+
+#define	LIST_ENTRY(type)						\
+struct {								\
+	struct type *le_next;	/* next element */			\
+	struct type **le_prev;	/* address of previous next element */	\
+}
+
+
+typedef	int64_t daddr_t;	/* disk address */
+typedef	uint32_t ino_t;		/* inode number */
+typedef	uint32_t uid_t;		/* user id */
+typedef	uint32_t gid_t;		/* group id */

--- a/sys/src/libufs/ufs/inode.h
+++ b/sys/src/libufs/ufs/inode.h
@@ -35,8 +35,6 @@
  * $FreeBSD$
  */
 
-#include <ufs/ufs/dinode.h>
-
 /*
  * This must agree with the definition in <ufs/ufs/dir.h>.
  */

--- a/sys/src/libufs/ufs/quota.h
+++ b/sys/src/libufs/ufs/quota.h
@@ -243,9 +243,7 @@ void	quotaadj(struct dquot **, struct ufsmount *, int64_t);
 
 #else /* !_KERNEL */
 
-__BEGIN_DECLS
 int	quotactl(const char *, int, int, void *);
-__END_DECLS
 
 #endif /* _KERNEL */
 

--- a/sys/src/libufs/ufs/ufs_bmap.c
+++ b/sys/src/libufs/ufs/ufs_bmap.c
@@ -36,11 +36,13 @@
 #include <u.h>
 #include <libc.h>
 
-#include <ufs/ufs/extattr.h>
-#include <ufs/ufs/quota.h>
-#include <ufs/ufs/inode.h>
-#include <ufs/ufs/ufsmount.h>
-#include <ufs/ufs/ufs_extern.h>
+#include "extattr.h"
+#include "quota.h"
+#include "freebsd_util.h"
+#include "dinode.h"
+#include "inode.h"
+#include "ufsmount.h"
+#include "ufs_extern.h"
 
 /*
  * Bmap converts the logical block number of a file to its physical block
@@ -83,13 +85,13 @@ ufs_bmap (struct vop_bmap_args *ap)
  */
 
 int
-ufs_bmaparray(vp, bn, bnp, nbp, runp, runb)
-	struct vnode *vp;
-	ufs2_daddr_t bn;
-	ufs2_daddr_t *bnp;
-	struct buf *nbp;
-	int *runp;
-	int *runb;
+ufs_bmaparray(
+	struct vnode *vp,
+	ufs2_daddr_t bn,
+	ufs2_daddr_t *bnp,
+	struct buf *nbp,
+	int *runp,
+	int *runb)
 {
 	struct inode *ip;
 	struct buf *bp;
@@ -291,11 +293,11 @@ ufs_bmaparray(vp, bn, bnp, nbp, runp, runb)
  * once with the offset into the page itself.
  */
 int
-ufs_getlbns(vp, bn, ap, nump)
-	struct vnode *vp;
-	ufs2_daddr_t bn;
-	struct indir *ap;
-	int *nump;
+ufs_getlbns(
+	struct vnode *vp,
+	ufs2_daddr_t bn,
+	struct indir *ap,
+	int *nump)
 {
 	ufs2_daddr_t blockcnt;
 	ufs_lbn_t metalbn, realbn;


### PR DESCRIPTION
Pull some defines and typedefs from FreeBSD into freebsd_util.h.
Remove some defines that wouldn't do anything in C.
Fix includes and signatures in ufs_bmap.c.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>