### PR TITLE
Remove dead code in newfs

### DIFF
--- a/sys/src/cmd/newfs/mkfs.c
+++ b/sys/src/cmd/newfs/mkfs.c
@@ -36,13 +36,7 @@
  * SUCH DAMAGE.
  */
 
-#if 0
-#ifndef lint
-static char sccsid[] = "@(#)mkfs.c	8.11 (Berkeley) 5/3/95";
-#endif /* not lint */
-#endif
 #include <sys/cdefs.h>
-__FBSDID("$FreeBSD$");
 
 #include <sys/param.h>
 #include <sys/disklabel.h>

--- a/sys/src/cmd/newfs/newfs.c
+++ b/sys/src/cmd/newfs/newfs.c
@@ -36,19 +36,7 @@
  * SUCH DAMAGE.
  */
 
-#if 0
-#ifndef lint
-static const char copyright[] =
-"@(#) Copyright (c) 1983, 1989, 1993, 1994\n\
-	The Regents of the University of California.  All rights reserved.\n";
-#endif /* not lint */
-
-#ifndef lint
-static char sccsid[] = "@(#)newfs.c	8.13 (Berkeley) 5/1/95";
-#endif /* not lint */
-#endif
 #include <sys/cdefs.h>
-__FBSDID("$FreeBSD$");
 
 /*
  * newfs: friendly front end to mkfs


### PR DESCRIPTION
Remove code that was guarded by an #if 0 block in newfs, and references to
an undefined __FBSDID macro.

Signed-off-by: Dave MacFarlane <driusan@gmail.com>