### PR TITLE
Reintroduce libString

### DIFF
--- a/sys/src/libString/libString.json
+++ b/sys/src/libString/libString.json
@@ -1,27 +1,28 @@
 {
-	"Include": [
-		"../lib.json"
-	],
-	"Install": "/$ARCH/lib/",
-	"Library": "libString.a",
-	"Name": "libString",
-	"SourceFiles": [
-		"s_alloc.c",
-		"s_append.c",
-		"s_array.c",
-		"s_copy.c",
-		"s_getline.c",
-		"s_grow.c",
-		"s_memappend.c",
-		"s_nappend.c",
-		"s_parse.c",
-		"s_putc.c",
-		"s_rdinstack.c",
-		"s_read.c",
-		"s_read_line.c",
-		"s_reset.c",
-		"s_terminate.c",
-		"s_tolower.c",
-		"s_unique.c"
-	]
+	"libString": {
+		"Include": [
+			"../lib.json"
+		],
+		"Install": "/$ARCH/lib/",
+		"Library": "libString.a",
+		"SourceFiles": [
+			"s_alloc.c",
+			"s_append.c",
+			"s_array.c",
+			"s_copy.c",
+			"s_getline.c",
+			"s_grow.c",
+			"s_memappend.c",
+			"s_nappend.c",
+			"s_parse.c",
+			"s_putc.c",
+			"s_rdinstack.c",
+			"s_read.c",
+			"s_read_line.c",
+			"s_reset.c",
+			"s_terminate.c",
+			"s_tolower.c",
+			"s_unique.c"
+		]
+	}
 }

--- a/sys/src/libString/s_alloc.c
+++ b/sys/src/libString/s_alloc.c
@@ -64,13 +64,13 @@ s_newalloc(int len)
 	sp = _s_alloc();
 	if(sp == nil)
 		sysfatal("s_newalloc: %r");
-	setmalloctag(sp, getcallerpc(&len));
+	setmalloctag(sp, getcallerpc());
 	if(len < STRLEN)
 		len = STRLEN;
 	sp->base = sp->ptr = malloc(len);
 	if (sp->base == nil)
 		sysfatal("s_newalloc: %r");
-	setmalloctag(sp->base, getcallerpc(&len));
+	setmalloctag(sp->base, getcallerpc());
 
 	sp->end = sp->base + len;
 	s_terminate(sp);

--- a/sys/src/libString/s_copy.c
+++ b/sys/src/libString/s_copy.c
@@ -21,7 +21,7 @@ s_copy(char *cp)
 
 	len = strlen(cp)+1;
 	sp = s_newalloc(len);
-	setmalloctag(sp, getcallerpc(&cp));
+	setmalloctag(sp, getcallerpc());
 	strcpy(sp->base, cp);
 	sp->ptr = sp->base + len - 1;		/* point to 0 terminator */
 	return sp;

--- a/sys/src/libString/s_getline.c
+++ b/sys/src/libString/s_getline.c
@@ -18,7 +18,7 @@
  * Leading whitespace and newlines are removed.
  *
  * Empty lines and lines starting with '#' are ignored.
- */ 
+ */
 extern char *
 s_getline(Biobuf *fp, String *to)
 {

--- a/sys/src/libString/s_grow.c
+++ b/sys/src/libString/s_grow.c
@@ -13,7 +13,7 @@
 
 /* grow a String's allocation by at least `incr' bytes */
 extern String*
-s_grow(String *s, int incr)	
+s_grow(String *s, int incr)
 {
 	char *cp;
 	int size;
@@ -40,4 +40,3 @@ s_grow(String *s, int incr)
 
 	return s;
 }
-

--- a/sys/src/libString/s_memappend.c
+++ b/sys/src/libString/s_memappend.c
@@ -26,4 +26,3 @@ s_memappend(String *to, char *from, int n)
 	s_terminate(to);
 	return to;
 }
-

--- a/sys/src/libString/s_nappend.c
+++ b/sys/src/libString/s_nappend.c
@@ -24,4 +24,3 @@ s_nappend(String *to, char *from, int n)
 	s_terminate(to);
 	return to;
 }
-

--- a/sys/src/libString/s_parse.c
+++ b/sys/src/libString/s_parse.c
@@ -27,13 +27,13 @@ s_parse(String *from, String *to)
 		from->ptr++;
 		for (;*from->ptr != '\'' && *from->ptr != '\0'; from->ptr++)
 			s_putc(to, *from->ptr);
