### PR TITLE
UFS Mountpoint vnode management, sharing

### DIFF
--- a/sys/src/9/ufs/ufs.json
+++ b/sys/src/9/ufs/ufs.json
@@ -34,7 +34,8 @@
 			"../ufs/ufs/ufs_lookup.c",
 			"../ufs/ufs/ufs_vfsops.c",
 			"../ufs/ufs/ufs_vnops.c",
-			"../ufs/ufs_harvey.c"
+			"../ufs/ufs_harvey.c",
+			"../ufs/ufs_mountpoint.c"
 		]
 	}
 }

--- a/sys/src/9/ufs/ufs_ext.h
+++ b/sys/src/9/ufs/ufs_ext.h
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the Harvey operating system.  It is subject to the
+ * license terms of the GNU GPL v2 in LICENSE.gpl found in the top-level
+ * directory of this distribution and at http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * No part of Harvey operating system, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.gpl file.
+ */
+
+// Functions to be exposed outside the UFS code (e.g. to devufs)
+
+typedef struct Chan Chan;
+typedef struct MountPoint MountPoint;
+typedef struct ufsmount ufsmount;
+typedef struct vnode vnode;
+
+
+/*
+ * filesystem statistics
+ */
+typedef struct statfs {
+	uint64_t f_iosize;		/* optimal transfer block size */
+} StatFs;
+
+
+/* Wrapper for a UFS mount.  Should support reading from both kernel and user
+ * space (eventually)
+ */
+typedef struct MountPoint {
+	ufsmount	*mnt_data;
+	Chan		*chan;
+	int		id;
+	StatFs		mnt_stat;		/* cache of filesystem stats */
+	int		mnt_maxsymlinklen;	/* max size of short symlink */
+
+	uint64_t	mnt_flag;	/* (i) flags shared with user */
+	QLock		mnt_lock;	/* (mnt_mtx) structure lock */
+
+	QLock		vnodes_lock;	/* lock on vnodes in use & freelist */
+	vnode		*vnodes;	/* vnode cache */
+	vnode		*free_vnodes;	/* vnode freelist */
+} MountPoint;
+
+
+
+MountPoint *newufsmount(Chan *c, int id);
+void releaseufsmount(MountPoint *mp);
+int countvnodes(vnode *vn);
+
+int ffs_mount(MountPoint *mp);
+int ffs_unmount(MountPoint *mp, int mntflags);
+
+// TODO HARVEY Are these here temporarily?
+int ufs_root(MountPoint *mp, int flags, vnode **vpp);
+int ufs_lookup(MountPoint *mp);

