### PR TITLE
Enable reading of files in UFS

### DIFF
--- a/sys/include/ufs/freebsd_util.h
+++ b/sys/include/ufs/freebsd_util.h
@@ -102,6 +102,7 @@ typedef int64_t intmax_t;	/* FIXME: This should probably be moved to <u.h> or re
 #define	EINVAL		22		/* Invalid argument */
 #define	EFBIG		27		/* File too large */
 #define	ENOSPC		28		/* No space left on device */
+#define	EOVERFLOW	84		/* Value too large to be stored in data type */
 
 #define	EJUSTRETURN	(-2)		/* don't modify regs, just return */
 

--- a/sys/include/ufs/inode.h
+++ b/sys/include/ufs/inode.h
@@ -36,6 +36,8 @@
  */
 
 typedef struct ufs2_dinode ufs2_dinode;
+typedef struct ufsmount ufsmount;
+typedef struct vnode vnode;
 
 /*
  * This must agree with the definition in <ufs/ufs/dir.h>.
@@ -61,8 +63,8 @@ typedef struct ufs2_dinode ufs2_dinode;
 struct inode {
 	// TODO HARVEY Replace when snapshot code re-enabled
 	//TAILQ_ENTRY(inode) i_nextsnap; /* snapshot file list. */
-	struct	vnode  *i_vnode;/* Vnode associated with this inode. */
-	struct 	ufsmount *i_ump;/* Ufsmount point associated with this inode. */
+	vnode  *i_vnode;/* Vnode associated with this inode. */
+	ufsmount *i_ump;/* Ufsmount point associated with this inode. */
 	struct	 dquot *i_dquot[MAXQUOTAS]; /* Dquot structures. */
 	union {
 		struct dirhash *dirhash; /* Hashing for large directories. */
@@ -154,6 +156,7 @@ typedef struct Indir {
 } Indir;
 
 /* Convert between inode pointers and vnode pointers. */
+// TODO HARVEY Just remove these 2 macros
 #define	VTOI(vp)	((inode *)(vp)->data)
 #define	ITOV(ip)	((ip)->i_vnode)
 

--- a/sys/src/9/port/devufs.c
+++ b/sys/src/9/port/devufs.c
@@ -338,19 +338,6 @@ dumpinode(void *a, int32_t n, int64_t offset, vnode *vn)
 	return n;
 }
 