-		if (*from->ptr == '\'')	
+		if (*from->ptr == '\'')
 			from->ptr++;
 	} else if (*from->ptr == '"') {
 		from->ptr++;
 		for (;*from->ptr != '"' && *from->ptr != '\0'; from->ptr++)
 			s_putc(to, *from->ptr);
-		if (*from->ptr == '"')	
+		if (*from->ptr == '"')
 			from->ptr++;
 	} else {
 		for (;!isspace(*from->ptr) && *from->ptr != '\0'; from->ptr++)

--- a/sys/src/libString/s_rdinstack.c
+++ b/sys/src/libString/s_rdinstack.c
@@ -98,7 +98,7 @@ out:
  * Leading whitespace and newlines are removed.
  * Lines starting with #include cause us to descend into the new file.
  * Empty lines and other lines starting with '#' are ignored.
- */ 
+ */
 extern char *
 s_rdinstack(Sinstack *sp, String *to)
 {

--- a/sys/src/libString/s_read.c
+++ b/sys/src/libString/s_read.c
@@ -20,7 +20,7 @@ enum
 /* Append up to 'len' input bytes to the string 'to'.
  *
  * Returns the number of characters read.
- */ 
+ */
 extern int
 s_read(Biobuf *fp, String *to, int len)
 {

--- a/sys/src/libString/s_read_line.c
+++ b/sys/src/libString/s_read_line.c
@@ -16,7 +16,7 @@
  *
  * Returns a pointer to the character string (or 0).
  * Trailing newline is left on.
- */ 
+ */
 extern char *
 s_read_line(Biobuf *fp, String *to)
 {


### PR DESCRIPTION
commit 1d0e45488f79506550e2f841ebe415b6bd1fb92a
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Sun Apr 24 13:01:24 2016 -0700

    clang: fix libString

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit 275f0b42411259f8078477cf24f2b338d47c6ab2
Author: Dan Cross <cross@gajendra.net>
Date:   Thu Apr 20 16:19:04 2017 +0000

    Really expose warnings

    But also make it so that we can continue building.
    By exposing them, we see them so we can fix them.

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit 331ffebb5394eb0768cea498e43a2d2c98829e9d
Author: Sevki Hasirci <s@sevki.org>
Date:   Mon Feb 22 00:55:22 2016 +0100

    just the files

commit 48090c023db7a9d0f4f36f3b270dc30080c24ce5
Author: ron minnich <rminnich@gmail.com>
Date:   Sun Feb 14 05:49:03 2016 +0100

    Revert "build: added new build files"
    Does not work at all. Can't build a working system with it yet.

    Let's take this slower, ok? Not break it all next time.

    This reverts commit 4fd75744926150212a0c0cd3c5a2ea51d0637d12.

    Change-Id: I91fce92249dd9d7bf3ca731a124c61a499382dd2

commit 4fd75744926150212a0c0cd3c5a2ea51d0637d12
Author: Sevki <sevki@spotify.com>
Date:   Wed Jan 27 12:46:31 2016 +0100

    build: added new build files

    kernel compiles and crashes

    closes #37

    to test use

            go get -u sevki.org/build/cmd/build
            build //sys/src/9/amd64:harvey
    or

            build -v //sys/src/9/amd64:harvey

    inside a editor like emacs or acme.

    If you are building on OS X you should also have something like .build
    file at the root of the project and add something like

            CC: gcc
            TOOLPREFIX: x86_64-elf-

    Change-Id: Ib6f6156eee1936ceb5f8b0bfa64ed45589195c31
    Signed-off-by: Sevki <sevki@spotify.com>

commit 6533db6114e97d5687bdb6a0f94136c98d009408
Author: Dan Cross <cross@gajendra.net>
Date:   Mon May 1 00:00:16 2017 +0000

    Remove trailing whitespace from source files.

    This is a trivial cleanup (done with a script, Ron!).

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit ba14fa27776ef2371a42607ec04bf50287fbd0be
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Fri Nov 13 08:20:41 2015 -0800

    New json format per Giacomo's ideas.

    Instead of this:
    {
            "Name": "a",
            ...
    }

    Do this:
    {
            "Name": {
                    ...
            }
    }

    This is way better. Now the name is visible at the top level of any json viewer, we can
    have multiple stanzas per file, the name is way more easy to find, ... the advantages are legion.

    This includes a change to build.go but not to preen.

    This now works fine, BUILD all produces a working kernel and userland. But someone else needs to verify it.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

    Change-Id: I9b1cf2597e582895b8f3ab127bc9c1d77de96cbd

commit c58c6c510d5875253d66b4d26d9ae9025f9191f3
Author: Dan Cross <cross@gajendra.net>
Date:   Mon May 1 00:39:33 2017 +0000

    Remove blank lines at end of file.

    Remove a bunch of blank lines at the end of files.

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit d1fb0c482bdf91d873a49e896e1c39d0812903a4
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Fri Apr 22 22:23:49 2016 -0700

    Further deanon.

    This fixes the rc explosions, weirdly enough.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit f200726d9517f4691bf61887751dfb59e9f3f8f6
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Fri Apr 22 21:05:35 2016 -0700

    Bring some things back (which I had hoped to remove forever)

    Now, this all boots, but something in cpurc gets a fault, not sure what.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>