### PR TITLE
Reintroduce libScribble

### DIFF
--- a/sys/src/libscribble/graffiti.c
+++ b/sys/src/libscribble/graffiti.c
@@ -128,7 +128,7 @@ recognize (Scribble *s)
 			s->ctrlShift = 0;
 			s->tmpShift = 0;
 			return rune;
-		}		  	
+		}
 		rune = '.';
 		if(0)fprint(2, "(case .) character = %c (0x%x)\n", rune, rune);
 		break;
@@ -138,7 +138,7 @@ recognize (Scribble *s)
 			return rune;
 		}
 		rune = c;
-		if (s->ctrlShift) 
+		if (s->ctrlShift)
 		{
 			if (c < 'a' || 'z' < c)
 			{
@@ -146,12 +146,12 @@ recognize (Scribble *s)
 				return rune;
 			}
 			rune = rune & 0x1f;
-		} else if ((s->capsLock && !s->tmpShift) || 
-				 (!s->capsLock && s->tmpShift)) 
+		} else if ((s->capsLock && !s->tmpShift) ||
+				 (!s->capsLock && s->tmpShift))
 		{
 			if (rune < 0xff)
 				rune = toupper(rune);
-		} 
+		}
 		s->tmpShift = 0;
 		s->puncShift = 0;
 		s->ctrlShift = 0;
@@ -211,15 +211,15 @@ graffiti_load_recognizers(struct graffiti *pg)
 
 		rec_return = recognizer_load_state(pg->rec[i], pg->cldir, cl_name[i]);
 		if ((rec_return == -1) && (usingDefault == false)) {
-			if(0)fprint(2, "Unable to load custom classifier file %s/%s.\nTrying default classifier file instead.\nOriginal error: %s\n ", 
-				pg->cldir, cl_name[i], 
+			if(0)fprint(2, "Unable to load custom classifier file %s/%s.\nTrying default classifier file instead.\nOriginal error: %s\n ",
+				pg->cldir, cl_name[i],
 				(s = recognizer_error(pg->rec[i])) ? s : "(none)");
 			rec_return = recognizer_load_state(pg->rec[i],
 						REC_DEFAULT_USER_DIR, cl_name[i]);
 		}
 		if (rec_return == -1) {
 			fprint(2, "Unable to load default classifier file %s.\nOriginal error: %s\n",
-				cl_name[i], 
+				cl_name[i],
 				(s = recognizer_error(pg->rec[i])) ? s : "(none)");
 			return 0;
 		}
@@ -232,7 +232,7 @@ graffiti_load_recognizers(struct graffiti *pg)
 		fprint(2, "LI Recognizer Training:No extension functions!");
 		return 0;
 	}
-	
+
 	/* ... and make sure the training & get-classes functions are okay. */
 	if( (pg->rec_train = (li_recognizer_train)fns[LI_TRAIN]) == nil ) {
 		fprint(2,
@@ -242,7 +242,7 @@ graffiti_load_recognizers(struct graffiti *pg)
 		}
 		return 0;
 	}
-  
+
 	if( (pg->rec_getClasses = (li_recognizer_getClasses)fns[LI_GET_CLASSES]) == nil ) {
 		fprint(2,
 			"LI Recognizer Training:li_recognizer_getClasses() not found!");

--- a/sys/src/libscribble/graffiti.h
+++ b/sys/src/libscribble/graffiti.h
@@ -24,7 +24,7 @@ struct graffiti {
 	/* pointer to training function: */
 	li_recognizer_train			rec_train;
 	/* pointer to function that lists the characters in the classifier file */
-	li_recognizer_getClasses	rec_getClasses; 
+	li_recognizer_getClasses	rec_getClasses;
 };
 
 extern char *cl_name[3];

--- a/sys/src/libscribble/hre_api.c
+++ b/sys/src/libscribble/hre_api.c
@@ -7,7 +7,7 @@
  * in the LICENSE file.
  */
 
-/* 
+/*
  *  hre_api.c:        Implementation of HRE API
  *  Author:           James &
  *  Created On:       Wed Dec  9 13:49:14 1992
@@ -16,8 +16,8 @@
  *  Update Count:     137
  *  Copyright (c) 1994 by Sun Microsystems Computer Company
  *  All rights reserved.
- *  
- *  Use and copying of this software and preparation of 
+ *
+ *  Use and copying of this software and preparation of
  *  derivative works based upon this software are permitted.
  *  Any distribution of this software or derivative works
  *  must comply with all applicable United States export control
@@ -113,7 +113,7 @@ static char *safe_malloc (int nbytes)
  * sets errno to indicate why.
 */
 
-recognizer 
+recognizer
 recognizer_load(char* directory, char* name, char** subset)
 {
     recognizer	rec;				/*the recognizer*/
@@ -128,11 +128,11 @@ recognizer_load(char* directory, char* name, char** subset)
     /*The name takes precedence.*/
     rinf = make_rec_info(directory, name, subset);
     if (rinf == nil) {
-	the_last_error = 
+	the_last_error =
 	  dgettext(INTL_DOMAIN,
 		   "Ran out of memory during prelinking initialization.");
 	return((recognizer)nil);
-    } 
+    }
 /* fprint(2, "Got past make_rec_info.\n"); */
 
     /*Let recognition code create recognizer and initialize*/
@@ -164,7 +164,7 @@ recognizer_load(char* directory, char* name, char** subset)
 
 	recognizer_unload(rec);
 /* fprint(2, "Unloading b/c null function pointer.\n"); */
-	the_last_error = 
+	the_last_error =
 	  dgettext(INTL_DOMAIN,
 		   "One or more recognizer function pointers is nil.");
 	return((recognizer)nil);
@@ -201,12 +201,12 @@ int
 recognizer_unload(recognizer rec)
 {
     /*Make sure magic numbers right.*/
-    
+
 	if( !RI_CHECK_MAGIC(rec) ) {
 		the_last_error = dgettext(INTL_DOMAIN,"Bad recognizer object.");
 		return(-1);
 	}
-    
+
 	return __recognizer_internal_finalize(rec);
 }
 
@@ -334,7 +334,7 @@ int recognizer_add_to_dictionary(recognizer rec,letterset* word,wordset dict)
  * return 0 if OK, -1 if error.
 */
 
-int 
+int
 recognizer_delete_from_dictionary(recognizer rec,letterset* word,wordset dict)
 {
     /*Make sure magic numbers right.*/
@@ -385,7 +385,7 @@ const char* recognizer_manager_version(recognizer rec)
     }
 
     return(rec->recognizer_version);
-  
+
 }
 /*
  * recognizer_error-Return the last error message, or nil if none.
@@ -393,7 +393,7 @@ const char* recognizer_manager_version(recognizer rec)
 
 char* recognizer_error(recognizer rec)
 {
-    
+
     /*Make sure magic numbers right and function there.*/
 
     if( !RI_CHECK_MAGIC(rec) && the_last_error == nil ) {
@@ -431,7 +431,7 @@ int recognizer_set_context(recognizer rec,rc* rec_xt)
     return(rec->recognizer_set_context(rec,rec_xt));
 }
 
