### PR TITLE
UFS Get rid of _KERNEL define

### DIFF
--- a/sys/src/9/ufs/ffs/ffs_balloc.c
+++ b/sys/src/9/ufs/ffs/ffs_balloc.c
@@ -65,8 +65,6 @@
 #include "dat.h"
 #include "fns.h"
 
-#define _KERNEL
-
 #include "freebsd_util.h"
 #include "ufs_harvey.h"
 

--- a/sys/src/9/ufs/ffs/ffs_extern.h
+++ b/sys/src/9/ufs/ffs/ffs_extern.h
@@ -30,10 +30,6 @@
  * $FreeBSD$
  */
 
-#ifndef _KERNEL
-#error "No user-serving parts inside"
-#else
-
 typedef struct Buf Buf;
 //struct cg;
 //struct fid;
@@ -193,5 +189,3 @@ struct snapdata {
 };
 
 #endif // 0
-
-#endif /* _KERNEL */

--- a/sys/src/9/ufs/ffs/ffs_subr.c
+++ b/sys/src/9/ufs/ffs/ffs_subr.c
@@ -170,9 +170,7 @@ ffs_isblock(struct fs *fs, unsigned char *cp, ufs1_daddr_t h)
 		mask = 0x01 << (h & 0x7);
 		return ((cp[h >> 3] & mask) == mask);
 	default:
-#ifdef _KERNEL
 		panic("ffs_isblock");
-#endif
 		break;
 	}
 	return (0);
@@ -195,9 +193,7 @@ ffs_isfreeblock(struct fs *fs, uint8_t *cp, ufs1_daddr_t h)
 	case 1:
 		return ((cp[h >> 3] & (0x01 << (h & 0x7))) == 0);
 	default:
-#ifdef _KERNEL
 		panic("ffs_isfreeblock");
-#endif
 		break;
 	}
 	return (0);
@@ -224,9 +220,7 @@ ffs_clrblock(struct fs *fs, uint8_t *cp, ufs1_daddr_t h)
 		cp[h >> 3] &= ~(0x01 << (h & 0x7));
 		return;
 	default:
-#ifdef _KERNEL
 		panic("ffs_clrblock");
-#endif
 		break;
 	}
 }
@@ -253,9 +247,7 @@ ffs_setblock(struct fs *fs, unsigned char *cp, ufs1_daddr_t h)
 		cp[h >> 3] |= (0x01 << (h & 0x7));
 		return;
 	default:
-#ifdef _KERNEL
 		panic("ffs_setblock");
-#endif
 		break;
 	}
 }

--- a/sys/src/9/ufs/ffs/ffs_vfsops.c
+++ b/sys/src/9/ufs/ffs/ffs_vfsops.c
@@ -38,8 +38,6 @@
 #include "freebsd_util.h"
 #include "ufs_harvey.h"
 
-#define _KERNEL
-
 //#include "dir.h"
 //#include "extattr.h"
 #include "ufs/quota.h"

--- a/sys/src/9/ufs/ufs/acl.h
+++ b/sys/src/9/ufs/ufs/acl.h
@@ -32,8 +32,6 @@
  * Support for POSIX.1e access control lists.
  */
 
-#ifdef _KERNEL
-
 int	ufs_getacl_nfs4_internal(struct vnode *vp, struct acl *aclp, struct thread *td);
 int	ufs_setacl_nfs4_internal(struct vnode *vp, struct acl *aclp, struct thread *td);
 void	ufs_sync_acl_from_inode(struct inode *ip, struct acl *acl);
@@ -42,5 +40,3 @@ void	ufs_sync_inode_from_acl(struct acl *acl, struct inode *ip);
 int	ufs_getacl(struct vop_getacl_args *);
 int	ufs_setacl(struct vop_setacl_args *);
 int	ufs_aclcheck(struct vop_aclcheck_args *);
-
-#endif /* !_KERNEL */

--- a/sys/src/9/ufs/ufs/extattr.h
+++ b/sys/src/9/ufs/ufs/extattr.h
@@ -99,8 +99,6 @@ struct extattr {
 #define	EXTATTR_BASE_LENGTH(eap) \
 	roundup2((sizeof(struct extattr) - 1 + (eap)->ea_namelength), 8)
 
-#ifdef _KERNEL
-
 struct vnode;
 LIST_HEAD(ufs_extattr_list_head, ufs_extattr_list_entry);
 struct ufs_extattr_list_entry {
@@ -134,6 +132,3 @@ int	ufs_getextattr(struct vop_getextattr_args *ap);
 int	ufs_deleteextattr(struct vop_deleteextattr_args *ap);
 int	ufs_setextattr(struct vop_setextattr_args *ap);
 void	ufs_extattr_vnode_inactive(struct vnode *vp, struct thread *td);
-
-#endif /* !_KERNEL */
-

--- a/sys/src/9/ufs/ufs/inode.h
+++ b/sys/src/9/ufs/ufs/inode.h
@@ -130,8 +130,6 @@ struct inode {
 #define	i_din1 dinode_u.din1
 #define	i_din2 dinode_u.din2
 
-#ifdef _KERNEL
-
 #define	ITOUMP(ip)	((ip)->i_ump)
 #define	ITODEV(ip)	(ITOUMP(ip)->um_dev)
 #define	ITODEVVP(ip)	(ITOUMP(ip)->um_devvp)
@@ -195,5 +193,4 @@ struct ufid {
 	uint32_t  ufid_ino;	/* File number (ino). */
 	uint32_t  ufid_gen;	/* Generation number. */
 };
-#endif /* _KERNEL */
 

--- a/sys/src/9/ufs/ufs/quota.h
+++ b/sys/src/9/ufs/ufs/quota.h
@@ -131,8 +131,6 @@ struct dqhdr64 {
 	char	  dqh_unused[44];	/* reserved for future extension */
 };
 
-#ifdef _KERNEL
-
 /*
  * The following structure records disk usage for a user or group on a
  * filesystem. There is one allocated for each quota that exists on any
@@ -244,10 +242,6 @@ void	quotarele(struct dquot **);
 void	quotaadj(struct dquot **, struct ufsmount *, int64_t);
 #endif /* SOFTUPDATES */
 
-#else /* !_KERNEL */
-
 int	quotactl(const char *, int, int, void *);
-
-#endif /* _KERNEL */
 
 #endif // 0

--- a/sys/src/9/ufs/ufs/ufs_lookup.c
+++ b/sys/src/9/ufs/ufs/ufs_lookup.c
@@ -43,8 +43,6 @@
 #include "freebsd_util.h"
 #include "ufs_harvey.h"
 
-#define _KERNEL
-
 //#include <ufs/ufs/extattr.h>
 #include "ufs/quota.h"
 #include "ufs/inode.h"

--- a/sys/src/9/ufs/ufs/ufsmount.h
+++ b/sys/src/9/ufs/ufs/ufsmount.h
@@ -41,8 +41,6 @@ struct ufs_args {
 
 #endif // 0
 
-#ifdef _KERNEL
-
 #ifdef MALLOC_DECLARE
 MALLOC_DECLARE(M_UFSMNT);
 #endif
@@ -140,5 +138,3 @@ typedef struct ufsmount {
 #define	blkptrtodb(ump, b)		((b) << (ump)->um_bptrtodb)
 #define	is_sequential(ump, a, b)	((b) == (a) + ump->um_seqinc)
 #endif // 0
-#endif /* _KERNEL */
-


### PR DESCRIPTION
...all of this is in the kernel anyway.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>