### PR TITLE
UFS: Mounting the (disabled) softdep data

### DIFF
--- a/sys/src/9/ufs/ffs/ffs_extern.h
+++ b/sys/src/9/ufs/ffs/ffs_extern.h
@@ -40,7 +40,7 @@ typedef struct Buf Buf;
 //struct fs;
 //struct inode;
 //struct malloc_type;
-//struct mount;
+typedef struct MountPoint MountPoint;
 //struct thread;
 //struct sockaddr;
 //struct statfs;
@@ -65,9 +65,9 @@ int	ffs_checkfreefile(struct fs *, struct vnode *, ino_t);
 void	ffs_clrblock(struct fs *, uint8_t *, ufs1_daddr_t);
 void	ffs_clusteracct(struct fs *, struct cg *, ufs1_daddr_t, int);
 void	ffs_bdflush(struct bufobj *, struct buf *);
-int	ffs_copyonwrite(struct vnode *, struct buf *);
-int	ffs_flushfiles(struct mount *, int, struct thread *);
-void	ffs_fragacct(struct fs *, int, int32_t [], int);
+int	ffs_copyonwrite(struct vnode *, struct buf *);*/
+int	ffs_flushfiles(MountPoint *, int, thread *);
+/*void	ffs_fragacct(struct fs *, int, int32_t [], int);
 int	ffs_freefile(struct ufsmount *, struct fs *, struct vnode *, ino_t,
 	    int, struct workhead *);
 void	ffs_fserr(struct fs *, ino_t, char *);
@@ -79,15 +79,15 @@ int	ffs_own_mount(const struct mount *mp);
 int	ffs_reallocblks(struct vop_reallocblks_args *);
 int	ffs_realloccg(struct inode *, ufs2_daddr_t, ufs2_daddr_t,
 	    ufs2_daddr_t, int, int, int, struct ucred *, struct buf **);
-int	ffs_reload(struct mount *, struct thread *, int);
-int	ffs_sbupdate(struct ufsmount *, int, int);
-void	ffs_setblock(struct fs *, uint8_t *, ufs1_daddr_t);
-int	ffs_snapblkfree(struct fs *, struct vnode *, ufs2_daddr_t, long, ino_t,
-	    enum vtype, struct workhead *);
-void	ffs_snapremove(struct vnode *vp);
-int	ffs_snapshot(struct mount *mp, char *snapfile);
-void	ffs_snapshot_mount(struct mount *mp);
-void	ffs_snapshot_unmount(struct mount *mp);
+int	ffs_reload(struct mount *, struct thread *, int);*/
+int	ffs_sbupdate(ufsmount *, int, int);
+//void	ffs_setblock(struct fs *, uint8_t *, ufs1_daddr_t);
+int	ffs_snapblkfree(fs *, vnode *, ufs2_daddr_t, long, ino_t,
+	    Vtype, struct workhead *);
+//void	ffs_snapremove(struct vnode *vp);
+//int	ffs_snapshot(struct mount *mp, char *snapfile);
+void	ffs_snapshot_mount(MountPoint *mp);
+/*void	ffs_snapshot_unmount(struct mount *mp);
 void	process_deferred_inactive(struct mount *mp);
 void	ffs_sync_snap(struct mount *, int);
 int	ffs_syncvnode(struct vnode *vp, int waitfor, int flags);*/
@@ -95,9 +95,8 @@ int	ffs_truncate(vnode *, off_t, int, Ucred *);
 int	ffs_update(vnode *, int);
 int	ffs_valloc(vnode *, int, Ucred *, vnode **);
 
-int	ffs_vfree(struct vnode *, ino_t, int);
-#if 0
-vfs_vget_t ffs_vget;
+int	ffs_vfree(vnode *, ino_t, int);
+/*vfs_vget_t ffs_vget;
 int	ffs_vgetf(struct mount *, ino_t, int, struct vnode **, int);
 void	ffs_susp_initialize(void);
 void	ffs_susp_uninitialize(void);
@@ -110,20 +109,19 @@ void	ffs_susp_uninitialize(void);
 extern struct vop_vector ffs_vnodeops1;
 extern struct vop_vector ffs_fifoops1;
 extern struct vop_vector ffs_vnodeops2;
-extern struct vop_vector ffs_fifoops2;
+extern struct vop_vector ffs_fifoops2;*/
 
 /*
  * Soft update function prototypes.
  */
 