-/* 
+/*
  * recognzier_get_context-Get the recognition context for translation.
  * If none or error, return nil.
 */
@@ -491,7 +491,7 @@ int recognizer_get_buffer(recognizer rec, uint* nstrokes,Stroke** strokes)
 }
 
 /*
- * recognizer_set_buffer-Set stroke buffer to arg. Return 0 if success, else 
+ * recognizer_set_buffer-Set stroke buffer to arg. Return 0 if success, else
  * return -1.
 */
 
@@ -513,7 +513,7 @@ int recognizer_set_buffer(recognizer rec,uint nstrokes,Stroke* strokes)
 
 /*
  * recognizer_translate-Translate the strokes in the current context, including
- * buffered strokes. If nstrokes == 0 or strokes == nil, return 
+ * buffered strokes. If nstrokes == 0 or strokes == nil, return
  * translation of stroke buffer.
 */
 
@@ -546,7 +546,7 @@ int recognizer_translate(recognizer rec,
  *	for (ari = 0; ari < ari_pstr.ps_npts; ari++)
  *	   fprint(2, "%ld -- (%d, %d)  ", ari_pts[ari], ari_pts[ari].x, ari_pts[ari].y);
  *      }
- *    }     
+ *    }
 */
     /*Do the function.*/
 /* ari -- this is calling cmu_recognizer_translate */
@@ -605,7 +605,7 @@ recognizer_get_gesture_names(recognizer rec)
  * recognizer_set_gesture_action-Set the action function for the gesture.
 */
 