-static int
-dumpinodedata(void *a, int32_t n, int64_t offset, vnode *vn)
-{
-	char *buf = malloc(READSTR);
-
-	writeinodedata(buf, READSTR, vn);
-	n = readstr(offset, a, n, buf);
-
-	free(buf);
-
-	return n;
-}
-
 static int32_t
 ufsread(Chan *c, void *a, int32_t n, int64_t offset)
 {
@@ -377,7 +364,7 @@ ufsread(Chan *c, void *a, int32_t n, int64_t offset)
 	case Qinodedata:
 	{
 		vnode *vn = (vnode*)c->aux;
-		n = dumpinodedata(a, n, offset, vn);
+		n = writeinodedata(a, n, offset, vn);
 		break;
 	}
 

--- a/sys/src/9/ufs/ffs_extern.h
+++ b/sys/src/9/ufs/ffs_extern.h
@@ -68,11 +68,12 @@ int	ffs_flushfiles(MountPoint *, int, thread *);
 //int	ffs_isblock(struct fs *, uint8_t *, ufs1_daddr_t);
 //int	ffs_isfreeblock(struct fs *, uint8_t *, ufs1_daddr_t);
 void	ffs_load_inode(Buf *, inode *, Fs *, ino_t);
-/*int	ffs_own_mount(const struct mount *mp);
-int	ffs_reallocblks(struct vop_reallocblks_args *);
-int	ffs_realloccg(struct inode *, ufs2_daddr_t, ufs2_daddr_t,
-	    ufs2_daddr_t, int, int, int, struct ucred *, struct buf **);
-int	ffs_reload(struct mount *, struct thread *, int);*/
+//int	ffs_own_mount(const struct mount *mp);
+//int	ffs_reallocblks(struct vop_reallocblks_args *);
+//int	ffs_realloccg(struct inode *, ufs2_daddr_t, ufs2_daddr_t,
+//	    ufs2_daddr_t, int, int, int, struct ucred *, struct buf **);
+int	ffs_read();
+//int	ffs_reload(struct mount *, struct thread *, int);
 int	ffs_sbupdate(ufsmount *, int, int);
 //void	ffs_setblock(struct fs *, uint8_t *, ufs1_daddr_t);
 int	ffs_snapblkfree(Fs *, vnode *, ufs2_daddr_t, long, ino_t, Vtype,

--- a/sys/src/9/ufs/ffs_vnops.c
+++ b/sys/src/9/ufs/ffs_vnops.c
@@ -391,7 +391,7 @@ ffs_read(vnode *vp, Uio *uio)
 	inode *ip;
 	Fs *fs;
 	Buf *bp;
-	ufs_lbn_t lbn, nextlbn;
+	ufs_lbn_t lbn;//, nextlbn;
 	off_t bytesinfile;
 	long size, xfersize, blkoffset;
 	int64_t orig_resid;
@@ -443,7 +443,7 @@ ffs_read(vnode *vp, Uio *uio)
 			break;
 
 		lbn = lblkno(fs, uio->offset);
-		nextlbn = lbn + 1;
+		//nextlbn = lbn + 1;
 
 		/*
 		 * size of buffer.  The buffer representing the

--- a/sys/src/9/ufs/ufs_harvey_internal.c
+++ b/sys/src/9/ufs/ufs_harvey_internal.c
@@ -105,6 +105,7 @@ breadmp(MountPoint *mp, daddr_t blkno, size_t size, Buf **buf)
 		return 1;
 	}
 
+	b->resid = size - bytesRead;
 	*buf = b;
 	return 0;
 }
@@ -130,13 +131,16 @@ bread(vnode *vn, daddr_t lblkno, size_t size, Buf **buf)
 	MountPoint *mp = vn->mount;
 	Chan *c = mp->chan;
 	int64_t offset = dbtob(pblkno);
+
 	int32_t bytesRead = c->dev->read(c, b->data, size, offset);
+
 	if (bytesRead != size) {
 		releasebuf(b);
 		print("bread returned wrong size\n");
 		return 1;
 	}
 
+	b->resid = size - bytesRead;
 	*buf = b;
 	return 0;
 }

--- a/sys/src/9/ufs/ufs_vnops.c
+++ b/sys/src/9/ufs/ufs_vnops.c
@@ -41,9 +41,9 @@
 #include "port/portfns.h"
 
 #include "ufsdat.h"
-#include <ufs/libufsdat.h>
+#include "ufs/libufsdat.h"
 #include "ufsfns.h"
-#include <ufs/freebsd_util.h>
+#include "ufs/freebsd_util.h"
 
 #include "ufs/quota.h"
 #include "ufs/inode.h"

--- a/sys/src/9/ufs/ufsdat.h
+++ b/sys/src/9/ufs/ufsdat.h
@@ -37,6 +37,10 @@ typedef struct Buf {
 	unsigned char*	data;
 	size_t		bcount;		/* Requested size of buffer */
 	int64_t		offset;		/* Offset into file. */
+
+	// Number of bytes remaining in I/O.  After an I/O operation
+ 	// completes, b_resid is usually 0 indicating 100% success.
+	int64_t		resid;
 } Buf;
 
 

--- a/sys/src/9/ufs/ufsfns.h
+++ b/sys/src/9/ufs/ufsfns.h
@@ -28,7 +28,7 @@ int		lookuppath(MountPoint *mp, char *path, vnode **vn);
 int		writestats(char *buf, int buflen, MountPoint *mp);
 int		writesuperblock(char *buf, int buflen, MountPoint *mp);
 int		writeinode(char *buf, int buflen, vnode *vn);
-int		writeinodedata(char *buf, int buflen, vnode *vn);
+int		writeinodedata(char *buf, int32_t n, int64_t offset, vnode *vn);
 
 // Misc
 int		ffs_init();


### PR DESCRIPTION
cat /dev/ufs/0/inodes/<fileinode>/data

Also handle file offsets better when dumping files or directories.
Quite a few todos here.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>