-int	softdep_check_suspend(struct mount *, struct vnode *,
+/*int	softdep_check_suspend(struct mount *, struct vnode *,
 	  int, int, int, int);
 void	softdep_get_depcounts(struct mount *, int *, int *);
 void	softdep_initialize(void);
-void	softdep_uninitialize(void);
-int	softdep_mount(struct vnode *, struct mount *, struct fs *,
-	    struct ucred *);
-void	softdep_unmount(struct mount *);
+void	softdep_uninitialize(void);*/
+int	softdep_mount(vnode *, MountPoint *, fs *, Ucred *);
+/*void	softdep_unmount(struct mount *);
 int	softdep_move_dependencies(struct buf *, struct buf *);
 int	softdep_flushworklist(struct mount *, int *, struct thread *);
 int	softdep_flushfiles(struct mount *, int, struct thread *);
@@ -159,9 +157,7 @@ void	softdep_journal_freeblocks(struct inode *, struct ucred *, off_t, int);
 void	softdep_journal_fsync(struct inode *);
 void	softdep_buf_append(struct buf *, struct workhead *);
 void	softdep_inode_append(struct inode *, struct ucred *, struct workhead *);
-void	softdep_freework(struct workhead *);
-
-#endif // 0
+void	softdep_freework(struct workhead *);*/
 
 /*
  * Things to request flushing in softdep_request_cleanup()

--- a/sys/src/9/ufs/ffs/ffs_snapshot.c
+++ b/sys/src/9/ufs/ffs/ffs_snapshot.c
@@ -35,73 +35,72 @@
 
 #include "u.h"
 #include "../../port/lib.h"
+#include "mem.h"
+#include "dat.h"
+#include "fns.h"
+
+#include "freebsd_util.h"
+#include "ufs_harvey.h"
 
 //#include <ufs/ufs/extattr.h>
-//#include <ufs/ufs/quota.h>
+#include "ufs/quota.h"
 //#include <ufs/ufs/ufsmount.h>
-//#include <ufs/ufs/inode.h>
+#include "ufs/inode.h"
+#include "ufs/dinode.h"
+#include "ffs/softdep.h"
 #include "ufs/ufs_extern.h"
 
-//#include <ufs/ffs/fs.h>
+#include "ffs/fs.h"
 //#include <ufs/ffs/ffs_extern.h>
 
 //#define KERNCRED thread0.td_ucred
 //#define DEBUG 1
 
 #ifdef NO_FFS_SNAPSHOT
-#if 0
 
-int 
-ffs_snapshot (struct mount *mp, char *snapfile)
+/*int 
+ffs_snapshot (MountPoint *mp, char *snapfile)
 {
 	return (EINVAL);
-}
+}*/
 
 int
-ffs_snapblkfree(fs, devvp, bno, size, inum, vtype, wkhd)
-	struct fs *fs;
-	struct vnode *devvp;
-	ufs2_daddr_t bno;
-	long size;
-	ino_t inum;
-	enum vtype vtype;
-	struct workhead *wkhd;
+ffs_snapblkfree(fs *fs, vnode *devvp, ufs2_daddr_t bno, long size, ino_t inum,
+	Vtype vtype, struct workhead *wkhd)
+{
+	return (EINVAL);
+}
+
+/*void 
+ffs_snapremove (vnode *vp)
+{
+}*/
+
+void 
+ffs_snapshot_mount (MountPoint *mp)
+{
+}
+
+/*void 
+ffs_snapshot_unmount (MountPoint *mp)
+{
+}*/
+
+void 
+ffs_snapgone (inode *ip)
+{
+}
+
+/*int 
+ffs_copyonwrite (vnode *devvp, buf *bp)
 {
 	return (EINVAL);
 }
 
 void 
-ffs_snapremove (struct vnode *vp)
+ffs_sync_snap (MountPoint *mp, int waitfor)
 {
-}
-
-void 
-ffs_snapshot_mount (struct mount *mp)
-{
-}
-
-void 
-ffs_snapshot_unmount (struct mount *mp)
-{
-}
-
-void 
-ffs_snapgone (struct inode *ip)
-{
-}
-
-int 
-ffs_copyonwrite (struct vnode *devvp, struct buf *bp)
-{
-	return (EINVAL);
-}
-
-void 
-ffs_sync_snap (struct mount *mp, int waitfor)
-{
-}
-
-#endif // 0
+}*/
 
 #else
 
@@ -1919,7 +1918,7 @@ retry:
  * Associate snapshot files when mounting.
  */
 void 
-ffs_snapshot_mount (struct mount *mp)
+ffs_snapshot_mount (MountPoint *mp)
 {
 	struct ufsmount *ump = VFSTOUFS(mp);
 	struct vnode *devvp = ump->um_devvp;

--- a/sys/src/9/ufs/ffs/ffs_softdep.c
+++ b/sys/src/9/ufs/ffs/ffs_softdep.c
@@ -38,8 +38,15 @@
  *
  *	from: @(#)ffs_softdep.c	9.59 (McKusick) 6/21/00
  */
-#include <u.h>
-#include <libc.h>
+
+#include "u.h"
+#include "../../port/lib.h"
+#include "mem.h"
+#include "dat.h"
+#include "../../port/portfns.h"
+
+#include "freebsd_util.h"
+#include "ufs_harvey.h"
 
 /*
  * For now we want the safety net that the DEBUG flag provides.
@@ -48,34 +55,38 @@
 #define DEBUG
 #endif
 
-#include <ufs/ufs/dir.h>
-#include <ufs/ufs/extattr.h>
-#include <ufs/ufs/quota.h>
-#include <ufs/ufs/inode.h>
-#include <ufs/ufs/ufsmount.h>
-#include <ufs/ffs/fs.h>
-#include <ufs/ffs/softdep.h>
-#include <ufs/ffs/ffs_extern.h>
-#include <ufs/ufs/ufs_extern.h>
+//#include <ufs/ufs/dir.h>
+//#include <ufs/ufs/extattr.h>
+//#include <ufs/ufs/quota.h>
+#include "../ufs/dinode.h"
+//#include <ufs/ufs/inode.h>
+//#include <ufs/ufs/ufsmount.h>
+#include "../ffs/fs.h"
+//#include <ufs/ffs/softdep.h>
+//#include <ufs/ffs/ffs_extern.h>
+//#include <ufs/ufs/ufs_extern.h>
 
 #define	KTR_SUJ	0	/* Define to KTR_SPARE. */
 
 #ifndef SOFTUPDATES
 
+#if 0
 int 
-softdep_flushfiles (struct mount *oldmnt, int flags, struct thread *td)
+softdep_flushfiles (MountPoint *oldmnt, int flags, thread *td)
 {
 
 	panic("softdep_flushfiles called");
 }
+#endif // 0
 
 int 
-softdep_mount (struct vnode *devvp, struct mount *mp, struct fs *fs, struct ucred *cred)
+softdep_mount (vnode *devvp, MountPoint *mp, fs *fs, Ucred *cred)
 {
 
 	return (0);
 }
 
+#if 0
 void 
 softdep_initialize (void)
 {
@@ -516,6 +527,8 @@ softdep_freework (struct workhead *wkhd)
 
 	panic("softdep_freework called");
 }
+
+#endif // 0
 
 #else
 

--- a/sys/src/9/ufs/ffs/ffs_vfsops.c
+++ b/sys/src/9/ufs/ffs/ffs_vfsops.c
@@ -42,15 +42,16 @@
 
 //#include "dir.h"
 //#include "extattr.h"
-//#include "quota.h"
-//#include "inode.h"
-#include "dinode.h"
-#include "ufs_extern.h"
+#include "ufs/quota.h"
+#include "ufs/inode.h"
+#include "ffs/softdep.h"
+#include "ufs/dinode.h"
+#include "ufs/ufs_extern.h"
 
-#include "../ffs/fs.h"
-#include "../ffs/ffs_extern.h"
+#include "ffs/fs.h"
+#include "ffs/ffs_extern.h"
 
-#include "ufsmount.h"
+#include "ufs/ufsmount.h"
 
 
 static char Ebadread[] = "bread returned wrong size";
@@ -745,10 +746,12 @@ ffs_mountfs (vnode *devvp, MountPoint *mp, thread *td)
 	int error, i, blks, /*len,*/ ronly;
 	uint64_t size;
 	int32_t *lp;
-	//struct ucred *cred;
+	Ucred *cred;
 	//struct g_consumer *cp;
 	//struct mount *nmp;
 
+	// TODO HARVEY
+	cred = nil;	// NOCRED
 	//cred = td ? td->td_ucred : NOCRED;
 	ump = nil;
 	ronly = (mp->mnt_flag & MNT_RDONLY) != 0;
@@ -994,17 +997,18 @@ ffs_mountfs (vnode *devvp, MountPoint *mp, thread *td)
 	ump->um_seqinc = fs->fs_frag;
 	//for (i = 0; i < MAXQUOTAS; i++)
 	//	ump->um_quotas[i] = NULLVP;
-#if 0
 #ifdef UFS_EXTATTR
 	ufs_extattr_uepm_init(&ump->um_extattr);
 #endif
 	/*
 	 * Set FS local "last mounted on" information (NULL pad)
 	 */
-	bzero(fs->fs_fsmnt, MAXMNTLEN);
-	strlcpy(fs->fs_fsmnt, mp->mnt_stat.f_mntonname, MAXMNTLEN);
-	mp->mnt_stat.f_iosize = fs->fs_bsize;
+	memset(fs->fs_fsmnt, 0, MAXMNTLEN);
+	// HARVEY TODO Mount name
+	//strlcpy(fs->fs_fsmnt, mp->mnt_stat.f_mntonname, MAXMNTLEN);
+	//mp->mnt_stat.f_iosize = fs->fs_bsize;
 
+#if 0
 	if (mp->mnt_flag & MNT_ROOTFS) {
 		/*
 		 * Root mount; update timestamp in mount structure.
@@ -1013,12 +1017,13 @@ ffs_mountfs (vnode *devvp, MountPoint *mp, thread *td)
 		 */
 		mp->mnt_time = fs->fs_time;
 	}
+#endif // 0
 
 	if (ronly == 0) {
-		fs->fs_mtime = time_second;
+		fs->fs_mtime = seconds();
 		if ((fs->fs_flags & FS_DOSOFTDEP) &&
 		    (error = softdep_mount(devvp, mp, fs, cred)) != 0) {
-			free(fs->fs_csp, M_UFSMNT);
+			free(fs->fs_csp);
 			ffs_flushfiles(mp, FORCECLOSE, td);
 			goto out;
 		}
@@ -1028,6 +1033,7 @@ ffs_mountfs (vnode *devvp, MountPoint *mp, thread *td)
 		fs->fs_clean = 0;
 		(void) ffs_sbupdate(ump, MNT_WAIT, 0);
 	}
+#if 0
 	/*
 	 * Initialize filesystem state information in mount struct.
 	 */
@@ -1284,12 +1290,17 @@ fail1:
 	return (error);
 }
 
+#endif // 0
+
 /*
  * Flush out all the files in a filesystem.
  */
 int 
-ffs_flushfiles (struct mount *mp, int flags, struct thread *td)
+ffs_flushfiles (MountPoint *mp, int flags, thread *td)
 {
+	int error = 0;
+	print("HARVEY TODO: %s\n", __func__);
+#if 0
 	struct ufsmount *ump;
 	int qerror, error;
 
@@ -1350,8 +1361,11 @@ ffs_flushfiles (struct mount *mp, int flags, struct thread *td)
 	vn_lock(ump->um_devvp, LK_EXCLUSIVE | LK_RETRY);
 	error = VOP_FSYNC(ump->um_devvp, MNT_WAIT, td);
 	VOP_UNLOCK(ump->um_devvp, 0);
+#endif // 0
 	return (error);
 }
+
+#if 0
 
 /*
  * Get filesystem statistics.
@@ -1833,12 +1847,17 @@ ffs_uninit (struct vfsconf *vfsp)
 	return (ret);
 }
 
+#endif // 0
+
 /*
  * Write a superblock and associated information back to disk.
  */
 int 
-ffs_sbupdate (struct ufsmount *ump, int waitfor, int suspended)
+ffs_sbupdate (ufsmount *ump, int waitfor, int suspended)
 {
+	int allerror = 0;
+	print("HARVEY TODO: %s\n", __func__);
+#if 0
 	struct fs *fs = ump->um_fs;
 	struct buf *sbbp;
 	struct buf *bp;
@@ -1909,8 +1928,11 @@ ffs_sbupdate (struct ufsmount *ump, int waitfor, int suspended)
 		bawrite(bp);
 	else if ((error = bwrite(bp)) != 0)
 		allerror = error;
+#endif // 0
 	return (allerror);
 }
+
+#if 0
 
 static int
 ffs_extattrctl(struct mount *mp, int cmd, struct vnode *filename_vp,

--- a/sys/src/9/ufs/ffs/softdep.h
+++ b/sys/src/9/ufs/ffs/softdep.h
@@ -187,7 +187,7 @@
  * per second to process the items on the queue.
  */
 
-/* LIST_HEAD(workhead, worklist);	-- declared in buf.h */
+LIST_HEAD(workhead, worklist);
 
 /*
  * Each request can be linked onto a work queue through its worklist structure.
@@ -1019,11 +1019,14 @@ LIST_HEAD(newblk_hashhead, newblk);
 LIST_HEAD(bmsafemap_hashhead, bmsafemap);
 TAILQ_HEAD(indir_hashhead, freework);
 
+#if 0
+
 /*
  * Per-filesystem soft dependency data.
  * Allocated at mount and freed at unmount.
  */
 struct mount_softdeps {
+	/* HARVEY TODO This lock is used in interrupt */
 	struct	rwlock sd_fslock;		/* softdep lock */
 	struct	workhead sd_workitem_pending;	/* softdep work queue */
 	struct	worklist *sd_worklist_tail;	/* Tail pointer for above */
@@ -1057,6 +1060,9 @@ struct mount_softdeps {
 	struct	ufsmount *sd_ump;		/* our ufsmount structure */
 	uint64_t	sd_curdeps[D_LAST + 1];		/* count of current deps */
 };
+
+#endif // 0
+
 /*
  * Flags for communicating with the syncer thread.
  */

--- a/sys/src/9/ufs/freebsd_util.h
+++ b/sys/src/9/ufs/freebsd_util.h
@@ -58,9 +58,18 @@ typedef	int64_t daddr_t;	/* disk address */
 typedef	uint32_t ino_t;		/* inode number */
 typedef	uint32_t uid_t;		/* user id */
 typedef	uint32_t gid_t;		/* group id */
-
+typedef	uint16_t nlink_t;	/* link count */
+typedef	char *caddr_t;		/* core address */
+typedef	uint16_t mode_t;	/* permissions */
 typedef int64_t off_t;		/* File offset */
-typedef int64_t ufs2_daddr_t;
+
+/*
+ * The size of physical and logical block numbers and time fields in UFS.
+ */
+typedef	int32_t	ufs1_daddr_t;
+typedef	int64_t	ufs2_daddr_t;
+typedef int64_t ufs_lbn_t;
+typedef int64_t ufs_time_t;
 
 typedef int64_t intmax_t;	/* FIXME: This should probably be moved to <u.h> or replaced with a spatch */
 
@@ -88,6 +97,12 @@ typedef int64_t intmax_t;	/* FIXME: This should probably be moved to <u.h> or re
  */
 #define	MNT_LOCAL	0x0000000000001000ULL /* filesystem is stored locally */
 
+/*
+ * Flags for various system call interfaces.
+ *
+ * waitfor flags to vfs_sync() and getfsstat()
+ */
+#define MNT_WAIT	1	/* synchronously wait for I/O to complete */
 
 /*
  * Error codes used by UFS.

--- a/sys/src/9/ufs/ufs.json
+++ b/sys/src/9/ufs/ufs.json
@@ -1,17 +1,17 @@
 {
 	"ufs": {
 		"Cflags": [
-		    "-fasm",
-		    "-I",
-		    "../ufs",
-		    "-I",
-		    "../ufs/ffs",
-		    "-I",
-		    "../ufs/ufs"
+			"-fasm",
+			"-I",
+			"../ufs",
+			"-I",
+			"../ufs/ffs",
+			"-I",
+			"../ufs/ufs",
+			"-DNO_FFS_SNAPSHOT"
 		],
 		"#SourceFiles": [
 			"../ufs/ffs/ffs_rawread.c",
-			"../ufs/ffs/ffs_softdep.c",
 			"../ufs/ffs/ffs_suspend.c",
 			"../ufs/ffs/ffs_vnops.c",
 			"../ufs/ufs/ufs_acl.c",
@@ -30,6 +30,7 @@
 			"../ufs/ffs/ffs_balloc.c",
 			"../ufs/ffs/ffs_inode.c",
 			"../ufs/ffs/ffs_snapshot.c",
+			"../ufs/ffs/ffs_softdep.c",
 			"../ufs/ffs/ffs_subr.c",
 			"../ufs/ffs/ffs_tables.c",
 			"../ufs/ffs/ffs_vfsops.c",

--- a/sys/src/9/ufs/ufs/quota.h
+++ b/sys/src/9/ufs/ufs/quota.h
@@ -87,6 +87,8 @@
 #define	Q_SETUSE	0x0900	/* set usage (64-bit version) */
 #define	Q_GETQUOTASIZE	0x0A00	/* get bit-size of quota file fields */
 
+#if 0
+
 /*
  * The following structure defines the format of the disk quota file
  * (as it appears on disk) - the file is an array of these structures
@@ -248,3 +250,4 @@ int	quotactl(const char *, int, int, void *);
 
 #endif /* _KERNEL */
 
+#endif // 0

--- a/sys/src/9/ufs/ufs_harvey.h
+++ b/sys/src/9/ufs/ufs_harvey.h
@@ -56,6 +56,13 @@ typedef struct Buf {
 
 
 /*
+ * Vnode types.  VNON means no type.
+ */
+enum vtype	{ VNON, VREG, VDIR, VBLK, VCHR, VLNK, VSOCK, VFIFO, VBAD,
+		  VMARKER };
+typedef enum vtype Vtype;
+
+/*
  * MAXBSIZE -	Filesystems are made out of blocks of at most MAXBSIZE bytes
  *		per block.  MAXBSIZE may be made larger without effecting
  *		any existing filesystems as long as it does not exceed MAXPHYS,
@@ -63,6 +70,12 @@ typedef struct Buf {
  *		filesystems which require a block size exceeding MAXBSIZE.
  */
 #define MAXBSIZE	65536	/* must be power of 2 */
+
+
+/*
+ * Flags to various vnode functions.
+ */
+#define	FORCECLOSE	0x0002	/* vflush: force file closure */
 
 
 MountPoint *newufsmount(Chan *c);


### PR DESCRIPTION
This brought in a lot of scattered changes unfortunately.  I've disabled snapshots for now (NO_FFS_SNAPSHOT).  Another slight bit of ugliness is 'struct workhead'.  Need to keep the struct due to the way the LIST_HEAD macro works.  If I change that (yes, I tried) then it breaks somewhere else that calls the macro as so: LIST_HEAD(, snapdata)....

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>