### PR TITLE
UFS Add ctl file for devufs mountpoints

### DIFF
--- a/sys/src/9/ufs/ffs/ffs_vfsops.c
+++ b/sys/src/9/ufs/ffs/ffs_vfsops.c
@@ -1166,12 +1166,18 @@ ffs_oldfscompat_write (struct fs *fs, struct ufsmount *ump)
 	}
 }
 
+#endif // 0
+
 /*
  * unmount system call
  */
-static int 
-ffs_unmount (struct mount *mp, int mntflags)
+int 
+ffs_unmount (MountPoint *mp, int mntflags)
 {
+	int error = 0;
+	print("HARVEY TODO: %s\n", __func__);
+
+#if 0
 	struct thread *td;
 	struct ufsmount *ump = VFSTOUFS(mp);
 	struct fs *fs;
@@ -1279,10 +1285,9 @@ fail1:
 	}
 #endif
 
+#endif // 0
 	return (error);
 }
-
-#endif // 0
 
 /*
  * Flush out all the files in a filesystem.

--- a/sys/src/9/ufs/ufs_harvey.h
+++ b/sys/src/9/ufs/ufs_harvey.h
@@ -86,3 +86,4 @@ void releaseufsmount(MountPoint *mp);
 void releaseufsvnode(vnode *vn);
 
 int ffs_mount(MountPoint *mp);
+int ffs_unmount(MountPoint *mp, int mntflags);


### PR DESCRIPTION
echo unmount > /dev/ufs/0/ctl
will now unmount mountpoint 0.

Also embedding the mountpoint ID in the qid path, as seen in devproc.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>