### PR TITLE
Get libufs/block.c compiling without errors + 1st pass at ufsdat.h

### DIFF
--- a/sys/include/ufs/freebsd_util.h
+++ b/sys/include/ufs/freebsd_util.h
@@ -59,10 +59,7 @@ typedef	uint32_t ino_t;		/* inode number */
 typedef	uint32_t uid_t;		/* user id */
 typedef	uint32_t gid_t;		/* group id */
 typedef	uint16_t nlink_t;	/* link count */
-typedef	char *caddr_t;		/* core address */
 typedef	uint16_t mode_t;	/* permissions */
-typedef int64_t off_t;		/* File offset */
-typedef	uint32_t ino_t;		/* inode number */
 
 /*
  * The size of physical and logical block numbers and time fields in UFS.

--- a/sys/include/ufs/libufs.h
+++ b/sys/include/ufs/libufs.h
@@ -27,9 +27,6 @@
  * $FreeBSD$
  */
 
-#ifndef	__LIBUFS_H__
-#define	__LIBUFS_H__
-
 /*
  * libufs structures.
  */
@@ -37,7 +34,7 @@
 /*
  * userland ufs disk.
  */
-struct uufsd {
+typedef struct Uufsd {
 	const char *d_name;	/* disk name */
 	int d_ufs;		/* decimal UFS version */
 	int d_fd;		/* raw device file descriptor */
@@ -48,12 +45,12 @@ struct uufsd {
 	ino_t d_inomin;		/* low inode */
 	ino_t d_inomax;		/* high inode */
 	union {
-		struct fs d_fs;	/* filesystem information */
+		Fs d_fs;	/* filesystem information */
 		char d_sb[MAXBSIZE];
 				/* superblock as buffer */
 	} d_sbunion;
 	union {
-		struct cg d_cg;	/* cylinder group */
+		Cg d_cg;	/* cylinder group */
 		char d_buf[MAXBSIZE];
 				/* cylinder group storage */
 	} d_cgunion;
@@ -64,33 +61,8 @@ struct uufsd {
 #define	d_fs	d_sbunion.d_fs
 #define	d_sb	d_sbunion.d_sb
 #define	d_cg	d_cgunion.d_cg
-};
+} Uufsd;
 
-/*
- * libufs macros (internal, non-exported).
- */
-#ifdef	_LIBUFS
-/*
- * Trace steps through libufs, to be used at entry and erroneous return.
- */
-static inline void
-ERROR(struct uufsd *u, const char *str)
-{
-
-#ifdef	_LIBUFS_DEBUGGING
-	if (str != NULL) {
-		fprintf(stderr, "libufs: %s", str);
-		if (errno != 0)
-			fprintf(stderr, ": %s", strerror(errno));
-		fprintf(stderr, "\n");
-	}
-#endif
-	if (u != NULL)
-		u->d_error = str;
-}
-#endif	/* _LIBUFS */
-
-__BEGIN_DECLS
 
 /*
  * libufs prototypes.
@@ -99,51 +71,47 @@ __BEGIN_DECLS
 /*
  * block.c
  */
-ssize_t bread(struct uufsd *, ufs2_daddr_t, void *, size_t);
-ssize_t bwrite(struct uufsd *, ufs2_daddr_t, const void *, size_t);
-int berase(struct uufsd *, ufs2_daddr_t, ufs2_daddr_t);
+int32_t bread(Uufsd *, ufs2_daddr_t, void *, size_t);
+int32_t bwrite(Uufsd *, ufs2_daddr_t, const void *, size_t);
+void libufserror(Uufsd *u, const char *str);
 
 /*
  * cgroup.c
  */
-ufs2_daddr_t cgballoc(struct uufsd *);
-int cgbfree(struct uufsd *, ufs2_daddr_t, long);
-ino_t cgialloc(struct uufsd *);
-int cgread(struct uufsd *);
-int cgread1(struct uufsd *, int);
-int cgwrite(struct uufsd *);
-int cgwrite1(struct uufsd *, int);
+ufs2_daddr_t cgballoc(Uufsd *);
+int cgbfree(Uufsd *, ufs2_daddr_t, long);
+ino_t cgialloc(Uufsd *);
+int cgread(Uufsd *);
+int cgread1(Uufsd *, int);
+int cgwrite(Uufsd *);
+int cgwrite1(Uufsd *, int);
 
 /*
  * inode.c
  */
-int getino(struct uufsd *, void **, ino_t, int *);
-int putino(struct uufsd *);
+int getino(Uufsd *, void **, ino_t, int *);
+int putino(Uufsd *);
 
 /*
  * sblock.c
  */
-int sbread(struct uufsd *);
-int sbwrite(struct uufsd *, int);
+int sbread(Uufsd *);
+int sbwrite(Uufsd *, int);
 
 /*
  * type.c
  */
-int ufs_disk_close(struct uufsd *);
-int ufs_disk_fillout(struct uufsd *, const char *);
-int ufs_disk_fillout_blank(struct uufsd *, const char *);
-int ufs_disk_write(struct uufsd *);
+int ufs_disk_close(Uufsd *);
+int ufs_disk_fillout(Uufsd *, const char *);
+int ufs_disk_fillout_blank(Uufsd *, const char *);
+int ufs_disk_write(Uufsd *);
 
 /*
  * ffs_subr.c
  */
-void	ffs_clrblock(struct fs *, u_char *, ufs1_daddr_t);
-void	ffs_clusteracct(struct fs *, struct cg *, ufs1_daddr_t, int);
-void	ffs_fragacct(struct fs *, int, int32_t [], int);
-int	ffs_isblock(struct fs *, u_char *, ufs1_daddr_t);
-int	ffs_isfreeblock(struct fs *, u_char *, ufs1_daddr_t);
-void	ffs_setblock(struct fs *, u_char *, ufs1_daddr_t);
-
-__END_DECLS
-
-#endif	/* __LIBUFS_H__ */
+void	ffs_clrblock(Fs *, uint8_t *, ufs1_daddr_t);
+void	ffs_clusteracct(Fs *, Cg *, ufs1_daddr_t, int);
+void	ffs_fragacct(Fs *, int, int32_t [], int);
+int	ffs_isblock(Fs *, uint8_t *, ufs1_daddr_t);
+int	ffs_isfreeblock(Fs *, uint8_t *, ufs1_daddr_t);
+void	ffs_setblock(Fs *, uint8_t *, ufs1_daddr_t);

--- a/sys/include/ufs/ufsdat.h
+++ b/sys/include/ufs/ufsdat.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 1982, 1986, 1989, 1993
+ * Copyright (c) 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,69 +26,19 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- *	@(#)ffs_subr.c	8.5 (Berkeley) 3/21/95
+ *	@(#)queue.h	8.5 (Berkeley) 8/20/94
+ * $FreeBSD$
  */
 
-#include "u.h"
-#include "../../port/lib.h"
-#include "mem.h"
-#include "dat.h"
-#include "fns.h"
-
-#include <ufs/ufsdat.h>
-#include <ufs/freebsd_util.h>
-#include "ufs_harvey.h"
-
-#include "ufs/quota.h"
-#include <ffs/fs.h>
-#include "ufs/ufsmount.h"
-#include "ufs/inode.h"
-#include "ufs/dinode.h"
+typedef char *caddr_t;		/* core address */
+typedef int64_t off_t;		/* File offset */
+typedef uint32_t ino_t;		/* inode number */
 
 /*
- * Return buffer with the contents of block "offset" from the beginning of
- * directory "ip".  If "res" is non-zero, fill it in with a pointer to the
- * remaining space in the directory.
+ * MAXBSIZE -	Filesystems are made out of blocks of at most MAXBSIZE bytes
+ *		per block.  MAXBSIZE may be made larger without effecting
+ *		any existing filesystems as long as it does not exceed MAXPHYS,
+ *		and may be made smaller at the risk of not being able to use
+ *		filesystems which require a block size exceeding MAXBSIZE.
  */
-int
-ffs_blkatoff(vnode *vp, off_t offset, char **res, void **bpp)
-{
-	inode *ip;
-	Fs *fs;
-	void *bp;
-	ufs_lbn_t lbn;
-	int bsize, error;
-
-	ip = VTOI(vp);
-	fs = ITOFS(ip);
-	lbn = lblkno(fs, offset);
-	bsize = blksize(fs, ip, lbn);
-
-	*bpp = nil;
-	error = bread(vp->mount, lbn, bsize, /*NOCRED,*/ &bp); 
-	if (error) {
-		free(bp);
-		return (error);
-	}
-	if (res)
-		*res = (char *)bp + blkoff(fs, offset);
-	*bpp = bp;
-	return (0);
-}
-
-/*
- * Load up the contents of an inode and copy the appropriate pieces
- * to the incore copy.
- */
-void
-ffs_load_inode(void *buf, inode *ip, Fs *fs, ino_t ino)
-{
-	*ip->i_din2 = *((ufs2_dinode *)buf + ino_to_fsbo(fs, ino));
-	ip->i_mode = ip->i_din2->di_mode;
-	ip->i_nlink = ip->i_din2->di_nlink;
-	ip->i_size = ip->i_din2->di_size;
-	ip->i_flags = ip->i_din2->di_flags;
-	ip->i_gen = ip->i_din2->di_gen;
-	ip->i_uid = ip->i_din2->di_uid;
-	ip->i_gid = ip->i_din2->di_gid;
-}
+#define MAXBSIZE	65536	/* must be power of 2 */

--- a/sys/src/9/ufs/ffs/ffs_balloc.c
+++ b/sys/src/9/ufs/ffs/ffs_balloc.c
@@ -65,6 +65,7 @@
 #include "dat.h"
 #include "fns.h"
 
+#include <ufs/ufsdat.h>
 #include <ufs/freebsd_util.h>
 #include "ufs_harvey.h"
 

--- a/sys/src/9/ufs/ffs/ffs_inode.c
+++ b/sys/src/9/ufs/ffs/ffs_inode.c
@@ -35,6 +35,7 @@
 #include "dat.h"
 #include "fns.h"
 
+#include <ufs/ufsdat.h>
 #include <ufs/freebsd_util.h>
 #include "ufs_harvey.h"
 

--- a/sys/src/9/ufs/ffs/ffs_snapshot.c
+++ b/sys/src/9/ufs/ffs/ffs_snapshot.c
@@ -39,6 +39,7 @@
 #include "dat.h"
 #include "fns.h"
 
+#include <ufs/ufsdat.h>
 #include <ufs/freebsd_util.h>
 #include "ufs_harvey.h"
 

--- a/sys/src/9/ufs/ffs/ffs_vfsops.c
+++ b/sys/src/9/ufs/ffs/ffs_vfsops.c
@@ -37,6 +37,7 @@
 #include "dat.h"
 #include "../../port/portfns.h"
 
+#include <ufs/ufsdat.h>
 #include <ufs/freebsd_util.h>
 #include "ufs_mountpoint.h"
 #include "ufs_harvey.h"

--- a/sys/src/9/ufs/ufs/ufs_vfsops.c
+++ b/sys/src/9/ufs/ufs/ufs_vfsops.c
@@ -40,6 +40,7 @@
 #include "dat.h"
 #include "../../port/portfns.h"
 
+#include <ufs/ufsdat.h>
 #include <ufs/freebsd_util.h>
 #include "ufs_harvey.h"
 

--- a/sys/src/9/ufs/ufs_harvey.c
+++ b/sys/src/9/ufs/ufs_harvey.c
@@ -15,6 +15,7 @@
 #include "dat.h"
 #include "fns.h"
 
+#include <ufs/ufsdat.h>
 #include <ufs/freebsd_util.h>
 #include "ufs_harvey.h"
 #include "ufs_mountpoint.h"

--- a/sys/src/9/ufs/ufs_harvey.h
+++ b/sys/src/9/ufs/ufs_harvey.h
@@ -107,16 +107,6 @@ typedef struct vnode {
 
 
 /*
- * MAXBSIZE -	Filesystems are made out of blocks of at most MAXBSIZE bytes
- *		per block.  MAXBSIZE may be made larger without effecting
- *		any existing filesystems as long as it does not exceed MAXPHYS,
- *		and may be made smaller at the risk of not being able to use
- *		filesystems which require a block size exceeding MAXBSIZE.
- */
-#define MAXBSIZE	65536	/* must be power of 2 */
-
-
-/*
  * Flags to various vnode functions.
  */
 #define	FORCECLOSE	0x0002	/* vflush: force file closure */

--- a/sys/src/libufs/cgroup.c
+++ b/sys/src/libufs/cgroup.c
@@ -25,6 +25,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <u.h>
+#include <libc.h>
+
 //#include <sys/cdefs.h>
 
 //#include <sys/param.h>

--- a/sys/src/libufs/libufs_subr.c
+++ b/sys/src/libufs/libufs_subr.c
@@ -153,7 +153,7 @@ ffs_clrblock(Fs *fs, uint8_t *cp, ufs1_daddr_t h)
  * put a block into the map
  */
 void
-ffs_setblock(Fs *fs, unsigned char *cp, ufs1_daddr_t h)
+ffs_setblock(Fs *fs, uint8_t *cp, ufs1_daddr_t h)
 {
 	switch ((int)fs->fs_frag) {
 

--- a/sys/src/libufs/sblock.c
+++ b/sys/src/libufs/sblock.c
@@ -25,6 +25,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <u.h>
+#include <libc.h>
+
 //#include <sys/cdefs.h>
 
 //#include <sys/param.h>

--- a/sys/src/libufs/type.c
+++ b/sys/src/libufs/type.c
@@ -25,6 +25,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <u.h>
+#include <libc.h>
+
 //#include <sys/cdefs.h>
 
 //#include <sys/param.h>


### PR DESCRIPTION
ufsdat.h currently only has the header required by both libufs/block.c and the main UFS code.  It will grow as the other libufs/*.c files compile, and with some of the ffs_subr and ffs_tables declarations.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>