### PR TITLE
Add build.json for newfs

### DIFF
--- a/sys/src/cmd/newfs/build.json
+++ b/sys/src/cmd/newfs/build.json
@@ -1,0 +1,13 @@
+{
+	"newfs": {
+		"Include": [
+			"../cmd.json"
+		],
+		"Install": "/$ARCH/bin",
+		"Program": "newfs",
+		"SourceFiles": [
+			"newfs.c",
+			"mkfs.c"
+		]
+	}
+}


### PR DESCRIPTION
This doesn't build because of missing BSD headers, but it at least let's you try and build using util/build