### PR TITLE
newfs: Remove FreeBSD headers and add header from libufs

### DIFF
--- a/sys/src/cmd/newfs/build.json
+++ b/sys/src/cmd/newfs/build.json
@@ -1,5 +1,6 @@
 {
 	"newfs": {
+		"CFlags": ["-I", "/sys/src/libufs"],
 		"Include": [
 			"../cmd.json"
 		],

--- a/sys/src/cmd/newfs/newfs.c
+++ b/sys/src/cmd/newfs/newfs.c
@@ -36,6 +36,17 @@
  * SUCH DAMAGE.
  */
 
+#include <u.h>
+#include <libc.h>
+
+
+#include <ufs/dir.h>
+#include <ufs/dinode.h>
+#include <ffs/fs.h>
+#include <ufs/ufsmount.h>
+
+#include <ufs/freebsd_util.h>
+#if 0
 #include <sys/cdefs.h>
 
 /*
@@ -48,10 +59,6 @@
 #include <sys/file.h>
 #include <sys/mount.h>
 
-#include <ufs/ufs/dir.h>
-#include <ufs/ufs/dinode.h>
-#include <ufs/ffs/fs.h>
-#include <ufs/ufs/ufsmount.h>
 
 #include <ctype.h>
 #include <err.h>
@@ -66,6 +73,7 @@
 #include <unistd.h>
 
 #include <libutil.h>
+#endif
 
 #include "newfs.h"
 

--- a/sys/src/cmd/newfs/newfs.h
+++ b/sys/src/cmd/newfs/newfs.h
@@ -38,8 +38,6 @@
  * $FreeBSD$
  */
 
-#include <libufs.h>
-
 /*
  * The following two constants set the default block and fragment sizes.
  * Both constants must be a power of 2 and meet the following constraints:

--- a/sys/src/libufs/ufs/freebsd_util.h
+++ b/sys/src/libufs/ufs/freebsd_util.h
@@ -58,3 +58,8 @@ typedef	int64_t daddr_t;	/* disk address */
 typedef	uint32_t ino_t;		/* inode number */
 typedef	uint32_t uid_t;		/* user id */
 typedef	uint32_t gid_t;		/* group id */
+
+typedef int64_t off_t;		/* File offset */
+typedef int64_t ufs2_daddr_t;
+
+typedef int64_t intmax_t;	/* FIXME: This should probably be moved to <u.h> or replaced with a spatch */


### PR DESCRIPTION
- Add header from libufs which defines some FreeBSD types for Harvey rather
than duplicating the effort, and '#if 0'ed out the FreeBSD headers which
don't exist.
- Add a couple FreeBSD ufs types needed for newfs to libufs header

Signed-off-by: Dave MacFarlane <driusan@gmail.com>