--- a/sys/src/9/ufs/ufs_harvey.h
+++ b/sys/src/9/ufs/ufs_harvey.h
@@ -109,7 +109,6 @@ typedef struct vnode {
 	 * Fields which define the identity of the vnode.  These fields are
 	 * owned by the filesystem (XXX: and vgone() ?)
 	 */
-	const char 	*v_tag;		/* u type of underlying data */
 	inode		*v_data;
 	MountPoint	*v_mount;
 	

--- a/sys/src/9/ufs/ufs_mountpoint.c
+++ b/sys/src/9/ufs/ufs_mountpoint.c
@@ -130,7 +130,7 @@ getfreevnode(MountPoint *mp)
 
         // Clear out
         memset(vn, 0, sizeof(vnode));
-        vn->m_mount = mp;
+        vn->v_mount = mp;
 
         if (mp->vnodes != nil) {
                 mp->vnodes->prev = vn;

--- a/sys/src/9/ufs/ufs_mountpoint.c
+++ b/sys/src/9/ufs/ufs_mountpoint.c
@@ -1,0 +1,180 @@
+/*
+ * This file is part of the Harvey operating system.  It is subject to the
+ * license terms of the GNU GPL v2 in LICENSE.gpl found in the top-level
+ * directory of this distribution and at http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * No part of Harvey operating system, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.gpl file.
+ */
+
+
+#include "u.h"
+#include "../../port/lib.h"
+#include "mem.h"
+#include "dat.h"
+#include "fns.h"
+
+#include "freebsd_util.h"
+#include "ufs_harvey.h"
+#include "ufs_ext.h"
+
+#include "ufs/quota.h"
+#include "ufs/inode.h"
+
+
+const static int VnodeFreelistBatchSize = 1000;
+
+static vnode*
+alloc_freelist()
+{
+        vnode *head = nil;
+        vnode *curr = nil;
+
+        for (int i = 0; i < VnodeFreelistBatchSize; i++) {
+                vnode *vn = mallocz(sizeof(vnode), 1);
+                if (vn == nil) {
+                       break;
+                }
+
+                if (head == nil) {
+                        head = vn;
+                }
+
+                vn->prev = curr;
+                if (curr != nil) {
+                        curr->next = vn;
+                }
+
+                curr = vn;
+        }
+        return head;
+}
+
+MountPoint*
+newufsmount(Chan *c, int id)
+{
+        MountPoint *mp = mallocz(sizeof(MountPoint), 1);
+        mp->chan = c;
+        mp->free_vnodes = nil;
+        mp->id = id;
+        return mp;
+}
+
+void
+releaseufsmount(MountPoint *mp)
+{
+        // No need to unlock later, since we're freeing mp
+        qlock(&mp->vnodes_lock);
+
+        // TODO HARVEY What if there are referenced vnodes?
+
+        vnode *vntofree = nil;
+        vnode *vn = mp->vnodes;
+        while (vn) {
+                vntofree = vn;
+                vn = vn->next;
+                free(vntofree);
+        }
+
+        vn = mp->free_vnodes;
+        while (vn) {
+                vntofree = vn;
+                vn = vn->next;
+                free(vntofree);
+        }
+
+        free(mp);
+}
+
+vnode*
+findvnode(MountPoint *mp, ino_t ino)
+{
+        vnode *vn = nil;
+
+        qlock(&mp->vnodes_lock);
+
+        // Check for existing vnode
+        for (vn = mp->vnodes; vn != nil; vn = vn->next) {
+                if (vn->v_data->i_number == ino) {
+                        break;
+                }
+        }
+
+        if (vn != nil) {
+                incref(&vn->ref);
+        }
+
+        qunlock(&mp->vnodes_lock);
+
+        return vn;
+}
+
+vnode*
+getfreevnode(MountPoint *mp)
+{
+        qlock(&mp->vnodes_lock);
+
+        if (mp->free_vnodes == nil) {
+                mp->free_vnodes = alloc_freelist();
+                if (mp->free_vnodes == nil) {
+                        return nil;
+                }
+        }
+
+        vnode *vn = mp->free_vnodes;
+
+        // Move from freelist to vnodes
+        mp->free_vnodes = vn->next;
+        mp->free_vnodes->prev = nil;
+
+        if (mp->vnodes != nil) {
+                mp->vnodes->prev = vn;
+        }
+        vn->next = mp->vnodes;
+        vn->prev = nil;
+
+        incref(&vn->ref);
+
+        mp->vnodes = vn;
+
+        qunlock(&mp->vnodes_lock);
+
+        return vn;
+}
+
+void
+releasevnode(MountPoint *mp, vnode *vn)
+{
+        qlock(&mp->vnodes_lock);
+
+        if (decref(&vn->ref) == 0) {
+                // Remove vnode from vnodes list
+                if (vn->prev != nil) {
+                       vn->prev->next = vn->next;
+                }
+                if (vn->next != nil) {
+                        vn->next->prev = vn->prev;
+                }
+                if (mp->vnodes == vn) {
+                        mp->vnodes = vn->next;
+                }
+
+                // Return to free list
+                vn->next = mp->free_vnodes;
+                mp->free_vnodes->prev = vn;
+                mp->free_vnodes = vn;
+                vn->prev = nil;
+        }
+
+        qunlock(&mp->vnodes_lock);
+}
+
+int
+countvnodes(vnode* vn)
+{
+        int n = 0;
+        for (; vn != nil; vn = vn->next, n++)
+                ;
+        return n;
+}

--- a/sys/src/9/ufs/ufs_mountpoint.c
+++ b/sys/src/9/ufs/ufs_mountpoint.c
@@ -28,157 +28,160 @@ const static int VnodeFreelistBatchSize = 1000;
 static vnode*
 alloc_freelist()
 {
-        vnode *head = nil;
-        vnode *curr = nil;
+	vnode *head = nil;
+	vnode *curr = nil;
 
-        for (int i = 0; i < VnodeFreelistBatchSize; i++) {
-                vnode *vn = mallocz(sizeof(vnode), 1);
-                if (vn == nil) {
-                       break;
-                }
+	for (int i = 0; i < VnodeFreelistBatchSize; i++) {
+		vnode *vn = mallocz(sizeof(vnode), 1);
+		if (vn == nil) {
+		       break;
+		}
 
-                if (head == nil) {
-                        head = vn;
-                }
+		if (head == nil) {
+			head = vn;
+		}
 
-                vn->prev = curr;
-                if (curr != nil) {
-                        curr->next = vn;
-                }
+		vn->prev = curr;
+		if (curr != nil) {
+			curr->next = vn;
+		}
 
-                curr = vn;
-        }
-        return head;
+		curr = vn;
+	}
+	return head;
 }
 
 MountPoint*
 newufsmount(Chan *c, int id)
 {
-        MountPoint *mp = mallocz(sizeof(MountPoint), 1);
-        mp->chan = c;
-        mp->free_vnodes = nil;
-        mp->id = id;
-        return mp;
+	MountPoint *mp = mallocz(sizeof(MountPoint), 1);
+	mp->chan = c;
+	mp->free_vnodes = nil;
+	mp->id = id;
+	return mp;
 }
 
 void
 releaseufsmount(MountPoint *mp)
 {
-        // No need to unlock later, since we're freeing mp
-        qlock(&mp->vnodes_lock);
+	// No need to unlock later, since we're freeing mp
+	qlock(&mp->vnodes_lock);
 
-        // TODO HARVEY What if there are referenced vnodes?
+	// TODO HARVEY What if there are referenced vnodes?
+	// Ron's suggestion: you'd probably have a ref in the mountpoint and
+	// sleep on it until it went to zero maybe? Not sure.
 
-        vnode *vntofree = nil;
-        vnode *vn = mp->vnodes;
-        while (vn) {
-                vntofree = vn;
-                vn = vn->next;
-                free(vntofree);
-        }
+	vnode *vntofree = nil;
+	vnode *vn = mp->vnodes;
+	while (vn) {
+		vntofree = vn;
+		vn = vn->next;
+		free(vntofree);
+	}
 
-        vn = mp->free_vnodes;
-        while (vn) {
-                vntofree = vn;
-                vn = vn->next;
-                free(vntofree);
-        }
+	vn = mp->free_vnodes;
+	while (vn) {
+		vntofree = vn;
+		vn = vn->next;
+		free(vntofree);
+	}
 
-        free(mp);
+	free(mp);
 }
 
 vnode*
 findvnode(MountPoint *mp, ino_t ino)
 {
-        vnode *vn = nil;
+	vnode *vn = nil;
 
-        qlock(&mp->vnodes_lock);
+	qlock(&mp->vnodes_lock);
 
-        // Check for existing vnode
-        for (vn = mp->vnodes; vn != nil; vn = vn->next) {
-                if (vn->v_data->i_number == ino) {
-                        break;
-                }
-        }
+	// Check for existing vnode
+	for (vn = mp->vnodes; vn != nil; vn = vn->next) {
+		if (vn->v_data->i_number == ino) {
+			break;
+		}
+	}
 
-        if (vn != nil) {
-                incref(&vn->ref);
-        }
+	if (vn != nil) {
+		incref(&vn->ref);
+	}
 
-        qunlock(&mp->vnodes_lock);
+	qunlock(&mp->vnodes_lock);
 
-        return vn;
+	return vn;
 }
 
 vnode*
 getfreevnode(MountPoint *mp)
 {
-        qlock(&mp->vnodes_lock);
+	qlock(&mp->vnodes_lock);
 
-        if (mp->free_vnodes == nil) {
-                mp->free_vnodes = alloc_freelist();
-                if (mp->free_vnodes == nil) {
-                        return nil;
-                }
-        }
+	if (mp->free_vnodes == nil) {
+		mp->free_vnodes = alloc_freelist();
+		if (mp->free_vnodes == nil) {
+			qunlock(&mp->vnodes_lock);
+			return nil;
+		}
+	}
 
-        vnode *vn = mp->free_vnodes;
+	vnode *vn = mp->free_vnodes;
 
-        // Move from freelist to vnodes
-        mp->free_vnodes = vn->next;
-        mp->free_vnodes->prev = nil;
+	// Move from freelist to vnodes
+	mp->free_vnodes = vn->next;
+	mp->free_vnodes->prev = nil;
 
-        // Clear out
-        memset(vn, 0, sizeof(vnode));
-        vn->v_mount = mp;
+	// Clear out
+	memset(vn, 0, sizeof(vnode));
+	vn->v_mount = mp;
 
-        if (mp->vnodes != nil) {
-                mp->vnodes->prev = vn;
-        }
-        vn->next = mp->vnodes;
-        vn->prev = nil;
+	if (mp->vnodes != nil) {
+		mp->vnodes->prev = vn;
+	}
+	vn->next = mp->vnodes;
+	vn->prev = nil;
 
-        incref(&vn->ref);
+	incref(&vn->ref);
 
-        mp->vnodes = vn;
+	mp->vnodes = vn;
 
-        qunlock(&mp->vnodes_lock);
+	qunlock(&mp->vnodes_lock);
 
-        return vn;
+	return vn;
 }
 
 void
 releasevnode(MountPoint *mp, vnode *vn)
 {
-        qlock(&mp->vnodes_lock);
+	qlock(&mp->vnodes_lock);
 
-        if (decref(&vn->ref) == 0) {
-                // Remove vnode from vnodes list
-                if (vn->prev != nil) {
-                       vn->prev->next = vn->next;
-                }
-                if (vn->next != nil) {
-                        vn->next->prev = vn->prev;
-                }
-                if (mp->vnodes == vn) {
-                        mp->vnodes = vn->next;
-                }
+	if (decref(&vn->ref) == 0) {
+		// Remove vnode from vnodes list
+		if (vn->prev != nil) {
+		       vn->prev->next = vn->next;
+		}
+		if (vn->next != nil) {
+			vn->next->prev = vn->prev;
+		}
+		if (mp->vnodes == vn) {
+			mp->vnodes = vn->next;
+		}
 
-                // Return to free list
-                vn->next = mp->free_vnodes;
-                mp->free_vnodes->prev = vn;
-                mp->free_vnodes = vn;
-                vn->prev = nil;
-        }
+		// Return to free list
+		vn->next = mp->free_vnodes;
+		mp->free_vnodes->prev = vn;
+		mp->free_vnodes = vn;
+		vn->prev = nil;
+	}
 
-        qunlock(&mp->vnodes_lock);
+	qunlock(&mp->vnodes_lock);
 }
 
 int
 countvnodes(vnode* vn)
 {
-        int n = 0;
-        for (; vn != nil; vn = vn->next, n++)
-                ;
-        return n;
+	int n = 0;
+	for (; vn != nil; vn = vn->next, n++)
+		;
+	return n;
 }

--- a/sys/src/9/ufs/ufs_mountpoint.c
+++ b/sys/src/9/ufs/ufs_mountpoint.c
@@ -128,6 +128,10 @@ getfreevnode(MountPoint *mp)
         mp->free_vnodes = vn->next;
         mp->free_vnodes->prev = nil;
 
+        // Clear out
+        memset(vn, 0, sizeof(vnode));
+        vn->m_mount = mp;
+
         if (mp->vnodes != nil) {
                 mp->vnodes->prev = vn;
         }

--- a/sys/src/9/ufs/ufs_mountpoint.h
+++ b/sys/src/9/ufs/ufs_mountpoint.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the Harvey operating system.  It is subject to the
+ * license terms of the GNU GPL v2 in LICENSE.gpl found in the top-level
+ * directory of this distribution and at http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * No part of Harvey operating system, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.gpl file.
+ */
+
+
+typedef struct Chan Chan;
+typedef struct ufsmount ufsmount;
+typedef struct vnode vnode;
+
+
+/*
+ * filesystem statistics
+ */
+typedef struct statfs {
+	uint64_t f_iosize;		/* optimal transfer block size */
+} StatFs;
+
+
+/* Wrapper for a UFS mount.  Should support reading from both kernel and user
+ * space (eventually)
+ */
+typedef struct MountPoint {
+	ufsmount	*mnt_data;
+	Chan		*chan;
+	int		id;
+	StatFs		mnt_stat;		/* cache of filesystem stats */
+	int		mnt_maxsymlinklen;	/* max size of short symlink */
+
+	uint64_t	mnt_flag;	/* (i) flags shared with user */
+	QLock		mnt_lock;	/* (mnt_mtx) structure lock */
+
+	QLock		vnodes_lock;	/* lock on vnodes in use & freelist */
+	vnode		*vnodes;	/* vnode cache */
+	vnode		*free_vnodes;	/* vnode freelist */
+} MountPoint;
+
+
+vnode* findvnode(MountPoint *mp, ino_t ino);
+vnode* getfreevnode(MountPoint *mp);
+void releasevnode(MountPoint *mp, vnode *vn);


### PR DESCRIPTION
- ffs_vgetf will get an existing vnode or pick one from freelist
- vnodes for same inode are now shared and reference counted
- freelist of vnodes maintained on mountpoint
- vnode lists on mountpoint protected by qlock
- added stats file to mountpoint
- started to tidy up code with ufs_ext.h for externally facing definitions

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>