### PR TITLE
Remove old-style dir templates, some code for old-style file systems

### DIFF
--- a/sys/include/ufs/dir.h
+++ b/sys/include/ufs/dir.h
@@ -127,17 +127,3 @@ struct dirtemplate {
 	uint8_t	dotdot_namlen;
 	char		dotdot_name[4];	/* ditto */
 };
-
-/*
- * This is the old format of directories, sanz type element.
- */
-struct odirtemplate {
-	uint32_t	dot_ino;
-	int16_t		dot_reclen;
-	uint16_t	dot_namlen;
-	char		dot_name[4];	/* must be multiple of 4 */
-	uint32_t	dotdot_ino;
-	int16_t		dotdot_reclen;
-	uint16_t	dotdot_namlen;
-	char		dotdot_name[4];	/* ditto */
-};

--- a/sys/src/9/ufs/ufs/ufs_dirhash.c
+++ b/sys/src/9/ufs/ufs/ufs_dirhash.c
@@ -42,7 +42,6 @@
 
 #define WRAPINCR(val, limit)	(((val) + 1 == (limit)) ? 0 : ((val) + 1))
 #define WRAPDECR(val, limit)	(((val) == 0) ? ((limit) - 1) : ((val) - 1))
-#define OFSFMT(vp)		((vp)->v_mount->mnt_maxsymlinklen <= 0)
 #define BLKFREE2IDX(n)		((n) > DH_NFSTATS ? DH_NFSTATS : (n))
 
 static MALLOC_DEFINE(M_DIRHASH, "ufs_dirhash", "UFS directory hash tables");
@@ -331,8 +330,7 @@ ufsdirhash_build(struct inode *ip)
 	}
 
 	/* Check if we can/should use dirhash. */
-	if (ip->i_size < ufs_mindirhashsize || OFSFMT(ip->i_vnode) ||
-	    ip->i_effnlink == 0) {
+	if (ip->i_size < ufs_mindirhashsize || ip->i_effnlink == 0) {
 		if (ip->i_dirhash)
 			ufsdirhash_free(ip);
 		return (-1);

--- a/sys/src/9/ufs/ufs/ufs_lookup.c
+++ b/sys/src/9/ufs/ufs/ufs_lookup.c
@@ -62,9 +62,6 @@ static int	dirchk = 0;
 
 //SYSCTL_INT(_debug, OID_AUTO, dircheck, CTLFLAG_RW, &dirchk, 0, "");
 
-/* true if old FS format...*/
-#define OFSFMT(vp)	((vp)->v_mount->mnt_maxsymlinklen <= 0)
-
 #if 0
 
 static int
@@ -419,8 +416,7 @@ foundentry:
 				 * reclen in ndp->ni_ufs area, and release
 				 * directory buffer.
 				 */
-				if (vdp->v_mount->mnt_maxsymlinklen > 0 &&
-				    ep->d_type == DT_WHT) {
+				if (ep->d_type == DT_WHT) {
 					slotstatus = FOUND;
 					slotoffset = i_offset;
 					slotsize = ep->d_reclen;
@@ -1239,8 +1235,7 @@ ufs_dirrewrite(dp, oip, newinum, newtype, isrmdir)
 		return (EIDRM);
 	}
 	ep->d_ino = newinum;
-	if (!OFSFMT(vdp))
-		ep->d_type = newtype;
+	ep->d_type = newtype;
 	if (DOINGSOFTDEP(vdp)) {
 		softdep_setup_directory_change(bp, dp, oip, newinum, isrmdir);
 		bdwrite(bp);


### PR DESCRIPTION
Again based on the assumption that mnt_maxsymlinklen > 0 for our filesystems, and therefore OFSFMT always returns 0.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>