### PR TITLE
Remove all LITTLE_ENDIAN tests from ufs code

### DIFF
--- a/sys/include/ufs/dir.h
+++ b/sys/include/ufs/dir.h
@@ -104,21 +104,12 @@ typedef struct Direct {
  * the directory entry.  This requires the amount of space in struct direct
  * without the d_name field, plus enough space for the name with a terminating
  * null byte (dp->d_namlen+1), rounded up to a 4 byte boundary.
- *
- * 
  */
 #define	DIRECTSIZ(namlen)						\
 	((offsetof(Direct, d_name) +				\
 	  ((namlen)+1)*sizeof(((Direct *)0)->d_name[0]) + 3) & ~3)
-#if (BYTE_ORDER == LITTLE_ENDIAN)
-#define	DIRSIZ(oldfmt, dp) \
-    ((oldfmt) ? DIRECTSIZ((dp)->d_type) : DIRECTSIZ((dp)->d_namlen))
-#else
-#define	DIRSIZ(oldfmt, dp) \
+#define	DIRSIZ(dp) \
     DIRECTSIZ((dp)->d_namlen)
-#endif
-#define	OLDDIRFMT	1
-#define	NEWDIRFMT	0
 
 /*
  * Template for manipulating directories.  Should use struct direct's,

--- a/sys/src/9/ufs/ufs/ufs_dirhash.c
+++ b/sys/src/9/ufs/ufs/ufs_dirhash.c
@@ -428,7 +428,7 @@ ufsdirhash_build(struct inode *ip)
 				slot = WRAPINCR(slot, dh->dh_hlen);
 			dh->dh_hused++;
 			DH_ENTRY(dh, slot) = pos;
-			ufsdirhash_adjfree(dh, pos, -DIRSIZ(0, ep));
+			ufsdirhash_adjfree(dh, pos, -DIRSIZ(ep));
 		}
 		pos += ep->d_reclen;
 	}
@@ -632,7 +632,7 @@ restart:
 			}
 
 			/* Update offset. */
-			dh->dh_seqoff = offset + DIRSIZ(0, dp);
+			dh->dh_seqoff = offset + DIRSIZ(dp);
 			*bpp = bp;
 			*offp = offset;
 			ufsdirhash_release(dh);
@@ -708,7 +708,7 @@ ufsdirhash_findfree(struct inode *ip, int slotneeded, int *slotsize)
 			brelse(bp);
 			return (-1);
 		}
-		if (dp->d_ino == 0 || dp->d_reclen > DIRSIZ(0, dp))
+		if (dp->d_ino == 0 || dp->d_reclen > DIRSIZ(dp))
 			break;
 		i += dp->d_reclen;
 		dp = (struct direct *)((char *)dp + dp->d_reclen);
@@ -724,7 +724,7 @@ ufsdirhash_findfree(struct inode *ip, int slotneeded, int *slotsize)
 	while (i < DIRBLKSIZ && freebytes < slotneeded) {
 		freebytes += dp->d_reclen;
 		if (dp->d_ino != 0)
-			freebytes -= DIRSIZ(0, dp);
+			freebytes -= DIRSIZ(dp);
 		if (dp->d_reclen == 0) {
 			brelse(bp);
 			return (-1);
@@ -806,7 +806,7 @@ ufsdirhash_add(struct inode *ip, struct direct *dirp, doff_t offset)
 	dh->dh_lastused = time_second;
 
 	/* Update the per-block summary info. */
-	ufsdirhash_adjfree(dh, offset, -DIRSIZ(0, dirp));
+	ufsdirhash_adjfree(dh, offset, -DIRSIZ(dirp));
 	ufsdirhash_release(dh);
 }
 
@@ -833,7 +833,7 @@ ufsdirhash_remove(struct inode *ip, struct direct *dirp, doff_t offset)
 	ufsdirhash_delslot(dh, slot);
 
 	/* Update the per-block summary info. */
-	ufsdirhash_adjfree(dh, offset, DIRSIZ(0, dirp));
+	ufsdirhash_adjfree(dh, offset, DIRSIZ(dirp));
 	ufsdirhash_release(dh);
 }
 
@@ -982,7 +982,7 @@ ufsdirhash_checkblock(struct inode *ip, char *buf, doff_t offset)
 		/* Check that the entry	exists (will panic if it doesn't). */
 		ufsdirhash_findslot(dh, dp->d_name, dp->d_namlen, offset + i);
 
-		nfree += dp->d_reclen - DIRSIZ(0, dp);
+		nfree += dp->d_reclen - DIRSIZ(dp);
 	}
 	if (i != DIRBLKSIZ)
 		panic("ufsdirhash_checkblock: bad dir end");

--- a/sys/src/9/ufs/ufs/ufs_vnops.c
+++ b/sys/src/9/ufs/ufs/ufs_vnops.c
@@ -2105,17 +2105,10 @@ ufs_readdir (struct vop_readdir_args *ap)
 				error = EIO;
 				break;
 			}
-#if BYTE_ORDER == LITTLE_ENDIAN
-			/* Old filesystem format. */
-			if (vp->v_mount->mnt_maxsymlinklen <= 0) {
-				dstdp.d_namlen = dp->d_type;
-				dstdp.d_type = dp->d_namlen;
-			} else
-#endif
-			{
-				dstdp.d_namlen = dp->d_namlen;
-				dstdp.d_type = dp->d_type;
-			}
+
+			dstdp.d_namlen = dp->d_namlen;
+			dstdp.d_type = dp->d_type;
+
 			if (offsetof(struct direct, d_name) + dstdp.d_namlen >
 			    dp->d_reclen) {
 				error = EIO;

--- a/sys/src/cmd/newfs/mkfs.c
+++ b/sys/src/cmd/newfs/mkfs.c
@@ -760,13 +760,13 @@ makedir(Direct *protodir, int entries)
 	spcleft = DIRBLKSIZ;
 	memset(iobuf, 0, DIRBLKSIZ);
 	for (cp = iobuf, i = 0; i < entries - 1; i++) {
-		protodir[i].d_reclen = DIRSIZ(0, &protodir[i]);
+		protodir[i].d_reclen = DIRSIZ(&protodir[i]);
 		memmove(cp, &protodir[i], protodir[i].d_reclen);
 		cp += protodir[i].d_reclen;
 		spcleft -= protodir[i].d_reclen;
 	}
 	protodir[i].d_reclen = spcleft;
-	memmove(cp, &protodir[i], DIRSIZ(0, &protodir[i]));
+	memmove(cp, &protodir[i], DIRSIZ(&protodir[i]));
 	return (DIRBLKSIZ);
 }
 


### PR DESCRIPTION
By assuming that we only handle 'new' file systems with a fs_maxsymlinklen > 0, we can avoid all the LITTLE_ENDIAN tests.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>