### PR TITLE
Remove reference to #U in usbstart

### DIFF
--- a/rc/bin/usbstart
+++ b/rc/bin/usbstart
@@ -8,17 +8,4 @@ if(test -r '#u'/usb) {
 	if (! ps | grep -s ' usbd$')
 		usb/usbd
 }
-if not if(test -r '#U'/usb0) {
-	if(! test -r /dev/usb0)
-		bind -a '#U' /dev
-
-	# /boot/boot may have started usbd, usb/kb or usb/disk
-	if (! ps | grep -s ' usbd$')
-		usb/usbd
-	usb/usbmouse -a 2
-	if (! ps | grep -s ' kb$')
-		usb/kb -k
-	usb/usbaudio -s usbaudio.$sysname -V
-	# usb/print
-}
 exit ''


### PR DESCRIPTION
Seems to be for Inferno

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>