### PR TITLE
Use ID rather than mount name for UFS

### DIFF
--- a/sys/src/9/port/devufs.c
+++ b/sys/src/9/port/devufs.c
@@ -191,7 +191,9 @@ ufsread(Chan *c, void *a, int32_t n, int64_t offset)
 static MountPoint*
 mountufs(Chan* c)
 {
-	MountPoint *mp = newufsmount(c);
+	// TODO Use real IDs eventually
+	int id = 0;
+	MountPoint *mp = newufsmount(c, id);
 	if (mp == nil) {
 		print("couldn't prepare UFS mount\n");
 		error(Eufsmount);

--- a/sys/src/9/ufs/ffs/ffs_vfsops.c
+++ b/sys/src/9/ufs/ffs/ffs_vfsops.c
@@ -751,7 +751,6 @@ ffs_mountfs (vnode *devvp, MountPoint *mp, thread *td)
 	int32_t *lp;
 	Ucred *cred;
 	//struct g_consumer *cp;
-	//struct mount *nmp;
 
 	// TODO HARVEY
 	cred = nil;	// NOCRED
@@ -921,17 +920,7 @@ ffs_mountfs (vnode *devvp, MountPoint *mp, thread *td)
 	memset(fs->fs_contigdirs, 0, size);
 	fs->fs_active = nil;
 	mp->mnt_data = ump;
-	// TODO HARVEY - maybe we won't need this
-	/*mp->mnt_stat.f_fsid.val[0] = fs->fs_id[0];
-	mp->mnt_stat.f_fsid.val[1] = fs->fs_id[1];
-	nmp = nil;
-	if (fs->fs_id[0] == 0 || fs->fs_id[1] == 0 ||
-	    (nmp = vfs_getvfs(&mp->mnt_stat.f_fsid))) {
-		if (nmp)
-			vfs_rel(nmp);
-		vfs_getnewfsid(mp);
-	}*/
-	//mp->mnt_maxsymlinklen = fs->fs_maxsymlinklen;
+	mp->mnt_maxsymlinklen = fs->fs_maxsymlinklen;
 	qlock(&mp->mnt_lock);
 	mp->mnt_flag |= MNT_LOCAL;
 	qunlock(&mp->mnt_lock);
@@ -1013,13 +1002,7 @@ ffs_mountfs (vnode *devvp, MountPoint *mp, thread *td)
 #ifdef UFS_EXTATTR
 	ufs_extattr_uepm_init(&ump->um_extattr);
 #endif
-	/*
-	 * Set FS local "last mounted on" information (NULL pad)
-	 */
-	memset(fs->fs_fsmnt, 0, MAXMNTLEN);
-	// HARVEY TODO Mount name
-	//strlcpy(fs->fs_fsmnt, mp->mnt_stat.f_mntonname, MAXMNTLEN);
-	//mp->mnt_stat.f_iosize = fs->fs_bsize;
+	mp->mnt_stat.f_iosize = fs->fs_bsize;
 
 #if 0
 	if (mp->mnt_flag & MNT_ROOTFS) {

--- a/sys/src/9/ufs/ffs/fs.h
+++ b/sys/src/9/ufs/ffs/fs.h
@@ -362,7 +362,7 @@ typedef struct Fs {
 
 /* Sanity checking. */
 #ifdef CTASSERT
-CTASSERT(sizeof(struct fs) == 1376);
+CTASSERT(sizeof(Fs) == 1376);
 #endif
 
 /*

--- a/sys/src/9/ufs/ufs/ufsmount.h
+++ b/sys/src/9/ufs/ufs/ufsmount.h
@@ -30,17 +30,6 @@
  * $FreeBSD$
  */
 
-#if 0
-/*
- * Arguments to mount UFS-based filesystems
- */
-struct ufs_args {
-	char	*fspec;			/* block special device to mount */
-	struct	oexport_args export;	/* network export information */
-};
-
-#endif // 0
-
 #ifdef MALLOC_DECLARE
 MALLOC_DECLARE(M_UFSMNT);
 #endif

--- a/sys/src/9/ufs/ufs_harvey.c
+++ b/sys/src/9/ufs/ufs_harvey.c
@@ -19,11 +19,12 @@
 
 
 MountPoint*
-newufsmount(Chan *c)
+newufsmount(Chan *c, int id)
 {
 	// TODO HARVEY - Implement caching
 	MountPoint *mp = mallocz(sizeof(MountPoint), 1);
 	mp->chan = c;
+	mp->id = id;
 	return mp;
 }
 

--- a/sys/src/9/ufs/ufs_harvey.h
+++ b/sys/src/9/ufs/ufs_harvey.h
@@ -16,12 +16,22 @@ typedef struct thread thread;
 typedef struct inode inode;
 
 
+/*
+ * filesystem statistics
+ */
+typedef struct statfs {
+	uint64_t f_iosize;		/* optimal transfer block size */
+} StatFs;
+
 /* Wrapper for a UFS mount.  Should support reading from both kernel and user
  * space (eventually)
  */
 typedef struct MountPoint {
 	ufsmount	*mnt_data;
 	Chan		*chan;
+	int		id;
+	StatFs		mnt_stat;		/* cache of filesystem stats */
+	int		mnt_maxsymlinklen;	/* max size of short symlink */
 
 	uint64_t	mnt_flag;		/* (i) flags shared with user */
 	QLock		mnt_lock;		/* (mnt_mtx) structure lock */
@@ -139,7 +149,7 @@ typedef struct vnode {
 #define	FORCECLOSE	0x0002	/* vflush: force file closure */
 
 
-MountPoint *newufsmount(Chan *c);
+MountPoint *newufsmount(Chan *c, int id);
 
 vnode* newufsvnode();
 


### PR DESCRIPTION
- Don't need code to identify mount as UFS since it's the only choice
- Add in some stats and parameters from fs that we will need later
- A couple of small bits of tidying

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>