-xgesture 
+xgesture
 recognizer_train_gestures(recognizer rec,char* name,xgesture fn,void* wsinfo)
 {
     /*Make sure magic numbers right.*/
@@ -644,14 +644,14 @@ static char* shared_library_name(char* directory,char* locale,char* name)
 		strcat(ret,name);
     } else {
 		char* dir;
-	
+
 		/*First try the environment variable.*/
-	
+
 		if( (dir = getenv(RECHOME)) == nil ) {
 		    dir = "REC_DEFAULT_HOME_DIR";
-	
+
 		  }
-	
+
 		ret = (char*)safe_malloc(strlen(dir) + strlen(locale) + len + 3);
 		/*Form the pathname.*/
 		strcpy(ret,dir);
@@ -714,15 +714,15 @@ static rec_info* make_rec_info(char* c, char* d, char** subset)
     /*Initialize the subset information.*/
 
     if( subset != nil ) {
-	
+
 	/*Count the subset strings.*/
 
 	for( len = 1; subset[len] != nil; len++ ) ;
-	
+
 	/*Copy the subset strings.*/
-	
+
 	ri->ri_subset = (char**)safe_malloc((len +1)*sizeof(char*));
-	
+
 	for( i = 0; i < len; i++ ) {
 	    if( subset[i] != nil ) {
 		if( (ri->ri_subset[i] = strdup(subset[i])) == nil ) {
@@ -740,7 +740,7 @@ static rec_info* make_rec_info(char* c, char* d, char** subset)
 
 	ri->ri_subset = nil;
     }
-    
+
     return(ri);
 }
 
@@ -829,7 +829,7 @@ static int check_for_user_home()
 recognizer make_recognizer(rec_info* rif)
 {
     recognizer rec;
-    
+
     /*Allocate it.*/
 
     rec = (recognizer)safe_malloc(sizeof(*rec));
@@ -888,7 +888,7 @@ rec_alternative* make_rec_alternative_array(uint size)
 	ri[i].ra_next = nil;
     }
 
-    return(ri);    
+    return(ri);
 }
 
 rec_alternative*
@@ -915,9 +915,9 @@ void delete_rec_alternative_array(uint nalter,
 
       for( i = 0; i < nalter; i++ ) {
 	cleanup_rec_element(&ra[i].ra_elem,delete_points_p);
-	
+
 	/*Now do the next one down the line.*/
-	
+
 	if( ra[i].ra_nalter > 0 ) {
 	  delete_rec_alternative_array(ra[i].ra_nalter,
 				       ra[i].ra_next,
@@ -944,37 +944,37 @@ initialize_rec_element(rec_element* re,
 	re->re_type = type;
 	re->re_conf = conf;
 	re->re_result.aval = nil;
-	
+
 	switch (type) {
-	    
+
 	  case REC_GESTURE:
 	    if( size > 0 && trans != nil ) {
-		re->re_result.gval = 
+		re->re_result.gval =
 		     (gesture*)safe_malloc(sizeof(gesture));
 		memcpy((void*)re->re_result.gval,trans,sizeof(gesture));
 	    }
 	    break;
-	    
+
 	  case REC_ASCII:
 	  case REC_VAR:
 	  case REC_OTHER:
 	    if( size > 0 && trans != nil ) {
-		re->re_result.aval = 
+		re->re_result.aval =
 		     (char*)safe_malloc((size+1)*sizeof(char));
 		memcpy((void*)re->re_result.aval,trans,size*sizeof(char));
 		re->re_result.aval[size] = '\000';
 	    }
 	    break;
-	    
+
 	  case REC_WCHAR:
 	    if( size > 0 && trans != nil ) {
-		re->re_result.wval = 
+		re->re_result.wval =
 		     (wchar_t*)safe_malloc((size+1)*sizeof(wchar_t));
 		memcpy((void*)re->re_result.wval,trans,size*sizeof(wchar_t));
 		re->re_result.wval[size] = '\000';
 	    }
 	    break;
-	    
+
 	  case REC_CORR:
 	    if( size > 0 && trans != nil ) {
 	      re->re_result.rcval =
@@ -997,17 +997,17 @@ initialize_rec_element(rec_element* re,
 static void cleanup_rec_element(rec_element* re,bool delete_points_p)
 {
   switch(re->re_type) {
-    
+
   case REC_NONE:
     break;
-    
+
   case REC_ASCII:
   case REC_VAR:
   case REC_WCHAR:
   case REC_OTHER:
     free(re->re_result.aval);
     break;
-    
+
   case REC_GESTURE:
     delete_gesture_array(1,re->re_result.gval,true);
     break;
@@ -1016,9 +1016,9 @@ static void cleanup_rec_element(rec_element* re,bool delete_points_p)
     delete_rec_correlation(re->re_result.rcval,
 			   delete_points_p);
     break;
-    
+
   }
-  
+
 }
 
 /*
@@ -1026,7 +1026,7 @@ static void cleanup_rec_element(rec_element* re,bool delete_points_p)
 */
 
 
-rec_correlation* 
+rec_correlation*
 make_rec_correlation(char type,
 		     uint size,
 		     void* trans,
@@ -1048,11 +1048,11 @@ make_rec_correlation(char type,
 			       conf) == nil ) {
       return(nil);
     }
-    
+
     if( (rc->ro_strokes = make_Stroke_array(ps_size)) == nil ) {
       return(nil);
     }
-    
+
     rc->ro_start = (uint*)safe_malloc(ps_size * sizeof(int));
     rc->ro_stop = (uint*)safe_malloc(ps_size * sizeof(int));
     return(rc);
@@ -1122,7 +1122,7 @@ Stroke* make_Stroke_array(uint size)
 	ri[i].pts = nil;
     }
 
-    return(ri);       
+    return(ri);
 }
 
 Stroke* initialize_Stroke(Stroke* ps,
@@ -1139,7 +1139,7 @@ Stroke* initialize_Stroke(Stroke* ps,
 void delete_Stroke_array(uint size,Stroke* ps,bool delete_points_p)
 {
   int i;
-  
+
     if( ps != nil ) {
 
       for( i = 0; i < size; i++ ) {
@@ -1147,7 +1147,7 @@ void delete_Stroke_array(uint size,Stroke* ps,bool delete_points_p)
 		delete_pen_point_array(ps[i].pts);
 	    }
       }
-	
+
       free(ps);
     }
 }
@@ -1164,7 +1164,7 @@ void delete_pen_point_array(pen_point* pp)
 }
 
 /*
- * gesture 
+ * gesture
 */
 
 gesture*
@@ -1205,14 +1205,14 @@ delete_gesture_array(uint size,gesture* ga,bool delete_points_p)
     if( ga != nil ) {
 
       for( i = 0; i < size; i++ ) {
-	
+
 	free(ga[i].g_name);
-	
+
 	if( delete_points_p ) {
 	  delete_pen_point_array(ga[i].g_hspots);
 	}
       }
-      
+
       free(ga);
     }
 }
@@ -1221,7 +1221,7 @@ delete_gesture_array(uint size,gesture* ga,bool delete_points_p)
  * copy fns for stroke buffer management.
 */
 
-static Stroke* 
+static Stroke*
 copy_Stroke(Stroke* ps1,Stroke* ps2)
 {
   initialize_Stroke(ps1,

--- a/sys/src/libscribble/hre_internal.h
+++ b/sys/src/libscribble/hre_internal.h
@@ -7,7 +7,7 @@
  * in the LICENSE file.
  */
 
-/* 
+/*
  *  hre_internal.h:   Internal Interface for Recognizer.
  *  Author:           James Kempf
  *  Created On:       Thu Nov  5 10:54:18 1992
@@ -16,8 +16,8 @@
  *  Update Count:     99
  *  Copyright (c) 1994 by Sun Microsystems Computer Company
  *  All rights reserved.
- *  
- *  Use and copying of this software and preparation of 
+ *
+ *  Use and copying of this software and preparation of
  *  derivative works based upon this software are permitted.
  *  Any distribution of this software or derivative works
  *  must comply with all applicable United States export control
@@ -52,7 +52,7 @@ struct _wordset {
 
 struct _Recognizer {
 	uint		recognizer_magic;
-	char		*recognizer_version; 
+	char		*recognizer_version;
 
 	rec_info	*recognizer_info;
 	void		*recognizer_specific;
@@ -67,7 +67,7 @@ struct _Recognizer {
 	int		(*recognizer_delete_from_dictionary)(struct _Recognizer*, letterset*, wordset);
 	int		(*recognizer_set_context)(struct _Recognizer*,rc*);
 	rc*		(*recognizer_get_context)(struct _Recognizer*);
-				   
+
 	int		(*recognizer_clear)(struct _Recognizer*, bool);
 	int		(*recognizer_get_buffer)(struct _Recognizer*, uint*, Stroke**);
 
@@ -76,11 +76,11 @@ struct _Recognizer {
 	rec_fn*		(*recognizer_get_extension_functions)(struct _Recognizer*);
 	char**		(*recognizer_get_gesture_names)(struct _Recognizer*);
 	xgesture	(*recognizer_set_gesture_action)(struct _Recognizer*, char*, xgesture, void*);
-	uint recognizer_end_magic; 
+	uint recognizer_end_magic;
 };
 
 /*
- * recognizer_internal_initialize - Allocate and initialize the recognizer 
+ * recognizer_internal_initialize - Allocate and initialize the recognizer
  * object. The recognition shared library has the responsibility for filling
  * in all the function pointers for the recognition functions. This
  * function must be defined as a global function within the shared
@@ -119,12 +119,12 @@ RECOGNIZER_FINALIZE(_a);
 rec_alternative*	make_rec_alternative_array(uint size);
 rec_correlation*	make_rec_correlation(char type, uint size, void* trans, rec_confidence conf, uint ps_size);
 
-rec_fn* 
+rec_fn*
 make_rec_fn_array(uint size);
-void 
+void
 delete_rec_fn_array(rec_fn* rf);
 
-gesture* 
+gesture*
 initialize_gesture(gesture* g,
 		   char* name,
 		   uint nhs,
@@ -132,9 +132,9 @@ initialize_gesture(gesture* g,
 		   pen_rect bbox,
 		   xgesture cback,
 		   void* wsinfo);
-gesture* 
+gesture*
 make_gesture_array(uint size);
-void 
+void
 delete_gesture_array(uint size,gesture* ga,bool delete_points_p);
 
 Stroke*

--- a/sys/src/libscribble/li_recognizer.c
+++ b/sys/src/libscribble/li_recognizer.c
@@ -19,7 +19,7 @@
  *
  *
  *  Adapted from cmu_recognizer.c by Jay Kistler.
- *  
+ *
  *  Where is the CMU copyright???? Gotta track it down - Jim Gettys
  *
  *  Credit to Dean Rubine, Jim Kempf, and Ari Rapkin.
@@ -79,7 +79,7 @@ add_example(point_list* l,int npts,pen_point* pts)
 
 	return(p);
 }
-	
+
 
 static void
 delete_examples(point_list* l)
@@ -124,11 +124,11 @@ static int
   file_path(char* dir,char* filename,char* pathname)
 {
 	char* dot;
-	
+
 	/*Check for proper extension on file name.*/
-	
+
 	dot = strrchr(filename,'.');
-	
+
 	if( dot == nil ) {
 		return(-1);
 	}
@@ -140,17 +140,17 @@ static int
 	}
 
 	/*Concatenate directory and filename into pathname.*/
-	
+
 	strcpy(pathname,dir);
 	strcat(pathname,"/");
 	strcat(pathname,filename);
-	
+
 	return(0);
 }
 
 /*read_classifier_points-Read points so classifier can be extended.*/
 
-static int 
+static int
 read_classifier_points(FILE* fd,int nclss,point_list** ex,char** cnames)
 {
 	int i,j,k;
@@ -173,30 +173,30 @@ read_classifier_points(FILE* fd,int nclss,point_list** ex,char** cnames)
 		for( k = 0; k < nclss; k++ ) {
 
 				/*Read class name and number of examples.*/
-		
+
 				if( fscanf(fd,"%d %s",&nex,buf) != 2 )
 					goto unallocate;
-		
+
 				/*Save class name*/
-		
+
 				names[k] = strdup(buf);
-		
+
 				/*Read examples.*/
-				
+
 				for( i = 0; i < nex; i++ ) {
-					
+
 					/*Read number of points.*/
-					
+
 					if( fscanf(fd,"%d",&npts) != 1 )
 								goto unallocate; /*Boy would I like exceptions!*/
-					
+
 					/*Allocate array for points.*/
-					
+
 					if( (pts = mallocz(npts*sizeof(pen_point), 1)) == nil )
 								goto unallocate;
-					
+
 					/*Read in points.*/
-					
+
 					for( j = 0; j < npts; j++ ) {
 								int x,y;
 								if( fscanf(fd,"%d %d",&x,&y) != 2 ) {
@@ -205,16 +205,16 @@ read_classifier_points(FILE* fd,int nclss,point_list** ex,char** cnames)
 								}
 								pts[j].Point = Pt(x, y);
 					}
-					
+
 					/*Add example*/
-					
+
 					if( (examples[k] = add_example(examples[k],npts,pts)) == nil ) {
 								delete_pen_point_array(pts);
 								goto unallocate;
 					}
-					
+
 					delete_pen_point_array(pts);
-			
+
 				}
 		}
 
@@ -243,7 +243,7 @@ unallocate:
 
 static int read_classifier(FILE* fd,rClassifier* rc)
 {
-	
+
 	li_err_msg = nil;
 
 	/*Read in classifier file.*/
@@ -280,7 +280,7 @@ recognizer_getClasses (recognizer r, char ***list, int *nc)
 				li_err_msg = "Not a LI recognizer";
 				return(-1);
 	}
-	
+
 	*nc = nclasses = rec->li_rc.nclasses;
 	ret = malloc(nclasses*sizeof(char*));
 
@@ -315,16 +315,16 @@ recognizer_train(recognizer r, rc* rc, uint u, Stroke* s, rec_element* re, bool 
 
 int
 li_recognizer_get_example (recognizer r,
-						   int		class, 
+						   int		class,
 						   int		instance,
-						   char		**name, 
+						   char		**name,
 						   pen_point	**points,
 						   int		*npts)
 {
 	li_recognizer   *rec = (li_recognizer*)r->recognizer_specific;
 	int nclasses = rec->li_rc.nclasses;
 	point_list	    *pl;
-	
+
 		if( !CHECK_LI_MAGIC(rec) ) {
 				li_err_msg = "Not a LI recognizer";
 				return(-1);
@@ -358,7 +358,7 @@ static int li_recognizer_load(recognizer r, char* dir, char* filename)
 		char* pathname;
 		li_recognizer* rec;
 		rClassifier* rc;
-		
+
 		rec = (li_recognizer*)r->recognizer_specific;
 
 		/*Make sure recognizer's OK*/
@@ -417,7 +417,7 @@ static int li_recognizer_load(recognizer r, char* dir, char* filename)
 		}
 
 		/*Read classifier.*/
-		
+
 		if( read_classifier(fd,rc) < 0 ) {
 				free(pathname);
 				return(-1);
@@ -444,7 +444,7 @@ static int li_recognizer_load(recognizer r, char* dir, char* filename)
 /*li_recognizer_save-Save a classifier file.*/
 
 static int li_recognizer_save(recognizer r, char* c, char* d)
-{ 
+{
 		/*This operation isn't supported by the LI recognizer.*/
 
 		li_err_msg = "Saving is not supported by the LI recognizer";
@@ -510,10 +510,10 @@ li_recognizer_error(recognizer rec)
 	return ret;
 }
 
-static int 
+static int
 li_recognizer_clear(recognizer r, bool b)
 {
-		li_recognizer* rec; 
+		li_recognizer* rec;
 
 		rec = (li_recognizer*)r->recognizer_specific;
 		/*Check for LI recognizer.*/
@@ -524,7 +524,7 @@ li_recognizer_clear(recognizer r, bool b)
 		return 0;
 }
 
-static int 
+static int
 li_recognizer_set_context(recognizer r, rc* rc)
 {
 		/*This operation isn't supported by the LI recognizer.*/
@@ -540,7 +540,7 @@ li_recognizer_get_context(recognizer r)
 		return nil;
 }
 
-static int 
+static int
 li_recognizer_get_buffer(recognizer r, uint* u, Stroke** s)
 {
 		/*This operation isn't supported by the LI recognizer.*/
@@ -548,7 +548,7 @@ li_recognizer_get_buffer(recognizer r, uint* u, Stroke** s)
 		return -1;
 }
 
-static int 
+static int
 li_recognizer_set_buffer(recognizer r, uint u, Stroke* s)
 {
 		/*This operation isn't supported by the LI recognizer.*/
@@ -560,10 +560,10 @@ static int
 li_recognizer_translate(recognizer r, uint ncs, Stroke* tps, bool b, int* nret, rec_alternative** ret)
 {
 	char* clss;
-	li_recognizer* rec; 
+	li_recognizer* rec;
 	int conf;
 	rClassifier* rc;
-	  
+
 	rec = (li_recognizer*)r->recognizer_specific;
 
 	*nret = 0;
@@ -601,7 +601,7 @@ li_recognizer_translate(recognizer r, uint ncs, Stroke* tps, bool b, int* nret, 
 	 *   stroke recognizer, each stroke is treated as a separate
 	 *   character or gesture. We allow only characters or gestures
 	 *   to be recognized at one time, since otherwise, handling
-	 *   the display of segmentation would be difficult. 
+	 *   the display of segmentation would be difficult.
 	*/
 	clss = recognize_internal(rc,tps,&conf);
 	if (clss == nil) {
@@ -698,7 +698,7 @@ RECOGNIZER_INITIALIZE(ri)
 		}
 	  }
 	}
-			 
+
 /* ari */
 	r = make_recognizer(ri);
 /* fprint(2, "past make_recognizer.\n"); */
@@ -737,10 +737,10 @@ RECOGNIZER_INITIALIZE(ri)
 	r->recognizer_get_buffer = li_recognizer_get_buffer;
 	r->recognizer_set_buffer = li_recognizer_set_buffer;
 	r->recognizer_clear = li_recognizer_clear;
-	r->recognizer_get_extension_functions = 
+	r->recognizer_get_extension_functions =
 	  li_recognizer_get_extension_functions;
 	r->recognizer_get_gesture_names = li_recognizer_get_gesture_names;
-	r->recognizer_set_gesture_action = 
+	r->recognizer_set_gesture_action =
 	  li_recognizer_set_gesture_action;
 
 	/*Initialize LI Magic Number.*/
@@ -1001,7 +1001,7 @@ static int lialg_preprocess_stroke(point_list *points) {
 	lialg_get_bounding_box(points, &minx, &miny, &maxx, &maxy);
 	xrange = maxx - minx;
 	yrange = maxy - miny;
-	scale = ( ((100 * xrange + CANONICAL_X / 2) / CANONICAL_X) > 
+	scale = ( ((100 * xrange + CANONICAL_X / 2) / CANONICAL_X) >
 			  ((100 * yrange + CANONICAL_Y / 2) / CANONICAL_Y))
 	  ? (100 * CANONICAL_X + xrange / 2) / xrange
 	  : (100 * CANONICAL_Y + yrange / 2) / yrange;
@@ -1047,7 +1047,7 @@ static point_list *lialg_compute_dominant_points(point_list *points) {
 				int j;
 				fprint(2, "After interpolation:  %d ipts\n", ipts->npts);
 				for (j = 0; j < ipts->npts; j++) {
-					fprint(2, "  (%P), %lud\n", ipts->pts[j].Point, ipts->pts[j].chaincode);
+					fprint(2, "  (%P), %lu\n", ipts->pts[j].Point, ipts->pts[j].chaincode);
 				}
 				fflush(stderr);
 	}
@@ -1062,7 +1062,7 @@ static point_list *lialg_compute_dominant_points(point_list *points) {
 				int j;
 				fprint(2, "Dominant points:  ");
 				for (j = 0; j < dpts->npts; j++) {
-					fprint(2, "%P (%lud)  ", dpts->pts[j].Point, dpts->pts[j].chaincode);
+					fprint(2, "%P (%lu)  ", dpts->pts[j].Point, dpts->pts[j].chaincode);
 				}
 				fprint(2, "\n");
 				fflush(stderr);
@@ -1155,13 +1155,13 @@ static void lialg_bresline(pen_point *startpt, pen_point *endpt,
 				int dPr	= dY<<1;	    /* amount to increment decision if right is chosen (always) */
 				int dPru = dPr - (dX<<1);   /* amount to increment decision if up is chosen */
 				int P =	dPr - dX;	    /* decision variable start value */
-		
+
 				/* process each point in the line one at a time (just use dX) */
 				for (; dX>=0; dX--) {
 					newpts->pts[*j].x = Ax;
 					newpts->pts[*j].y = Ay;
 					(*j)++;
-		
+
 					if (P > 0) {	/* is the pixel	going right AND	up? */
 								Ax+=Xincr;	/* increment independent variable */
 								Ay+=Yincr;	/* increment dependent variable */
@@ -1175,13 +1175,13 @@ static void lialg_bresline(pen_point *startpt, pen_point *endpt,
 				int dPr	= dX<<1;	    /* amount to increment decision if right is chosen (always) */
 				int dPru = dPr - (dY<<1);   /* amount to increment decision if up is chosen */
 				int P  = dPr - dY;	    /* decision variable start value */
-		
+
 				/* process each point in the line one at a time (just use dY) */
 				for (; dY>=0; dY--) {
 					newpts->pts[*j].x = Ax;
 					newpts->pts[*j].y = Ay;
 					(*j)++;
-		
+
 					if (P > 0) {	/* is the pixel going up AND right? */
 								Ax+=Xincr;	/* increment dependent variable */
 								Ay+=Yincr;	/* increment independent variable */
@@ -1204,7 +1204,7 @@ static void lialg_compute_chain_code(point_list *pts) {
 				int dy = endpt->y - startpt->y;
 				int tmp = quadr(likeatan(dy, dx));
 				int dircode = (12 - tmp) % 8;
-		
+
 				startpt->chaincode = dircode;
 	}
 }
@@ -1250,12 +1250,12 @@ static region_list *lialg_compute_regions(point_list *pts) {
 				int d_i = pts->pts[i].chaincode;
 				int d_iminusone = pts->pts[i-1].chaincode;
 				int a_i;
-		
+
 				if (d_iminusone < d_i)
 					d_iminusone += 8;
-		
+
 				a_i = (d_iminusone - d_i) % 8;
-		
+
 				/* convert to degrees, x 100 */
 				curr[i] = ((12 - a_i) % 8) * 45 * 100;
 	}
@@ -1266,14 +1266,14 @@ static region_list *lialg_compute_regions(point_list *pts) {
 	for (j = 0; j < LP_FILTER_ITERS; j++, curr = R[j], next = R[j+1]) {
 				for (i = 0; i < pts->npts; i++) {
 					int k;
-		
+
 					next[i] = 0;
-		
+
 					for (k = i - LP_FILTER_WIDTH; k <= i + LP_FILTER_WIDTH; k++) {
 						int oldval = (k < 0 || k >= pts->npts) ? 18000 : curr[k];
 						next[i]	+= oldval * lialg_lpfwts[k - (i	- LP_FILTER_WIDTH)];	/* overflow? */
 					}
-		
+
 					next[i] /= lialg_lpfconst;
 				}
 	}
@@ -1287,7 +1287,7 @@ static region_list *lialg_compute_regions(point_list *pts) {
 	/* Debugging. */
 	if (lidebug > 1) {
 				for (i = 0; i < pts->npts; i++) {
-					fprint(2, "%3d:  (%P)  %lud  ",
+					fprint(2, "%3d:  (%P)  %lu  ",
 								i, pts->pts[i].Point, pts->pts[i].chaincode);
 					for (j = 0; j < 2 + LP_FILTER_ITERS; j++)
 						fprint(2, "%d  ", R[j][i]);
@@ -1299,9 +1299,9 @@ static region_list *lialg_compute_regions(point_list *pts) {
 	{
 				int start, end;
 				int currtype;
-		
+
 #define	RGN_TYPE(val) (((val)==18000)?RGN_PLAIN:((val)<18000?RGN_CONCAVE:RGN_CONVEX))
-		
+
 				start = 0;
 				currtype = RGN_TYPE(curr[0]);
 				regions = malloc(sizeof(region_list));
@@ -1312,15 +1312,15 @@ static region_list *lialg_compute_regions(point_list *pts) {
 				curr_reg->next = nil;
 				for (i = 1; i < pts->npts; i++) {
 					int nexttype = RGN_TYPE(curr[i]);
-		
+
 					if (nexttype != currtype) {
 								region_list *next_reg;
-				
+
 								end = i - 1;
 								curr_reg->end = end;
 								if (lidebug > 1)
 									fprint(2, "  (%d, %d), %d\n", start, end, currtype);
-				
+
 								start = i;
 								currtype = nexttype;
 								next_reg = malloc(sizeof(region_list));
@@ -1328,7 +1328,7 @@ static region_list *lialg_compute_regions(point_list *pts) {
 								next_reg->end = 0;
 								next_reg->type = nexttype;
 								next_reg->next = nil;
-				
+
 								curr_reg->next = next_reg;
 								curr_reg = next_reg;
 					}
@@ -1342,7 +1342,7 @@ static region_list *lialg_compute_regions(point_list *pts) {
 				for (curr_reg = regions; curr_reg; curr_reg = curr_reg->next)
 					if (curr_reg->type == RGN_PLAIN) {
 								region_list *next_reg;
-				
+
 								for (next_reg = curr_reg->next;
 									 next_reg != nil &&
 									   (next_reg->end - next_reg->start) < LP_FILTER_MIN;
@@ -1350,19 +1350,19 @@ static region_list *lialg_compute_regions(point_list *pts) {
 									/* next_reg must not be plain, and it must be followed by a plain */
 									/* assert(next_reg->type != RGN_PLAIN); */
 									/* assert(next_reg->next != nil && (next_reg->next)->type == RGN_PLAIN); */
-				
+
 									curr_reg->next = (next_reg->next)->next;
 									curr_reg->end = (next_reg->next)->end;
-				
+
 									free(next_reg->next);
 									free(next_reg);
 								}
 					}
-		
+
 				/* Add-in pseudo-extremes. */
 				{
 					region_list *tmp, *prev_reg;
-		
+
 					tmp = regions;
 					regions = nil;
 					prev_reg = nil;
@@ -1380,20 +1380,20 @@ static region_list *lialg_compute_regions(point_list *pts) {
 
 							if (lidebug)
 								fprint(2, "%d, %d, %d\n", arclen, chordlen, atcr);
-		
+
 							/* Split region if necessary. */
 							if (arclen >= PE_AL_THLD && atcr >= PE_ATCR_THLD) {
 								int mid = curr_reg->start + (curr_reg->end - curr_reg->start) / 2;
 								int end = curr_reg->end;
 								region_list *saved_next = curr_reg->next;
-		
+
 								curr_reg->end = mid - 1;
 								if (prev_reg == nil)
 									regions = curr_reg;
 								else
 									prev_reg->next = curr_reg;
 								prev_reg = curr_reg;
-		
+
 								/* curr_reg = (region_list *)safe_malloc(sizeof(region_list));*/
 								curr_reg = malloc(sizeof(region_list));
 								curr_reg->start = mid;
@@ -1402,7 +1402,7 @@ static region_list *lialg_compute_regions(point_list *pts) {
 								curr_reg->next = nil;
 								prev_reg->next = curr_reg;
 								prev_reg = curr_reg;
-		
+
 								/* curr_reg = (region_list *)malloc(sizeof(region_list)); */
 								curr_reg = malloc(sizeof(region_list));
 								curr_reg->start = mid + 1;
@@ -1411,12 +1411,12 @@ static region_list *lialg_compute_regions(point_list *pts) {
 								curr_reg->next = nil;
 								prev_reg->next = curr_reg;
 								prev_reg = curr_reg;
-		
+
 								curr_reg->next = saved_next;
 								continue;
 							}
 						}
-		
+
 						if (prev_reg == nil)
 							regions = curr_reg;
 						else
@@ -1475,7 +1475,7 @@ static point_list *lialg_compute_dompts(point_list *pts, region_list *regions) {
 						int max_ix = -1;
 						int min_ix = -1;
 						int i;
-		
+
 						for (i = curr->start; i <= curr->end; i++) {
 							int v = cas[i];
 							if (v > max_v) { max_v = v; max_ix = i; }
@@ -1483,15 +1483,15 @@ static point_list *lialg_compute_dompts(point_list *pts, region_list *regions) {
 							if (lidebug > 1)
 								fprint(2, "  %d\n", v);
 						}
-		
+
 						currix = (curr->type == RGN_CONVEX ? max_ix : min_ix);
-		
+
 						/* Record midpoint. */
 						dpts->pts[dp++] = pts->pts[previx + (currix - previx) / 2];
-		
+
 						/* Record extreme point. */
 						dpts->pts[dp++] = pts->pts[currix];
-		
+
 						previx = currix;
 			}
 
@@ -1701,7 +1701,7 @@ static int lialg_compute_distance(point_list *input_dompts,
 						int dx = bx - ax;
 						int dy = by - ay;
 						int dist = isqrt(10000 * (dx * dx + dy * dy));
-				
+
 						C[i][j] = dist;
 				}
 		}
@@ -1712,29 +1712,29 @@ static int lialg_compute_distance(point_list *input_dompts,
 		for (j = N; j > 0; j--)
 				for (i = M; i > 0; i--) {
 						int min = MAX_DIST;
-		
+
 						if (i > BE[j] || i < TE[j] || (j == N && i == M))
 								continue;
-		
+
 						if (j < N) {
 								if (i >= TE[j+1]) {
 										int tmp = C[i][j+1];
 										if (tmp < min)
 												min = tmp;
 								}
-		
+
 								if (i < M) {
 										int tmp = C[i+1][j+1];
 										if (tmp < min)
 												min = tmp;
 								}
 						}
-		
+
 						if (i < BE[j]) {
 								int tmp = C[i+1][j];
 								if (tmp < min) min = tmp;
 						}
-		
+
 						C[i][j] += min;
 				}
 
@@ -1762,26 +1762,26 @@ static int lialg_read_classifier_digest(rClassifier *rec) {
 	{
 				char *clx_path;
 				char *dot;
-		
+
 				/* Get a copy of the filename, with some room on the end. */
 				/*	clx_path = safe_malloc(strlen(rec->file_name) + 5); */
 				clx_path = malloc((strlen(rec->file_name) + 5) *sizeof(char));
 				strcpy(clx_path, rec->file_name);
-		
+
 				/* Truncate the path after the last dot. */
 				dot = strrchr(clx_path, '.');
 				if (dot == nil) { free(clx_path); return(-1); }
 				*(dot + 1) = 0;
-		
+
 				/* Append the classifier-digest extension. */
 				strcat(clx_path, "clx");
-		
+
 				fp = fopen(clx_path, "r");
 				if (fp == nil) {
 						free(clx_path);
 						return(-1);
 				}
-		
+
 				free(clx_path);
 	}
 
@@ -1881,7 +1881,7 @@ static int lialg_canonicalize_examples(rClassifier *rec) {
 		int minx, miny, maxx, maxy;
 		int avgxrange, avgyrange, avgxoff, avgyoff, avgscale;
 
-		
+
 		if (lidebug) {
 			fprint(2, "lialg_canonicalize_examples working on class %s\n",
 					rec->cnames[i]);
@@ -2144,7 +2144,7 @@ static int lialg_compute_equipoints(point_list *points) {
 		equipoints[nequipoints] = points->pts[points->npts - 1];
 	} else {
 	  if (lidebug) {
-		fprint(2,"lialg_compute_equipoints: nequipoints = %d\n", 
+		fprint(2,"lialg_compute_equipoints: nequipoints = %d\n",
 				nequipoints);
 	  }
 /*	assert(false);*/
@@ -2298,19 +2298,19 @@ static int isqrt(int n) {
 
 
 /* Helper routines from Mark Hayter. */
-static int likeatan(int tantop, int tanbot) { 
+static int likeatan(int tantop, int tanbot) {
 		int t;
 		/* Use tan(theta)=top/bot --> order for t */
 		/* t in range 0..0x40000 */
 
-		if ((tantop == 0) && (tanbot == 0)) 
+		if ((tantop == 0) && (tanbot == 0))
 				t = 0;
 	else
 		{
 				t = (tantop << 16) / (abs(tantop) + abs(tanbot));
-				if (tanbot < 0) 
+				if (tanbot < 0)
 						t = 0x20000 - t;
-				else 
+				else
 						if (tantop < 0) t = 0x40000 + t;
 		}
 		return t;

--- a/sys/src/libscribble/scribbleimpl.h
+++ b/sys/src/libscribble/scribbleimpl.h
@@ -7,7 +7,7 @@
  * in the LICENSE file.
  */
 
-/* 
+/*
  *  scribble.h:			User-Level API for Handwriting Recognition
  *  Author:				James Kempf
  *  Created On:			Mon Nov  2 14:01:25 1992
@@ -15,8 +15,8 @@
  *  Last Modified On:	Fri Aug 25 10:24:50 EDT 2000
  *  Copyright (c) 1994 by Sun Microsystems Computer Company
  *  All rights reserved.
- *  
- *  Use and copying of this software and preparation of 
+ *
+ *  Use and copying of this software and preparation of
  *  derivative works based upon this software are permitted.
  *  Any distribution of this software or derivative works
  *  must comply with all applicable United States export control
@@ -31,7 +31,7 @@
  * Opaque type for the recognizer. The toolkit must access through
  * appropriate access functions.
  */
-#pragma incomplete struct _Recognizer
+//#pragma incomplete struct _Recognizer
 typedef struct _Recognizer* recognizer;
 
 /*
@@ -74,7 +74,7 @@ typedef unsigned char rec_confidence;
  * recognition can be limited. The locale and category should be
  * suitable for the setlocale(3). Those recognizers which don't do text
  * can simply report a blank locale and category, and report the
- * graphics types they recognize in the subset. 
+ * graphics types they recognize in the subset.
  */
 
 typedef struct {
@@ -111,7 +111,7 @@ typedef struct {
 
 /*Bounding box. Structurally identical to Rectangle.*/
 
-typedef Rectangle pen_rect;    
+typedef Rectangle pen_rect;
 
 
 /*
@@ -123,10 +123,10 @@ typedef Rectangle pen_rect;
 typedef struct {
 	pen_rect pr_area;
 	short pr_row, pr_col;
-} pen_frame; 
+} pen_frame;
 
-/* 
- * Structure for describing a set of letters to constrain recognition. 
+/*
+ * Structure for describing a set of letters to constrain recognition.
  * ls_type is the same as the re_type field for rec_element below.
 */
 
@@ -152,8 +152,8 @@ typedef struct _letterset {
 #define REC_CORR    0x20	    /*rec_correlation struct*/
 
 /*
- * Recognition elements. A recognition element is a structure having a 
- * confidence level member, and a union, along with a flag indicating 
+ * Recognition elements. A recognition element is a structure having a
+ * confidence level member, and a union, along with a flag indicating
  * the union type. The union contains a pointer to the result. This
  * is the basic recognition return value, corresponding to one
  * recognized word, letter, or group of letters.
@@ -166,7 +166,7 @@ struct rec_element {
 		char*				aval;	/*ASCII and variable width.*/
 		wchar_t*			wval;	/*Unicode.*/
 		rec_correlation*	rcval;	/*rec_correlation*/
-	} re_result;                   
+	} re_result;
 	rec_confidence	re_conf;        /*Confidence (0-100).*/
 };
 
@@ -187,7 +187,7 @@ struct rec_alternative {
 
 /*
  * Gestures. The toolkit initializes the recognizer with a
- * set of gestures having appropriate callbacks. 
+ * set of gestures having appropriate callbacks.
  * When a gesture is recognized, it is returned as part of a
  * recognition element. The recognizer fills in the bounding
  * box and hotspots. The toolkit fills in any additional values,
@@ -212,7 +212,7 @@ typedef void (*xgesture)(gesture*);
  * a pointer to an arrray of pointers to strokes, and
  * two arrays of integers, giving the starting point and
  * stopping point of each corresponding recogition element returned
- * in the strokes. 
+ * in the strokes.
  */
 
 struct rec_correlation {
@@ -244,7 +244,7 @@ recognizer	recognizer_load(char*, char*, char**);
 int			recognizer_unload(recognizer);
 
 /*
- * recognizer_get_info-Get a pointer to a rec_info 
+ * recognizer_get_info-Get a pointer to a rec_info
  * giving the locale and subsets supported by the recognizer, and shared
  * library pathname.
  */
@@ -324,26 +324,26 @@ int			recognizer_delete_from_dictionary(recognizer, letterset*, wordset);
  * TRANSLATION
  */
 
-/* recognizer_set/get_context - Set/get the recognition context for 
- * subsequent buffering and translation. recognizer_set_context() 
- * returns -1 if an error occurs, otherwise 0. recognizer_get_context() 
- * returns NULL if no context has been set. The context is copied to avoid 
+/* recognizer_set/get_context - Set/get the recognition context for
+ * subsequent buffering and translation. recognizer_set_context()
+ * returns -1 if an error occurs, otherwise 0. recognizer_get_context()
+ * returns NULL if no context has been set. The context is copied to avoid
  * potential memory deallocation problems.
  */
 
 int			recognizer_set_context(recognizer, rc*);
 rc*			recognizer_get_context(recognizer);
 
-/* recognizer_clear - Set stroke buffer to NULL and clear the context. 
- * Returns -1 if an error occurred, otherwise 0. Both the context and the 
+/* recognizer_clear - Set stroke buffer to NULL and clear the context.
+ * Returns -1 if an error occurred, otherwise 0. Both the context and the
  * stroke buffer are deallocated. If delete_points_p is true, delete the
  * points also.
  */
 
 int			recognizer_clear(recognizer, bool);
 
-/* recognizer_get/set_buffer - Get/set the stroke buffer. The stroke buffer 
- * is copied to avoid potential memory allocation problems. Returns -1 if 
+/* recognizer_get/set_buffer - Get/set the stroke buffer. The stroke buffer
+ * is copied to avoid potential memory allocation problems. Returns -1 if
  * an error occurs, otherwise 0.
  */
 
@@ -351,14 +351,14 @@ int			recognizer_get_buffer(recognizer, uint*, Stroke**);
 int			recognizer_set_buffer(recognizer, uint, Stroke*);
 
 /* recognizer_translate - Copy the strokes argument into the stroke buffer and
- * translate the buffer. If correlate_p is true, then provide stroke 
- * correlations as well. If either nstrokes is 0 or strokes is NULL, then 
- * just translate the stroke buffer and return the translation. Return an 
- * array of alternative translation segmentations in the ret pointer and the 
- * number of alternatives in nret, or NULL and 0 if there is no translation. 
- * The direction of segmentation is as specified by the rc_direction field in 
- * the buffered recognition context. Returns -1 if an error occurred, 
- * otherwise 0. 
+ * translate the buffer. If correlate_p is true, then provide stroke
+ * correlations as well. If either nstrokes is 0 or strokes is NULL, then
+ * just translate the stroke buffer and return the translation. Return an
+ * array of alternative translation segmentations in the ret pointer and the
+ * number of alternatives in nret, or NULL and 0 if there is no translation.
+ * The direction of segmentation is as specified by the rc_direction field in
+ * the buffered recognition context. Returns -1 if an error occurred,
+ * otherwise 0.
  */
 
 int			recognizer_translate(recognizer, uint, Stroke*, bool,
@@ -384,7 +384,7 @@ rec_fn*		recognizer_get_extension_functions(recognizer);
 char**		recognizer_get_gesture_names(recognizer);
 
 /*
- * recognizer_set_gesture_action-Set the action function associated with the 
+ * recognizer_set_gesture_action-Set the action function associated with the
  *  name.
  */
 


### PR DESCRIPTION
commit 6533db6114e97d5687bdb6a0f94136c98d009408
Author: Dan Cross <cross@gajendra.net>
Date:   Mon May 1 00:00:16 2017 +0000

    Remove trailing whitespace from source files.

    This is a trivial cleanup (done with a script, Ron!).

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit 789474da8c5122316f7ee093a02e84a4aed24ad2
Author: Dan Cross <cross@gajendra.net>
Date:   Thu Apr 20 17:59:21 2017 +0000

    Kill a couple of thousand warnings.

    These are the easy ones. I've got a few hundred left.

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit 9fba51d999489cf1bf2adf3a35c2260caebf0c32
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Wed Jul 6 13:09:10 2016 -0700

    fixfmt: fix all usages of %u so that u is a type, not a modifier

    The rest of the world uses %u to mean unsigned decimal. Plan 9
    uses it as a modifier, which is arguably better, but what can we do?
    You don't always get to pick the standard.

    This change modifies libc/fmt so that %u is unsigned decimal, and
    modifies most uses of it so the kernel almost boots. Almost. Obviously
    we didn't get them all yet.

    It hangs in ipconfig.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>