### PR TITLE
Reintroduce libusb

### DIFF
--- a/sys/src/libusb/BUILD
+++ b/sys/src/libusb/BUILD
@@ -14,7 +14,6 @@ cc_library(
 		"lib/parse.c",
 		"lib/fs.c",
 		"lib/fsdir.c",
-		"audio/audio.c",
 		"audio/audioctl.c",
 		"audio/audiofs.c",
 		"audio/audiosub.c",

--- a/sys/src/libusb/audio/audioctl.c
+++ b/sys/src/libusb/audio/audioctl.c
@@ -1,0 +1,706 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <usb/usb.h>
+#include <usb/audio.h>
+#include <usb/audioctl.h>
+
+int endpt[2] =		{-1, -1};
+int interface[2] =	{-1, -1};
+int featureid[2] =	{-1, -1};
+int selectorid[2] =	{-1, -1};
+int mixerid[2] =	{-1, -1};
+int curalt[2] =		{-1, -1};
+int buttonendpt =	-1;
+
+int id;
+Dev *ad;
+
+Audiocontrol controls[2][Ncontrol] = {
+	{
+	[Speed_control] = {		"speed",	0, 0, 0,	{44100,	Undef}},
+	[Mute_control] = {		"mute",		0, 0, 0,	{0,	Undef}},
+	[Volume_control] = {		"volume",	0, 0, 0,	{0,	Undef}},
+	[Bass_control] = {		"bass",		0, 0, 0,	{0,	Undef}},
+	[Mid_control] = {		"mid",		0, 0, 0,	{0,	Undef}},
+	[Treble_control] = {		"treble",	0, 0, 0,	{0,	Undef}},
+	[Equalizer_control] = {		"equalizer",	0, 0, 0,	{0,	Undef}},
+	[Agc_control] = {		"agc",		0, 0, 0,	{0,	Undef}},
+	[Delay_control] = {		"delay",	0, 0, 0,	{0,	Undef}},
+	[Bassboost_control] = {		"bassboost",	0, 0, 0,	{0,	Undef}},
+	[Loudness_control] = {		"loudness",	0, 0, 0,	{0,	Undef}},
+	[Channel_control] = {		"channels",	0, 0, 0,	{2,	Undef}},
+	[Resolution_control] = {	"resolution",	0, 0, 0,	{16,	Undef}},
+//	[Selector_control] = {		"selector",	0, 0, 0,	{0,	Undef}},
+	}, {
+	[Speed_control] = {		"speed",	0, 0, 0,	{44100,	Undef}},
+	[Mute_control] = {		"mute",		0, 0, 0,	{0,	Undef}},
+	[Volume_control] = {		"volume",	0, 0, 0,	{0,	Undef}},
+	[Bass_control] = {		"bass",		0, 0, 0,	{0,	Undef}},
+	[Mid_control] = {		"mid",		0, 0, 0,	{0,	Undef}},
+	[Treble_control] = {		"treble",	0, 0, 0,	{0,	Undef}},
+	[Equalizer_control] = {		"equalizer",	0, 0, 0,	{0,	Undef}},
+	[Agc_control] = {		"agc",		0, 0, 0,	{0,	Undef}},
+	[Delay_control] = {		"delay",	0, 0, 0,	{0,	Undef}},
+	[Bassboost_control] = {		"bassboost",	0, 0, 0,	{0,	Undef}},
+	[Loudness_control] = {		"loudness",	0, 0, 0,	{0,	Undef}},
+	[Channel_control] = {		"channels",	0, 0, 0,	{2,	Undef}},
+	[Resolution_control] = {	"resolution",	0, 0, 0,	{16,	Undef}},
+//	[Selector_control] = {		"selector",	0, 0, 0,	{0,	Undef}},
+	}
+};
+
+int
+setaudioalt(int rec, Audiocontrol *c, int control)
+{
+	dprint(2, "setcontrol %s: Set alt %d\n", c->name, control);
+	curalt[rec] = control;
+	if(usbcmd(ad, Rh2d|Rstd|Riface, Rsetiface, control, interface[rec], nil, 0) < 0){
+		dprint(2, "setcontrol: setupcmd %s failed\n", c->name);
+		return -1;
+	}
+	return control;
+}
+
+int
+findalt(int rec, int nchan, int res, int speed)
+{
+	Ep *ep;
+	Audioalt *a;
+	Altc *da;
+	int i, j, k, retval;
+
+	retval = -1;
+	controls[rec][Channel_control].min = 1000000;
+	controls[rec][Channel_control].max = 0;
+	controls[rec][Channel_control].step = Undef;
+	controls[rec][Resolution_control].min = 1000000;
+	controls[rec][Resolution_control].max = 0;
+	controls[rec][Resolution_control].step = Undef;
+	for(i = 0; i < nelem(ad->usb->ep); i++){
+		if((ep = ad->usb->ep[i]) == nil)
+			continue;
+		if(ep->iface == nil){
+			fprint(2, "\tno interface\n");
+			return 0;
+		}
+		if(ep->iface->csp != CSP(Claudio, 2, 0))
+			continue;
+		if((rec == Play && (ep->addr &  0x80))
+		|| (rec == Record && (ep->addr &  0x80) == 0))
+			continue;
+		for(j = 0; j < 16; j++){
+			if((da = ep->iface->altc[j]) == nil || (a = da->aux) == nil)
+				continue;
+			if(a->nchan < controls[rec][Channel_control].min)
+				controls[rec][Channel_control].min = a->nchan;
+			if(a->nchan > controls[rec][Channel_control].max)
+				controls[rec][Channel_control].max = a->nchan;
+			if(a->res < controls[rec][Resolution_control].min)
+				controls[rec][Resolution_control].min = a->res;
+			if(a->res > controls[rec][Resolution_control].max)
+				controls[rec][Resolution_control].max = a->res;
+			controls[rec][Channel_control].settable = 1;
+			controls[rec][Channel_control].readable = 1;
+			controls[rec][Resolution_control].settable = 1;
+			controls[rec][Resolution_control].readable = 1;
+			controls[rec][Speed_control].settable = 1;
+			controls[rec][Speed_control].readable = 1;
+			if(a->nchan == nchan && a->res == res){
+				if(speed == Undef)
+					retval = j;
+				else if(a->caps & (has_discfreq|onefreq)){
+					for(k = 0; k < nelem(a->freqs); k++){
+						if(a->freqs[k] == speed){
+							retval = j;
+							break;
+						}
+					}
+				}else{
+					if(speed >= a->minfreq && speed <= a->maxfreq)
+						retval = j;
+				}
+			}
+		}
+	}
+	if(usbdebug && retval < 0)
+		fprint(2, "findalt(%d, %d, %d, %d) failed\n", rec, nchan, res, speed);
+	return retval;
+}
+
+int
+setspeed(int rec, int speed)
+{
+	int ps, n, no, dist, i;
+	Audioalt *a;
+	Altc *da;
+	Ep *ep;
+	uint8_t buf[3];
+
+	if(rec == Record && !setrec)
+		return Undef;
+	if(curalt[rec] < 0){
+		fprint(2, "Must set channels and resolution before speed\n");
+		return Undef;
+	}
+	if(endpt[rec] < 0)
+		sysfatal("endpt[%s] not set", rec?"Record":"Playback");
+	ep = ad->usb->ep[endpt[rec]];
+	if(ep->iface == nil)
+		sysfatal("no interface");
+	if(curalt[rec] < 0)
+		sysfatal("curalt[%s] not set", rec?"Record":"Playback");
+	da = ep->iface->altc[curalt[rec]];
+	a = da->aux;
+	if(a->caps & onefreq){
+		dprint(2, "setspeed %d: onefreq\n", speed);
+		/* speed not settable, but packet size must still be set */
+		speed = a->freqs[0];
+	}else if(a->caps & has_contfreq){
+		dprint(2, "setspeed %d: contfreq\n", speed);
+		if(speed < a->minfreq)
+			speed = a->minfreq;
+		else if(speed > a->maxfreq)
+			speed = a->maxfreq;
+		dprint(2, "Setting continuously variable %s speed to %d\n",
+				rec?"record":"playback", speed);
+	}else if(a->caps & has_discfreq){
+		dprint(2, "setspeed %d: discfreq\n", speed);
+		dist = 1000000;
+		no = -1;
+		for(i = 0; a->freqs[i] > 0; i++)
+			if(abs(a->freqs[i] - speed) < dist){
+				dist = abs(a->freqs[i] - speed);
+				no = i;
+			}
+		if(no == -1){
+			dprint(2, "no = -1\n");
+			return Undef;
+		}
+		speed = a->freqs[no];
+		dprint(2, "Setting discreetly variable %s speed to %d\n",
+				rec?"record":"playback", speed);
+	}else{
+		dprint(2, "can't happen\n?");
+		return Undef;
+	}
+	if(a->caps & has_setspeed){
+		dprint(2, "Setting %s speed to %d Hz;", rec?"record":"playback", speed);
+		buf[0] = speed;
+		buf[1] = speed >> 8;
+		buf[2] = speed >> 16;
+		n = endpt[rec];
+		if(rec)
+			n |= 0x80;
+		if(usbcmd(ad, Rh2d|Rclass|Rep, Rsetcur, sampling_freq_control<<8, n, buf, 3) < 0){
+			fprint(2, "Error in setupcmd\n");
+			return Undef;
+		}
+		if((n=usbcmd(ad, Rd2h|Rclass|Rep, Rgetcur, sampling_freq_control<<8, n, buf, 3)) < 0){
+			fprint(2, "Error in setupreq\n");
+			return Undef;
+		}
+		if(n != 3)
+			fprint(2, "Error in setupreply: %d\n", n);
+		else{
+			n = buf[0] | buf[1] << 8 | buf[2] << 16;
+			if(buf[2] || n == 0){
+				dprint(2, "Speed out of bounds %d (0x%x)\n", n, n);
+			}else if(n != speed && ad->usb->vid == 0x077d &&
+			    (ad->usb->did == 0x0223 || ad->usb->did == 0x07af)){
+				/* Griffin iMic responds incorrectly to sample rate inquiry */
+				dprint(2, " reported as %d (iMic bug?);", n);
+			}else
+				speed = n;
+		}
+		dprint(2, " speed now %d Hz;", speed);
+	}
+	ps = ((speed * da->interval + 999) / 1000)
+		* controls[rec][Channel_control].value[0]
+		* controls[rec][Resolution_control].value[0]/8;
+	if(ps > ep->maxpkt){
+		fprint(2, "%s: setspeed(rec %d, speed %d): packet size %d > "
+			"maximum packet size %d\n",
+			argv0, rec, speed, ps, ep->maxpkt);
+		return Undef;
+	}
+	dprint(2, "Configuring %s endpoint for %d Hz\n",
+				rec?"record":"playback", speed);
+	epdev[rec] = openep(ad, endpt[rec]);
+	if(epdev[rec] == nil)
+		sysfatal("openep rec %d: %r", rec);
+
+	devctl(epdev[rec], "pollival %d", da->interval);
+	devctl(epdev[rec], "samplesz %ld", controls[rec][Channel_control].value[0] *
+				controls[rec][Resolution_control].value[0]/8);
+	devctl(epdev[rec], "hz %d", speed);
+
+	/* NO: the client uses the endpoint file directly
+	if(opendevdata(epdev[rec], rec ? OREAD : OWRITE) < 0)
+		sysfatal("openep rec %d: %r", rec);
+	*/
+	return speed;
+}
+
+int32_t
+getspeed(int rec, int which)
+{
+	int i, n;
+	Audioalt *a;
+	Altc *da;
+	Ep *ep;
+	uint8_t buf[3];
+	int r;
+
+	if(curalt[rec] < 0){
+		fprint(2, "Must set channels and resolution before getspeed\n");
+		return Undef;
+	}
+	if(endpt[rec] < 0)
+		sysfatal("endpt[%s] not set", rec?"Record":"Playback");
+	dprint(2, "getspeed: endpt[%d] == %d\n", rec, endpt[rec]);
+	ep = ad->usb->ep[endpt[rec]];
+	if(ep->iface == nil)
+		sysfatal("no interface");
+	if(curalt[rec] < 0)
+		sysfatal("curalt[%s] not set", rec?"Record":"Playback");
+	da = ep->iface->altc[curalt[rec]];
+	a = da->aux;
+	if(a->caps & onefreq){
+		dprint(2, "getspeed: onefreq\n");
+		if(which == Rgetres)
+			return Undef;
+		return a->freqs[0];		/* speed not settable */
+	}
+	if(a->caps & has_setspeed){
+		dprint(2, "getspeed: has_setspeed, ask\n");
+		n = endpt[rec];
+		if(rec)
+			n |= 0x80;
+		r = Rd2h|Rclass|Rep;
+		if(usbcmd(ad,r,which,sampling_freq_control<<8, n, buf, 3) < 0)
+			return Undef;
+		if(n == 3){
+			if(buf[2]){
+				dprint(2, "Speed out of bounds\n");
+				if((a->caps & has_discfreq) && (buf[0] | buf[1] << 8) < 8)
+					return a->freqs[buf[0] | buf[1] << 8];
+			}
+			return buf[0] | buf[1] << 8 | buf[2] << 16;
+		}
+		dprint(2, "getspeed: n = %d\n", n);
+	}
+	if(a->caps & has_contfreq){
+		dprint(2, "getspeed: has_contfreq\n");
+		if(which == Rgetcur)
+			return controls[rec][Speed_control].value[0];
+		if(which == Rgetmin)
+			return a->minfreq;
+		if(which == Rgetmax)
+			return a->maxfreq;
+		if(which == Rgetres)
+			return 1;
+	}
+	if(a->caps & has_discfreq){
+		dprint(2, "getspeed: has_discfreq\n");
+		if(which == Rgetcur)
+			return controls[rec][Speed_control].value[0];
+		if(which == Rgetmin)
+			return a->freqs[0];
+		for(i = 0; i < 8 && a->freqs[i] > 0; i++)
+			;
+		if(which == Rgetmax)
+			return a->freqs[i-1];
+		if(which == Rgetres)
+			return Undef;
+	}
+	dprint(2, "can't happen\n?");
+	return Undef;
+}
+
+int
+setcontrol(int rec, char *name, int32_t *value)
+{
+	int i, ctl, m;
+	byte buf[3];
+	int type, req, control, index, count;
+	Audiocontrol *c;
+
+	c = nil;
+	for(ctl = 0; ctl < Ncontrol; ctl++){
+		c = &controls[rec][ctl];
+		if(strcmp(name, c->name) == 0)
+			break;
+	}
+	if(ctl == Ncontrol){
+		dprint(2, "setcontrol: control not found\n");
+		return -1;
+	}
+	if(c->settable == 0){
+		dprint(2, "setcontrol: control %d.%d not settable\n", rec, ctl);
+		if(c->chans){
+			for(i = 0; i < 8; i++)
+				if((c->chans & 1 << i) && c->value[i] != value[i])
+					return -1;
+			return 0;
+		}
+		if(c->value[0] != value[0])
+			return -1;
+		return 0;
+	}
+	if(c->chans){
+		value[0] = 0;	// set to average
+		m = 0;
+		for(i = 1; i < 8; i++)
+			if(c->chans & 1 << i){
+				if(c->min != Undef && value[i] < c->min)
+					value[i] = c->min;
+				if(c->max != Undef && value[i] > c->max)
+					value[i] = c->max;
+				value[0] += value[i];
+				m++;
+			}else
+				value[i] = Undef;
+		if(m) value[0] /= m;
+	}else{
+		if(c->min != Undef && value[0] < c->min)
+			value[0] = c->min;
+		if(c->max != Undef && value[0] > c->max)
+			value[0] = c->max;
+	}
+	req = Rsetcur;
+	count = 1;
+	switch(ctl){
+	default:
+		dprint(2, "setcontrol: can't happen\n");
+		return -1;
+	case Speed_control:
+		if((rec != Record || setrec) && (value[0] = setspeed(rec, value[0])) < 0)
+			return -1;
+		c->value[0] = value[0];
+		return 0;
+	case Equalizer_control:
+		/* not implemented */
+		return -1;
+	case Resolution_control:
+		control = findalt(rec, controls[rec][Channel_control].value[0], value[0], defaultspeed[rec]);
+		if(control < 0 || setaudioalt(rec, c, control) < 0){
+			dprint(2, "setcontrol: can't find setting for %s\n", c->name);
+			return -1;
+		}
+		c->value[0] = value[0];
+		controls[rec][Speed_control].value[0] = defaultspeed[rec];
+		return 0;
+	case Volume_control:
+	case Delay_control:
+		count = 2;
+		/* fall through */
+	case Mute_control:
+	case Bass_control:
+	case Mid_control:
+	case Treble_control:
+	case Agc_control:
+	case Bassboost_control:
+	case Loudness_control:
+		type = Rh2d|Rclass|Riface;
+		control = ctl<<8;
+		index = featureid[rec]<<8;
+		break;
+	case Selector_control:
+		type = Rh2d|Rclass|Riface;
+		control = 0;
+		index = selectorid[rec]<<8;
+		break;
+	case Channel_control:
+		control = findalt(rec, value[0], controls[rec][Resolution_control].value[0], defaultspeed[rec]);
+		if(control < 0 || setaudioalt(rec, c, control) < 0){
+			dprint(2, "setcontrol: can't find setting for %s\n", c->name);
+			return -1;
+		}
+		c->value[0] = value[0];
+		controls[rec][Speed_control].value[0] = defaultspeed[rec];
+		return 0;
+	}
+	if(c->chans){
+		for(i = 1; i < 8; i++)
+			if(c->chans & 1 << i){
+				switch(count){
+				case 2:
+					buf[1] = value[i] >> 8;
+				case 1:
+					buf[0] = value[i];
+				}
+				if(usbcmd(ad, type, req, control | i, index, buf, count) < 0){
+					dprint(2, "setcontrol: setupcmd %s failed\n",
+						controls[rec][ctl].name);
+					return -1;
+				}
+				c->value[i] = value[i];
+			}
+	}else{
+		switch(count){
+		case 2:
+			buf[1] = value[0] >> 8;
+		case 1:
+			buf[0] = value[0];
+		}
+		if(usbcmd(ad, type, req, control, index, buf, count) < 0){
+			dprint(2, "setcontrol: setupcmd %s failed\n", c->name);
+			return -1;
+		}
+	}
+	c->value[0] = value[0];
+	return 0;
+}
+
+int
+getspecialcontrol(int rec, int ctl, int req, int32_t *value)
+{
+	byte buf[3];
+	int m, n, i;
+	int type, control, index, count, signedbyte;
+	int16_t svalue;
+
+	count = 1;
+	signedbyte = 0;
+	switch(ctl){
+	default:
+		return Undef;
+	case Speed_control:
+		value[0] =  getspeed(rec, req);
+		return 0;
+	case Channel_control:
+	case Resolution_control:
+		if(req == Rgetmin)
+			value[0] = controls[rec][ctl].min;
+		if(req == Rgetmax)
+			value[0] = controls[rec][ctl].max;
+		if(req == Rgetres)
+			value[0] = controls[rec][ctl].step;
+		if(req == Rgetcur)
+			value[0] = controls[rec][ctl].value[0];
+		return 0;
+	case Volume_control:
+	case Delay_control:
+		count = 2;
+		/* fall through */
+	case Bass_control:
+	case Mid_control:
+	case Treble_control:
+	case Equalizer_control:
+		signedbyte = 1;
+		type = Rd2h|Rclass|Riface;
+		control = ctl<<8;
+		index = featureid[rec]<<8;
+		break;
+	case Selector_control:
+		type = Rd2h|Rclass|Riface;
+		control = 0;
+		index = selectorid[rec]<<8;
+		break;
+	case Mute_control:
+	case Agc_control:
+	case Bassboost_control:
+	case Loudness_control:
+		if(req != Rgetcur)
+			return Undef;
+		type = Rd2h|Rclass|Riface;
+		control = ctl<<8;
+		index = featureid[rec]<<8;
+		break;
+	}
+	if(controls[rec][ctl].chans){
+		m = 0;
+		value[0] = 0; // set to average
+		for(i = 1; i < 8; i++){
+			value[i] = Undef;
+			if(controls[rec][ctl].chans & 1 << i){
+				n=usbcmd(ad, type,req, control|i,index,buf,count);
+				if(n < 0)
+					return Undef;
+				if(n != count)
+					return -1;
+				switch (count){
+				case 2:
+					svalue = buf[1] << 8 | buf[0];
+					if(req == Rgetcur){
+						value[i] = svalue;
+						value[0] += svalue;
+						m++;
+					}else
+						value[0] = svalue;
+					break;
+				case 1:
+					svalue = buf[0];
+					if(signedbyte && (svalue&0x80))
+						svalue |= 0xFF00;
+					if(req == Rgetcur){
+						value[i] = svalue;
+						value[0] += svalue;
+						m++;
+					}else
+						value[0] = svalue;
+				}
+			}
+		}
+		if(m) value[0] /= m;
+		return 0;
+	}
+	value[0] = Undef;
+	if(usbcmd(ad, type, req, control, index, buf, count) != count)
+		return -1;
+	switch (count){
+	case 2:
+		svalue = buf[1] << 8 | buf[0];
+		value[0] = svalue;
+		break;
+	case 1:
+		svalue = buf[0];
+		if(signedbyte && (svalue&0x80))
+			svalue |= 0xFF00;
+		value[0] = svalue;
+	}
+	return 0;
+}
+
+int
+getcontrol(int rec, char *name, int32_t *value)
+{
+	int i;
+
+	for(i = 0; i < Ncontrol; i++){
+		if(strcmp(name, controls[rec][i].name) == 0)
+			break;
+	}
+	if(i == Ncontrol)
+		return -1;
+	if(controls[rec][i].readable == 0)
+		return -1;
+	if(getspecialcontrol(rec, i, Rgetcur, value) < 0)
+		return -1;
+	memmove(controls[rec][i].value, value, sizeof controls[rec][i].value);
+	return 0;
+}
+
+void
+getcontrols(void)
+{
+	int rec, ctl, i;
+	Audiocontrol *c;
+	int32_t v[8];
+
+	for(rec = 0; rec < 2; rec++){
+		if(rec == Record && !setrec)
+			continue;
+		for(ctl = 0; ctl < Ncontrol; ctl++){
+			c = &controls[rec][ctl];
+			if(c->readable){
+				if(verbose)
+					fprint(2, "%s %s control",
+						rec?"Record":"Playback", controls[rec][ctl].name);
+				c->min = (getspecialcontrol(rec, ctl, Rgetmin, v) < 0) ? Undef : v[0];
+				if(verbose && c->min != Undef)
+					fprint(2, ", min %ld", c->min);
+				c->max = (getspecialcontrol(rec, ctl, Rgetmax, v) < 0) ? Undef : v[0];
+				if(verbose && c->max != Undef)
+					fprint(2, ", max %ld", c->max);
+				c->step = (getspecialcontrol(rec, ctl, Rgetres, v) < 0) ? Undef : v[0];
+				if(verbose && c->step != Undef)
+					fprint(2, ", step %ld", c->step);
+				if(getspecialcontrol(rec, ctl, Rgetcur, c->value) == 0){
+					if(verbose){
+						if(c->chans){
+							fprint(2, ", values");
+							for(i = 1; i < 8; i++)
+								if(c->chans & 1 << i)
+									fprint(2, "[%d] %ld  ", i, c->value[i]);
+						}else
+							fprint(2, ", value %ld", c->value[0]);
+					}
+				}
+				if(verbose)
+					fprint(2, "\n");
+			}else{
+				c->min = Undef;
+				c->max = Undef;
+				c->step = Undef;
+				c->value[0] = Undef;
+				dprint(2, "%s %s control not settable\n",
+					rec?"Playback":"Record", controls[rec][ctl].name);
+			}
+		}
+	}
+}
+
+int
+ctlparse(char *s, Audiocontrol *c, int32_t *v)
+{
+	int i, j, nf, m;
+	char *vals[9];
+	char *p;
+	int32_t val;
+
+	nf = tokenize(s, vals, nelem(vals));
+	if(nf <= 0)
+		return -1;
+	if(c->chans){
+		j = 0;
+		m = 0;
+		SET(val);
+		v[0] = 0;	// will compute average of v[i]
+		for(i = 1; i < 8; i++)
+			if(c->chans & 1 << i){
+				if(j < nf){
+					val = strtol(vals[j], &p, 0);
+					if(val == 0 && *p != '\0' && *p != '%')
+						return -1;
+					if(*p == '%' && c->min != Undef)
+						val = (val*c->max + (100-val)*c->min)/100;
+					j++;
+				}
+				v[i] = val;
+				v[0] += val;
+				m++;
+			}else
+				v[i] = Undef;
+		if(m) v[0] /= m;
+	}else{
+		val = strtol(vals[0], &p, 0);
+		if(*p == '%' && c->min != Undef)
+			val = (val*c->max + (100-val)*c->min)/100;
+		v[0] = val;
+	}
+	return 0;
+}
+
+int
+Aconv(Fmt *fp)
+{
+	char str[256];
+	Audiocontrol *c;
+	int fst, i;
+	char *p;
+
+	c = va_arg(fp->args, Audiocontrol*);
+	p = str;
+	if(c->chans){
+		fst = 1;
+		for(i = 1; i < 8; i++)
+			if(c->chans & 1 << i){
+				p = seprint(p, str+sizeof str, "%s%ld", fst?"'":" ", c->value[i]);
+				fst = 0;
+			}
+		seprint(p, str+sizeof str, "'");
+	}else
+		seprint(p, str+sizeof str, "%ld", c->value[0]);
+	return fmtstrcpy(fp, str);
+}

--- a/sys/src/libusb/audio/audiofs.c
+++ b/sys/src/libusb/audio/audiofs.c
@@ -1,0 +1,942 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <auth.h>
+#include <fcall.h>
+#include <mp.h>
+#include <libsec.h>
+#include <usb/usb.h>
+#include <usb/audio.h>
+#include <usb/audioctl.h>
+
+int attachok;
+
+#define STACKSIZE 16*1024
+
+enum
+{
+	OPERM	= 0x3,	/* mask of all permission types in open mode */
+};
+
+typedef struct Fid Fid;
+typedef struct Audioctldata Audioctldata;
+typedef struct Worker Worker;
+
+struct Audioctldata
+{
+	int32_t	offoff;			/* offset of the offset for audioctl */
+	int32_t	values[2][Ncontrol][8];	/* last values transmitted */
+	char	*s;
+	int	ns;
+};
+
+enum {
+	Busy =	0x01,
+	Open =	0x02,
+	Eof =	0x04,
+};
+
+struct Fid
+{
+	QLock	QLock;
+	int	fid;
+	Dir	*dir;
+	uint16_t	flags;
+	int16_t	readers;
+	void	*fiddata;  /* file specific per-fid data (used for audioctl) */
+	Fid	*next;
+};
+
+struct Worker
+{
+	Fid	*fid;
+	uint16_t	tag;
+	Fcall	*rhdr;
+	Dir	*dir;
+	Channel	*eventc;
+	Worker	*next;
+};
+
+enum {
+	/* Event channel messages for worker */
+	Work =	0x01,
+	Check =	0x02,
+	Flush =	0x03,
+};
+
+enum {
+	Qdir,
+	Qvolume,
+	Qaudioctl,
+	Qaudiostat,
+	Nqid,
+};
+
+Dir dirs[] = {
+[Qdir] =		{0,0,{Qdir,      0,QTDIR},0555|DMDIR,0,0,0, ".",  nil,nil,nil},
+[Qvolume] =	{0,0,{Qvolume,   0,QTFILE},0666,0,0,0,	"volume", nil,nil,nil},
+[Qaudioctl] =	{0,0,{Qaudioctl, 0,QTFILE},0666,0,0,0,	"audioctl",nil,nil,nil},
+[Qaudiostat] =	{0,0,{Qaudiostat,0,QTFILE},0666,0,0,0,	"audiostat",nil,nil,nil},
+};
+
+int	messagesize = 4*1024+IOHDRSZ;
+uint8_t	mdata[8*1024+IOHDRSZ];
+uint8_t	mbuf[8*1024+IOHDRSZ];
+
+Fcall	thdr;
+Fcall	rhdr;
+Worker *workers;
+
+char srvfile[64], mntdir[64], epdata[64], audiofile[64];
+int mfd[2], p[2];
+char user[32];
+char *srvpost;
+
+Channel *procchan;
+Channel *replchan;
+
+Fid *fids;
+
+Fid*		newfid(int);
+void		io(void *);
+void		usage(void);
+
+extern char *mntpt;
+
+char	*rflush(Fid*), *rauth(Fid*),
+	*rattach(Fid*), *rwalk(Fid*),
+	*ropen(Fid*), *rcreate(Fid*),
+	*rread(Fid*), *rwrite(Fid*), *rclunk(Fid*),
+	*rremove(Fid*), *rstat(Fid*), *rwstat(Fid*),
+	*rversion(Fid*);
+
+char 	*(*fcalls[])(Fid*) = {
+	[Tflush] =	rflush,
+	[Tversion] =	rversion,
+	[Tauth] =		rauth,
+	[Tattach] =	rattach,
+	[Twalk] =		rwalk,
+	[Topen] =		ropen,
+	[Tcreate] =	rcreate,
+	[Tread] =		rread,
+	[Twrite] =	rwrite,
+	[Tclunk] =	rclunk,
+	[Tremove] =	rremove,
+	[Tstat] =		rstat,
+	[Twstat] =	rwstat,
+};
+
+static char	Eperm[] =	"permission denied";
+static char	Enotexist[] =	"file does not exist";
+static char	Eisopen[] = 	"file already open for I/O";
+static char	Ebadctl[] =	"unknown control message";
+
+int
+notifyf(void *_1, char *s)
+{
+	if(strncmp(s, "interrupt", 9) == 0)
+		return 1;
+	return 0;
+}
+
+void
+post(char *name, char *envname, int srvfd)
+{
+	int fd;
+	char buf[32];
+
+	fd = create(name, OWRITE, attachok?0666:0600);
+	if(fd < 0)
+		return;
+	snprint(buf, sizeof buf, "%d", srvfd);
+	if(write(fd, buf, strlen(buf)) != strlen(buf))
+		sysfatal("srv write");
+	close(fd);
+	putenv(envname, name);
+}
+
+/*
+ * BUG: If audio is later used on a different name space, the
+ * audio/audioin files are not there because of the bind trick.
+ * We should actually implement those files despite the binds.
+ * If audio is used from within the same ns nothing would change,
+ * otherwise, whoever would mount the audio files could still
+ * play/record audio (unlike now).
+ */
+void
+serve(void *_)
+{
+	int i;
+	uint32_t t;
+
+	if(pipe(p) < 0)
+		sysfatal("pipe failed");
+	mfd[0] = p[0];
+	mfd[1] = p[0];
+
+	atnotify(notifyf, 1);
+	strcpy(user, getuser());
+	t = time(nil);
+	for(i = 0; i < Nqid; i++){
+		dirs[i].uid = user;
+		dirs[i].gid = user;
+		dirs[i].muid = user;
+		dirs[i].atime = t;
+		dirs[i].mtime = t;
+	}
+	if(mntpt == nil){
+		snprint(mntdir, sizeof(mntdir), "/dev");
+		mntpt = mntdir;
+	}
+
+	if(usbdebug)
+		fmtinstall('F', fcallfmt);
+
+	procrfork(io, nil, STACKSIZE, RFFDG|RFNAMEG);
+
+	close(p[0]);	/* don't deadlock if child fails */
+	if(srvpost){
+		snprint(srvfile, sizeof srvfile, "/srv/%s", srvpost);
+		remove(srvfile);
+		post(srvfile, "usbaudio", p[1]);
+	}
+	if(mount(p[1], -1, mntpt, MBEFORE, "", 'M') < 0)
+		sysfatal("mount failed");
+	if(endpt[Play] >= 0 && devctl(epdev[Play], "name audio") < 0)
+		fprint(2, "audio: name audio: %r\n");
+	if(endpt[Record] >= 0 && devctl(epdev[Record], "name audioin") < 0)
+		fprint(2, "audio: name audioin: %r\n");
+	threadexits(nil);
+}
+
+char*
+rversion(Fid*_)
+{
+	Fid *f;
+
+	if(thdr.msize < 256)
+		return "max messagesize too small";
+	if(thdr.msize < messagesize)
+		messagesize = thdr.msize;
+	rhdr.msize = messagesize;
+	if(strncmp(thdr.version, "9P2000", 6) != 0)
+		return "unknown 9P version";
+	else
+		rhdr.version = "9P2000";
+	for(f = fids; f; f = f->next)
+		if(f->flags & Busy)
+			rclunk(f);
+	return nil;
+}
+
+char*
+rauth(Fid*_)
+{
+	return "usbaudio: no authentication required";
+}
+
+char*
+rflush(Fid *_)
+{
+	Worker *w;
+	int waitflush;
+
+	do {
+		waitflush = 0;
+		for(w = workers; w; w = w->next)
+			if(w->tag == thdr.oldtag){
+				waitflush++;
+				nbsendul(w->eventc, thdr.oldtag << 16 | Flush);
+			}
+		if(waitflush)
+			sleep(50);
+	} while(waitflush);
+	dprint(2, "flush done on tag %d\n", thdr.oldtag);
+	return 0;
+}
+
+char*
+rattach(Fid *f)
+{
+	f->flags |= Busy;
+	f->dir = &dirs[Qdir];
+	rhdr.qid = f->dir->qid;
+	if(attachok == 0 && strcmp(thdr.uname, user) != 0)
+		return Eperm;
+	return 0;
+}
+
+static Fid*
+doclone(Fid *f, int nfid)
+{
+	Fid *nf;
+
+	nf = newfid(nfid);
+	if(nf->flags & Busy)
+		return nil;
+	nf->flags |= Busy;
+	nf->flags &= ~Open;
+	nf->dir = f->dir;
+	return nf;
+}
+
+char*
+dowalk(Fid *f, char *name)
+{
+	int t;
+
+	if(strcmp(name, ".") == 0)
+		return nil;
+	if(strcmp(name, "..") == 0){
+		f->dir = &dirs[Qdir];
+		return nil;
+	}
+	if(f->dir != &dirs[Qdir])
+		return Enotexist;
+	for(t = 1; t < Nqid; t++){
+		if(strcmp(name, dirs[t].name) == 0){
+			f->dir = &dirs[t];
+			return nil;
+		}
+	}
+	return Enotexist;
+}
+
+char*
+rwalk(Fid *f)
+{
+	Fid *nf;
+	char *rv;
+	int i;
+	Dir *savedir;
+
+	if(f->flags & Open)
+		return Eisopen;
+
+	rhdr.nwqid = 0;
+	nf = nil;
+	savedir = f->dir;
+	/* clone if requested */
+	if(thdr.newfid != thdr.fid){
+		nf = doclone(f, thdr.newfid);
+		if(nf == nil)
+			return "new fid in use";
+		f = nf;
+	}
+
+	/* if it's just a clone, return */
+	if(thdr.nwname == 0 && nf != nil)
+		return nil;
+
+	/* walk each element */
+	rv = nil;
+	for(i = 0; i < thdr.nwname; i++){
+		rv = dowalk(f, thdr.wname[i]);
+		if(rv != nil){
+			if(nf != nil)
+				rclunk(nf);
+			else
+				f->dir = savedir;
+			break;
+		}
+		rhdr.wqid[i] = f->dir->qid;
+	}
+	rhdr.nwqid = i;
+
+	/* we only error out if no walk  */
+	if(i > 0)
+		rv = nil;
+
+	return rv;
+}
+
+Audioctldata *
+allocaudioctldata(void)
+{
+	int i, j, k;
+	Audioctldata *a;
+
+	a = emallocz(sizeof(Audioctldata), 1);
+	for(i = 0; i < 2; i++)
+		for(j=0; j < Ncontrol; j++)
+			for(k=0; k < 8; k++)
+				a->values[i][j][k] = Undef;
+	return a;
+}
+
+char *
+ropen(Fid *f)
+{
+	if(f->flags & Open)
+		return Eisopen;
+
+	if(thdr.mode != OREAD && (f->dir->mode & 0x2) == 0)
+		return Eperm;
+	qlock(&f->QLock);
+	if(f->dir == &dirs[Qaudioctl] && f->fiddata == nil)
+		f->fiddata = allocaudioctldata();
+	qunlock(&f->QLock);
+	rhdr.iounit = 0;
+	rhdr.qid = f->dir->qid;
+	f->flags |= Open;
+	return nil;
+}
+
+char *
+rcreate(Fid*_)
+{
+	return Eperm;
+}
+
+int
+readtopdir(Fid*_, uint8_t *buf, int32_t off, int cnt, int blen)
+{
+	int i, m, n;
+	int32_t pos;
+
+	n = 0;
+	pos = 0;
+	for(i = 1; i < Nqid; i++){
+		m = convD2M(&dirs[i], &buf[n], blen-n);
+		if(off <= pos){
+			if(m <= BIT16SZ || m > cnt)
+				break;
+			n += m;
+			cnt -= m;
+		}
+		pos += m;
+	}
+	return n;
+}
+
+enum { Chunk = 1024, };
+
+int
+makeaudioctldata(Fid *f)
+{
+	int rec, ctl, i, diff;
+	int32_t *actls;		/* 8 of them */
+	char *p, *e;
+	Audiocontrol *c;
+	Audioctldata *a;
+
+	if((a = f->fiddata) == nil)
+		sysfatal("fiddata");
+	if((p = a->s) == nil)
+		a->s = p = emallocz(Chunk, 0);
+	e = p + Chunk - 1;	/* e must point *at* last byte, not *after* */
+	for(rec = 0; rec < 2; rec++)
+		for(ctl = 0; ctl < Ncontrol; ctl++){
+			c = &controls[rec][ctl];
+			actls = a->values[rec][ctl];
+			diff = 0;
+			if(c->chans){
+				for(i = 1; i < 8; i++)
+					if((c->chans & 1<<i) &&
+					    c->value[i] != actls[i])
+						diff = 1;
+			}else
+				if(c->value[0] != actls[0])
+					diff = 1;
+			if(diff){
+				p = seprint(p, e, "%s %s %A", c->name,
+					rec? "in": "out", c);
+				memmove(actls, c->value, sizeof c->value);
+				if(c->min != Undef){
+					p = seprint(p, e, " %ld %ld", c->min,
+						c->max);
+					if(c->step != Undef)
+						p = seprint(p, e, " %ld",
+							c->step);
+				}
+				p = seprint(p, e, "\n");
+			}
+		}
+	assert(strlen(a->s) < Chunk);
+	a->ns = p - a->s;
+	return a->ns;
+}
+
+void
+readproc(void *x)
+{
+	int n, cnt;
+	uint32_t event;
+	int64_t off;
+	uint8_t *mdata;
+	Audioctldata *a;
+	Fcall *rhdr;
+	Fid *f;
+	Worker *w;
+
+	w = x;
+	mdata = emallocz(8*1024+IOHDRSZ, 0);
+	while((event = recvul(w->eventc)) != 0){
+		if(event != Work)
+			continue;
+		f = w->fid;
+		rhdr = w->rhdr;
+		a = f->fiddata;
+		off = rhdr->offset;
+		cnt = rhdr->count;
+		assert(a->offoff == off);
+		/* f is already locked */
+		for(;;){
+			qunlock(&f->QLock);
+			event = recvul(w->eventc);
+			qlock(&f->QLock);
+			ddprint(2, "readproc unblocked fid %d %lld\n",
+					f->fid, f->dir->qid.path);
+			switch (event & 0xffff){
+			case Work:
+				sysfatal("readproc phase error");
+			case Check:
+				if(f->fiddata && makeaudioctldata(f) == 0)
+					continue;
+				break;
+			case Flush:
+				if((event >> 16) == rhdr->tag){
+					ddprint(2, "readproc flushing fid %d, tag %d\n",
+						f->fid, rhdr->tag);
+					goto flush;
+				}
+				continue;
+			}
+			if(f->fiddata){
+				rhdr->data = a->s;
+				rhdr->count = a->ns;
+				break;
+			}
+			yield();
+		}
+		if(rhdr->count > cnt)
+			rhdr->count = cnt;
+		if(rhdr->count)
+			f->flags &= ~Eof;
+		ddprint(2, "readproc:->%F\n", rhdr);
+		n = convS2M(rhdr, mdata, messagesize);
+		if(write(mfd[1], mdata, n) != n)
+			sysfatal("mount write");
+flush:
+		w->tag = NOTAG;
+		f->readers--;
+		assert(f->readers == 0);
+		free(rhdr);
+		w->rhdr = nil;
+		qunlock(&f->QLock);
+		sendp(procchan, w);
+	}
+	threadexits(nil);
+}
+
+char*
+rread(Fid *f)
+{
+	int i, n, cnt, rec, div;
+	int64_t off;
+	char *p;
+	Audiocontrol *c;
+	Audioctldata *a;
+	Worker *w;
+	static char buf[1024];
+
+	rhdr.count = 0;
+	off = thdr.offset;
+	cnt = thdr.count;
+
+	if(cnt > messagesize - IOHDRSZ)
+		cnt = messagesize - IOHDRSZ;
+
+	rhdr.data = (char*)mbuf;
+
+	if(f->dir == &dirs[Qdir]){
+		n = readtopdir(f, mbuf, off, cnt, messagesize - IOHDRSZ);
+		rhdr.count = n;
+		return nil;
+	}
+
+	if(f->dir == &dirs[Qvolume]){
+		p = buf;
+		n = sizeof buf;
+		for(rec = 0; rec < 2; rec++){
+			c = &controls[rec][Volume_control];
+			if(c->readable){
+				div = c->max - c->min;
+				i = snprint(p, n, "audio %s %ld\n",
+					rec? "in": "out", (c->min != Undef?
+					100*(c->value[0]-c->min)/(div? div: 1):
+					c->value[0]));
+				p += i;
+				n -= i;
+			}
+			c = &controls[rec][Treble_control];
+			if(c->readable){
+				div = c->max - c->min;
+				i = snprint(p, n, "treb %s %ld\n",
+					rec? "in": "out", (c->min != Undef?
+					100*(c->value[0]-c->min)/(div? div: 1):
+					c->value[0]));
+				p += i;
+				n -= i;
+			}
+			c = &controls[rec][Bass_control];
+			if(c->readable){
+				div = c->max - c->min;
+				i = snprint(p, n, "bass %s %ld\n",
+					rec? "in": "out", (c->min != Undef?
+					100*(c->value[0]-c->min)/(div? div: 1):
+					c->value[0]));
+				p += i;
+				n -= i;
+			}
+			c = &controls[rec][Speed_control];
+			if(c->readable){
+				i = snprint(p, n, "speed %s %ld\n",
+					rec? "in": "out", c->value[0]);
+				p += i;
+				n -= i;
+			}
+		}
+		n = sizeof buf - n;
+		if(off > n)
+			rhdr.count = 0;
+		else{
+			rhdr.data = buf + off;
+			rhdr.count = n - off;
+			if(rhdr.count > cnt)
+				rhdr.count = cnt;
+		}
+		return nil;
+	}
+
+	if(f->dir == &dirs[Qaudioctl]){
+		Fcall *hdr;
+
+		qlock(&f->QLock);
+		a = f->fiddata;
+		if(off - a->offoff < 0){
+			/* there was a seek */
+			a->offoff = off;
+			a->ns = 0;
+		}
+		do {
+			if(off - a->offoff < a->ns){
+				rhdr.data = a->s + (off - a->offoff);
+				rhdr.count = a->ns - (off - a->offoff);
+				if(rhdr.count > cnt)
+					rhdr.count = cnt;
+				qunlock(&f->QLock);
+				return nil;
+			}
+			if(a->offoff != off){
+				a->ns = 0;
+				a->offoff = off;
+				rhdr.count = 0;
+				qunlock(&f->QLock);
+				return nil;
+			}
+		} while(makeaudioctldata(f) != 0);
+
+		assert(a->offoff == off);
+		/* Wait for data off line */
+		f->readers++;
+		w = nbrecvp(procchan);
+		if(w == nil){
+			w = emallocz(sizeof(Worker), 1);
+			w->eventc = chancreate(sizeof(uint32_t), 1);
+			w->next = workers;
+			workers = w;
+			proccreate(readproc, w, 4096);
+		}
+		hdr = emallocz(sizeof(Fcall), 0);
+		w->fid = f;
+		w->tag = thdr.tag;
+		assert(w->rhdr == nil);
+		w->rhdr = hdr;
+		hdr->count = cnt;
+		hdr->offset = off;
+		hdr->type = thdr.type+1;
+		hdr->fid = thdr.fid;
+		hdr->tag = thdr.tag;
+		sendul(w->eventc, Work);
+		return (char*)~0;
+	}
+
+	return Eperm;
+}
+
+char*
+rwrite(Fid *f)
+{
+	int32_t cnt, value;
+	char *lines[2*Ncontrol], *fields[4], *subfields[9], *err, *p;
+	int nlines, i, nf, nnf, rec, ctl;
+	Audiocontrol *c;
+	Worker *w;
+	static char buf[256];
+
+	rhdr.count = 0;
+	cnt = thdr.count;
+
+	if(cnt > messagesize - IOHDRSZ)
+		cnt = messagesize - IOHDRSZ;
+
+	err = nil;
+	if(f->dir == &dirs[Qvolume] || f->dir == &dirs[Qaudioctl]){
+		thdr.data[cnt] = '\0';
+		nlines = getfields(thdr.data, lines, 2*Ncontrol, 1, "\n");
+		for(i = 0; i < nlines; i++){
+			dprint(2, "line: %s\n", lines[i]);
+			nf = tokenize(lines[i], fields, 4);
+			if(nf == 0)
+				continue;
+			if(nf == 3)
+				if(strcmp(fields[1], "in") == 0 ||
+				    strcmp(fields[1], "record") == 0)
+					rec = 1;
+				else if(strcmp(fields[1], "out") == 0 ||
+				    strcmp(fields[1], "playback") == 0)
+					rec = 0;
+				else{
+					dprint(2, "bad1\n");
+					return Ebadctl;
+				}
+			else if(nf == 2)
+				rec = 0;
+			else{
+				dprint(2, "bad2 %d\n", nf);
+				return Ebadctl;
+			}
+			c = nil;
+			if(strcmp(fields[0], "audio") == 0) /* special case */
+				fields[0] = "volume";
+			for(ctl = 0; ctl < Ncontrol; ctl++){
+				c = &controls[rec][ctl];
+				if(strcmp(fields[0], c->name) == 0)
+					break;
+			}
+			if(ctl == Ncontrol){
+				dprint(2, "bad3\n");
+				return Ebadctl;
+			}
+			if(f->dir == &dirs[Qvolume] && ctl != Speed_control &&
+			    c->min != Undef && c->max != Undef){
+				nnf = tokenize(fields[nf-1], subfields,
+					nelem(subfields));
+				if(nnf <= 0 || nnf > 8){
+					dprint(2, "bad4\n");
+					return Ebadctl;
+				}
+				p = buf;
+				for(i = 0; i < nnf; i++){
+					value = strtol(subfields[i], nil, 0);
+					value = ((100 - value)*c->min +
+						value*c->max) / 100;
+					if(p == buf){
+						dprint(2, "rwrite: %s %s '%ld",
+								c->name, rec?
+								"record":
+								"playback",
+								value);
+					}else
+						dprint(2, " %ld", value);
+					if(p == buf)
+						p = seprint(p, buf+sizeof buf,
+							"0x%p %s %s '%ld",
+							replchan, c->name, rec?
+							"record": "playback",
+							value);
+					else
+						p = seprint(p, buf+sizeof buf,
+							" %ld", value);
+				}
+				dprint(2, "'\n");
+				seprint(p, buf+sizeof buf-1, "'");
+				chanprint(controlchan, buf);
+			}else{
+				dprint(2, "rwrite: %s %s %q", c->name,
+						rec? "record": "playback",
+						fields[nf-1]);
+				chanprint(controlchan, "0x%p %s %s %q",
+					replchan, c->name, rec? "record":
+					"playback", fields[nf-1]);
+			}
+			p = recvp(replchan);
+			if(p){
+				if(strcmp(p, "ok") == 0){
+					free(p);
+					p = nil;
+				}
+				if(err == nil)
+					err = p;
+			}
+		}
+		for(w = workers; w; w = w->next)
+			nbsendul(w->eventc, Qaudioctl << 16 | Check);
+		rhdr.count = thdr.count;
+		return err;
+	}
+	return Eperm;
+}
+
+char *
+rclunk(Fid *f)
+{
+	Audioctldata *a;
+
+	qlock(&f->QLock);
+	f->flags &= ~(Open|Busy);
+	assert(f->readers ==0);
+	if(f->fiddata){
+		a = f->fiddata;
+		if(a->s)
+			free(a->s);
+		free(a);
+		f->fiddata = nil;
+	}
+	qunlock(&f->QLock);
+	return 0;
+}
+
+char *
+rremove(Fid *_)
+{
+	return Eperm;
+}
+
+char *
+rstat(Fid *f)
+{
+	Audioctldata *a;
+
+	if(f->dir == &dirs[Qaudioctl]){
+		qlock(&f->QLock);
+		if(f->fiddata == nil)
+			f->fiddata = allocaudioctldata();
+		a = f->fiddata;
+		if(a->ns == 0)
+			makeaudioctldata(f);
+		f->dir->length = a->offoff + a->ns;
+		qunlock(&f->QLock);
+	}
+	rhdr.nstat = convD2M(f->dir, mbuf, messagesize - IOHDRSZ);
+	rhdr.stat = mbuf;
+	return 0;
+}
+
+char *
+rwstat(Fid*_)
+{
+	return Eperm;
+}
+
+Fid *
+newfid(int fid)
+{
+	Fid *f, *ff;
+
+	ff = nil;
+	for(f = fids; f; f = f->next)
+		if(f->fid == fid)
+			return f;
+		else if(ff == nil && (f->flags & Busy) == 0)
+			ff = f;
+	if(ff == nil){
+		ff = emallocz(sizeof *ff, 1);
+		ff->next = fids;
+		fids = ff;
+	}
+	ff->fid = fid;
+	ff->flags &= ~(Busy|Open);
+	ff->dir = nil;
+	return ff;
+}
+
+void
+io(void *_)
+{
+	char *err, e[32];
+	int n;
+
+	close(p[1]);
+
+	procchan = chancreate(sizeof(Channel*), 8);
+	replchan = chancreate(sizeof(char*), 0);
+	for(;;){
+		/*
+		 * reading from a pipe or a network device
+		 * will give an error after a few eof reads
+		 * however, we cannot tell the difference
+		 * between a zero-length read and an interrupt
+		 * on the processes writing to us,
+		 * so we wait for the error
+		 */
+		n = read9pmsg(mfd[0], mdata, messagesize);
+		if(n == 0)
+			continue;
+		if(n < 0){
+			rerrstr(e, sizeof e);
+			if(strcmp(e, "interrupted") == 0){
+				dprint(2, "read9pmsg interrupted\n");
+				continue;
+			}
+			return;
+		}
+		if(convM2S(mdata, n, &thdr) == 0)
+			continue;
+
+		ddprint(2, "io:<-%F\n", &thdr);
+
+		rhdr.data = (char*)mdata + messagesize;
+		if(!fcalls[thdr.type])
+			err = "bad fcall type";
+		else
+			err = (*fcalls[thdr.type])(newfid(thdr.fid));
+		if(err == (char*)~0)
+			continue;	/* handled off line */
+		if(err){
+			rhdr.type = Rerror;
+			rhdr.ename = err;
+		}else{
+			rhdr.type = thdr.type + 1;
+			rhdr.fid = thdr.fid;
+		}
+		rhdr.tag = thdr.tag;
+		ddprint(2, "io:->%F\n", &rhdr);
+		n = convS2M(&rhdr, mdata, messagesize);
+		if(write(mfd[1], mdata, n) != n)
+			sysfatal("mount write");
+	}
+}
+
+int
+newid(void)
+{
+	int rv;
+	static int id;
+	static Lock idlock;
+
+	lock(&idlock);
+	rv = ++id;
+	unlock(&idlock);
+
+	return rv;
+}
+
+void
+ctlevent(void)
+{
+	Worker *w;
+
+	for(w = workers; w; w = w->next)
+		nbsendul(w->eventc, Qaudioctl << 16 | Check);
+}

--- a/sys/src/libusb/audio/audiosub.c
+++ b/sys/src/libusb/audio/audiosub.c
@@ -1,0 +1,308 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <usb/usb.h>
+#include <usb/audio.h>
+#include <usb/audioctl.h>
+
+typedef struct Namelist Namelist;
+
+struct Namelist
+{
+	int16_t	index;
+	char		*name;
+};
+
+Namelist terminal_types[] = {
+	{	0x100, "USB Terminal, undefined type"},
+	{	0x101, "USB Streaming"},
+	{	0x201, "Microphone"},
+	{	0x301, "Speaker"},
+	{	0x603, "Line connector"},
+	{	0x605, "S/PDIF"},
+	{	0, nil }
+};
+
+int units[2][8];	/* rec and play units */
+int nunits[2];		/* number in use */
+
+char*
+namefor(Namelist *list, int item)
+{
+	while(list->name){
+		if(list->index == item)
+			return list->name;
+		list++;
+	}
+	return "<unnamed>";
+}
+
+static int
+findunit(int nr)
+{
+	int rec, i;
+	for(rec = 0; rec < 2; rec++)
+		for(i = 0; i < nunits[rec]; i++)
+			if(units[rec][i] == nr)
+				return rec;
+	return -1;
+}
+
+void
+audio_interface(Dev *_1, Desc *dd)
+{
+	byte *b = (uint8_t*)&dd->data;
+	byte *bb = b;
+	int nb = dd->data.bLength;
+	int ctl, ch, u, x;
+	byte *p;
+	int class, subclass;
+	Audioalt *aa;
+	char *hd;
+
+	class = Class(dd->iface->csp);
+	subclass = Subclass(dd->iface->csp);
+
+	dprint(2, "%d.%d: ", class, subclass);
+	switch (subclass){
+	case 1:	// control
+		switch (b[2]){
+		case 0x01:
+			dprint(2, "Class-Specific AC Interface Header Descriptor\n");
+			dprint(2, "\tAudioDevClass release (bcd)%c%c%c%c, "
+				"TotalLength %d, InCollection %d aInterfaceNr %d\n",
+					'0'+((b[4]>>4)&0xf), '0'+(b[4]&0xf),
+					'0'+((b[3]>>4)&0xf), '0'+(b[3]&0xf),
+					b[5]|(b[6]<<8), b[7], b[8]);
+			break;
+		case 0x02:	// input
+			dprint(2, "Audio Input Terminal Descriptor\n");
+			dprint(2, "\tbTerminalId %d, wTerminalType "
+				"0x%x (%s), bAssocTerminal %d bNrChannels %d, "
+				"wChannelConfig %d, iChannelNames %d iTerminal %d\n",
+					b[3], b[4]|(b[5]<<8),
+					namefor(terminal_types, b[4]|(b[5]<<8)),
+					b[6], b[7], b[8]|(b[9]<<8), b[10], b[11]);
+			if((b[4]|b[5]<<8) == 0x101){
+				if(verbose)
+					fprint(2, "Audio output unit %d\n", b[3]);
+				/* USB streaming input: play interface */
+				units[Play][nunits[Play]++] = b[3];
+			}else{
+				if(verbose)
+					fprint(2, "Dev can record from %s\n",
+						namefor(terminal_types, b[4]|(b[5]<<8)));
+				/* Non-USB input: record interface */
+				units[Record][nunits[Record]++] = b[3];
+			}
+			break;
+		case 0x03:	// output
+			if(usbdebug){
+				fprint(2, "Audio Output Terminal Descriptor\n");
+				fprint(2, "\tbTerminalId %d, wTerminalType 0x%x (%s), bAssocTerminal %d bSourceId %d, iTerminal %d\n",
+					b[3], b[4]|(b[5]<<8),
+					namefor(terminal_types, b[4]|(b[5]<<8)),
+					b[6], b[7], b[8]);
+			}
+			if((b[4]|b[5]<<8) == 0x101){
+				if(verbose)
+					fprint(2, "Audio input unit %d\n", b[3]);
+				/* USB streaming output: record interface */
+				units[Record][nunits[Record]++] = b[3];
+				if(verbose)
+					fprint(2, "Dev can play to %s\n",
+						namefor(terminal_types, b[4]|(b[5]<<8)));
+				/* Non-USB output: play interface */
+				units[Play][nunits[Play]++] = b[3];
+			}
+			break;
+		case 0x04:
+			if(verbose)
+				fprint(2, "Audio Mixer Unit %d\n", b[3]);
+			if(usbdebug){
+				fprint(2, "\t%d bytes:", nb);
+				for(ctl = 0; ctl < nb; ctl++)
+					fprint(2, " 0x%2.2x", b[ctl]);
+				fprint(2, "\n\tbUnitId %d, bNrInPins %d", b[3], b[4]);
+			}
+			if(b[4]){
+				dprint(2, ", baSourceIDs: [%d", b[5]);
+				u = findunit(b[5]);
+				for(ctl = 1; ctl < b[4]; ctl++){
+					if(u < 0)
+						u = findunit(b[5+ctl]);
+					else if((x = findunit(b[5+ctl])) >= 0 && u != x && verbose)
+						fprint(2, "\tMixer %d for I & O \n", b[3]);
+					dprint(2, ", %d", b[5+ctl]);
+				}
+				dprint(2, "]\n");
+				if(u >= 0){
+					units[u][nunits[u]++] = b[3];
+					if(mixerid[u] >= 0)
+						fprint(2, "Second mixer (%d, %d) on %s\n",
+						 mixerid[u], b[3], u?"record":"playback");
+					mixerid[u] = b[3];
+				}
+				if(usbdebug){
+					fprint(2, "Channels %d, config %d, ",
+						b[ctl+5], b[ctl+5+1] | b[ctl+5+2] << 8);
+					x = b[ctl+5] * b[4];
+					fprint(2, "programmable: %d bits, 0x", x);
+					x = (x + 7) >> 3;
+					while(x--)
+						fprint(2, "%2.2x", b[ctl+x+5+4]);
+				}
+			}
+			break;
+		case 0x05:
+			if(verbose)
+				fprint(2, "Audio Selector Unit %d\n", b[3]);
+			dprint(2, "\tbUnitId %d, bNrInPins %d", b[3], b[4]);
+			if(b[4]){
+				u = findunit(b[5]);
+				dprint(2, ", baSourceIDs: %s [%d",
+					u?"record":"playback", b[5]);
+				for(ctl = 1; ctl < b[4]; ctl++){
+					if(u < 0)
+						u = findunit(b[5+ctl]);
+					else if((x = findunit(b[5+ctl])) >= 0 &&
+						u != x && verbose)
+						fprint(2, "\tSelector %d for I & O\n", b[3]);
+					dprint(2, ", %d", b[5+ctl]);
+				}
+				dprint(2, "]\n");
+				if(u >= 0){
+					units[u][nunits[u]++] = b[3];
+					if(selectorid[u] >= 0)
+						fprint(2, "Second selector (%d, %d) on %s\n", selectorid[u], b[3], u?"record":"playback");
+					selectorid[u] = b[3];
+					controls[u][Selector_control].readable = 1;
+					controls[u][Selector_control].settable = 1;
+					controls[u][Selector_control].chans = 0;
+				}
+			}
+			break;
+		case 0x06:	// feature
+			if(verbose) fprint(2, "Audio Feature Unit %d", b[3]);
+			dprint(2, "\tbUnitId %d, bSourceId %d, bControlSize %d\n",
+				b[3], b[4], b[5]);
+			u = findunit(b[4]);
+			if(u >= 0){
+				if(verbose) fprint(2, " for %s\n", u?"Record":"Playback");
+				units[u][nunits[u]++] = b[3];
+				if(featureid[u] >= 0)
+					if(verbose)
+						fprint(2, "Second feature unit (%d, %d)"
+							" on %s\n", featureid[u], b[3],
+							u?"record":"playback");
+				featureid[u] = b[3];
+			}else
+				if(verbose) fprint(2, ", not known what for\n");
+			p = b + 6;
+			for(ctl = 1; ctl < 0x0b; ctl++)
+				if((1<<(ctl-1)) & (b[6] | ((b[5]>1)?(b[7]<<8):0))){
+					if(verbose)
+						fprint(2, "\t%s control on master channel\n",
+							controls[0][ctl].name);
+					if(u >= 0){
+						controls[u][ctl].readable = 1;
+						controls[u][ctl].settable = 1;
+						controls[u][ctl].chans = 0;
+					}
+				}
+			p += (b[5]>1)?2:1;
+			for(ch = 0; ch < (nb - 8)/b[5]; ch++){
+				for(ctl = 1; ctl < 0x0b; ctl++)
+					if((1<<(ctl-1)) & (p[0] | ((b[5]>1)?(p[1]<<8):0))){
+						if(verbose)
+						  fprint(2, "\t%s control on channel %d\n",
+							controls[0][ctl].name, ch+1);
+						if(u >= 0){
+							controls[u][ctl].readable = 1;
+							controls[u][ctl].settable = 1;
+							controls[u][ctl].chans |= 1 <<(ch+1);
+						}
+					}
+				p += (b[5]>1)?2:1;
+			}
+			break;
+		default:
+			hd = hexstr(bb, nb);
+			fprint(2, "audio control unknown: %s\n", hd);
+			free(hd);
+		}
+		break;
+	case 2: // stream
+		switch (b[2]){
+		case 0x01:
+			dprint(2, "Audio stream for TerminalID %d, delay %d, format_tag %#x\n",
+				b[3], b[4], b[5] | (b[6]<<8));
+			break;
+		case 0x02:
+			aa = (Audioalt *)dd->altc->aux;
+			if(aa == nil){
+				aa = mallocz(sizeof(Audioalt), 1);
+				dd->altc->aux = aa;
+			}
+			if(verbose){
+				if(b[4] <= 2)
+					fprint(2, "Interface %d: %s, %d bits, ",
+						dd->iface->id, (b[4] == 1)?"mono":"stereo", b[6]);
+				else
+					fprint(2, "Interface %d, %d channels, %d bits, ",
+						dd->iface->id, b[4], b[6]);
+			}
+			if(b[7] == 0){
+				if(verbose)
+					fprint(2, "frequency variable between %d and %d\n",
+						b[8] | b[9]<<8 | b[10]<<16, b[11] | b[12]<<8 | b[13]<<16);
+				aa->minfreq = b[8] | b[9]<<8 | b[10]<<16;
+				aa->maxfreq = b[11] | b[12]<<8 | b[13]<<16;
+				aa->caps |= has_contfreq;
+			}else{
+				if(verbose)
+					fprint(2, "discrete frequencies are:");
+				for(ch = 0; ch < b[7] && ch < 8; ch++){
+					aa->freqs[ch] = b[8+3*ch] | b[9+3*ch]<<8 | b[10+3*ch]<<16;
+					if(verbose)
+						fprint(2, " %d", b[8+3*ch] | b[9+3*ch]<<8 | b[10+3*ch]<<16);
+				}
+				if(ch < 8)
+					aa->freqs[ch] = -1;
+				if(verbose)
+					fprint(2, "\n");
+				if(ch > 1)
+					aa->caps |= has_discfreq;	/* more than one frequency */
+				else
+					aa->caps |= onefreq;		/* only one frequency */
+			}
+			aa->nchan = b[4];
+			aa->res = b[6];
+			aa->subframesize = b[5];
+			break;
+		default:
+			if(usbdebug){
+				hd = hexstr(bb, nb);
+				fprint(2, "audio stream unknown: %s\n", hd);
+				free(hd);
+			}
+		}
+		break;
+	case 3: // midi
+	default:
+		if(usbdebug){
+			hd = hexstr(bb, nb);
+			fprint(2, "Unknown audio stream type: CS_INTERFACE: %s\n", hd);
+			free(hd);
+		}
+	}
+}

--- a/sys/src/libusb/build.json
+++ b/sys/src/libusb/build.json
@@ -1,0 +1,40 @@
+{
+	"Libusb": {
+		"Cflags": [
+			"-fasm"
+		],
+		"Include": [
+			"/sys/src/lib.json"
+		],
+		"Install": "/$ARCH/lib/",
+		"Library": "libusb.a",
+		"NotYet": [
+			"audio/audioctl.c"
+		],
+		"SourceFiles": [
+			"lib/dev.c",
+			"lib/devs.c",
+			"lib/dump.c",
+			"lib/parse.c",
+			"lib/fs.c",
+			"lib/fsdir.c",
+			"audio/audioctl.c",
+			"audio/audiofs.c",
+			"audio/audiosub.c",
+			"disk/disk.c",
+			"disk/scsireq.c",
+			"ether/asix.c",
+			"ether/cdc.c",
+			"ether/ether.c",
+			"ether/smsc.c",
+			"kb/hid.c",
+			"kb/kb.c",
+			"print/print.c",
+			"serial/ftdi.c",
+			"serial/prolific.c",
+			"serial/serial.c",
+			"serial/silabs.c",
+			"serial/ucons.c"
+		]
+	}
+}

--- a/sys/src/libusb/disk/disk.c
+++ b/sys/src/libusb/disk/disk.c
@@ -1,0 +1,807 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+/*
+ * usb/disk - usb mass storage file server
+ *
+ * supports only the scsi command interface, not ata.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <ctype.h>
+#include <fcall.h>
+#include <thread.h>
+#include <disk.h>
+#include <usb/scsireq.h>
+#include <usb/usb.h>
+#include <usb/usbfs.h>
+#include <usb/ums.h>
+
+enum
+{
+	Qdir = 0,
+	Qctl,
+	Qraw,
+	Qdata,
+	Qmax,
+};
+
+typedef struct Dirtab Dirtab;
+struct Dirtab
+{
+	char	*name;
+	int	mode;
+};
+
+static Dirtab dirtab[] =
+{
+	[Qdir] =	{"/",	 DMDIR|0555},
+	[Qctl] =	{"ctl",	 0664},		/* nothing secret here */
+	[Qraw] =	{"raw",	 0640},
+	[Qdata] =	{"data", 0640},
+};
+
+/*
+ * These are used by scuzz scsireq
+ */
+int exabyte, force6bytecmds;
+
+int diskdebug;
+
+static int
+getmaxlun(Dev *dev)
+{
+	uint8_t max;
+	int r;
+
+	max = 0;
+	r = Rd2h|Rclass|Riface;
+	if(usbcmd(dev, r, Getmaxlun, 0, 0, &max, 1) < 0){
+		dprint(2, "disk: %s: getmaxlun failed: %r\n", dev->dir);
+	}else{
+		max &= 017;			/* 15 is the max. allowed */
+		dprint(2, "disk: %s: maxlun %d\n", dev->dir, max);
+	}
+	return max;
+}
+
+static int
+umsreset(Ums *ums)
+{
+	int r;
+
+	r = Rh2d|Rclass|Riface;
+	if(usbcmd(ums->dev, r, Umsreset, 0, 0, nil, 0) < 0){
+		fprint(2, "disk: reset: %r\n");
+		return -1;
+	}
+	return 0;
+}
+
+static int
+umsrecover(Ums *ums)
+{
+	if(umsreset(ums) < 0)
+		return -1;
+	if(unstall(ums->dev, ums->epin, Ein) < 0)
+		dprint(2, "disk: unstall epin: %r\n");
+
+	/* do we need this when epin == epout? */
+	if(unstall(ums->dev, ums->epout, Eout) < 0)
+		dprint(2, "disk: unstall epout: %r\n");
+	return 0;
+}
+
+static void
+umsfatal(Ums *ums)
+{
+	int i;
+
+	devctl(ums->dev, "detach");
+	for(i = 0; i < ums->maxlun; i++)
+		usbfsdel(&ums->lun[i].fs);
+}
+
+static int
+ispow2(uint64_t ul)
+{
+	return (ul & (ul - 1)) == 0;
+}
+
+/*
+ * return smallest power of 2 >= n
+ */
+static int
+log2(int n)
+{
+	int i;
+
+	for(i = 0; (1 << i) < n; i++)
+		;
+	return i;
+}
+
+static int
+umscapacity(Umsc *lun)
+{
+	uint8_t data[32];
+
+	lun->blocks = 0;
+	lun->capacity = 0;
+	lun->ScsiReq.lbsize = 0;
+	memset(data, 0, sizeof data);
+	if(SRrcapacity(&lun->ScsiReq, data) < 0 && SRrcapacity(&lun->ScsiReq, data)  < 0)
+		return -1;
+	lun->blocks = GETBELONG(data);
+	lun->ScsiReq.lbsize = GETBELONG(data+4);
+	if(lun->blocks == 0xFFFFFFFF){
+		if(SRrcapacity16(&lun->ScsiReq, data) < 0){
+			lun->ScsiReq.lbsize = 0;
+			lun->blocks = 0;
+			return -1;
+		}else{
+			lun->ScsiReq.lbsize = GETBELONG(data + 8);
+			lun->blocks = (uint64_t)GETBELONG(data)<<32 |
+				GETBELONG(data + 4);
+		}
+	}
+	lun->blocks++; /* SRcapacity returns LBA of last block */
+	lun->capacity = (int64_t)lun->blocks * lun->ScsiReq.lbsize;
+	if(diskdebug)
+		fprint(2, "disk: logical block size %lu, # blocks %llu\n",
+			lun->ScsiReq.lbsize, lun->blocks);
+	return 0;
+}
+
+static int
+umsinit(Ums *ums)
+{
+	uint8_t i;
+	Umsc *lun;
+	int some;
+
+	umsreset(ums);
+	ums->maxlun = getmaxlun(ums->dev);
+	ums->lun = mallocz((ums->maxlun+1) * sizeof(*ums->lun), 1);
+	some = 0;
+	for(i = 0; i <= ums->maxlun; i++){
+		lun = &ums->lun[i];
+		lun->ums = ums;
+		lun->ScsiReq.umsc = lun;
+		lun->ScsiReq.lun = i;
+		lun->ScsiReq.flags = Fopen | Fusb | Frw10;
+		if(SRinquiry(&lun->ScsiReq) < 0 && SRinquiry(&lun->ScsiReq) < 0){
+			dprint(2, "disk: lun %d inquiry failed\n", i);
+			continue;
+		}
+		switch(lun->ScsiReq.inquiry[0]){
+		case Devdir:
+		case Devworm:		/* a little different than the others */
+		case Devcd:
+		case Devmo:
+			break;
+		default:
+			fprint(2, "disk: lun %d is not a disk (type %#02x)\n",
+				i, lun->ScsiReq.inquiry[0]);
+			continue;
+		}
+		SRstart(&lun->ScsiReq, 1);
+		/*
+		 * we ignore the device type reported by inquiry.
+		 * Some devices return a wrong value but would still work.
+		 */
+		some++;
+		lun->inq = smprint("%.48s", (char *)lun->ScsiReq.inquiry+8);
+		umscapacity(lun);
+	}
+	if(some == 0){
+		dprint(2, "disk: all luns failed\n");
+		devctl(ums->dev, "detach");
+		return -1;
+	}
+	return 0;
+}
+
+
+/*
+ * called by SR*() commands provided by scuzz's scsireq
+ */
+int32_t
+umsrequest(Umsc *umsc, ScsiPtr *cmd, ScsiPtr *data, int *status)
+{
+	Cbw cbw;
+	Csw csw;
+	int n, nio, left;
+	Ums *ums;
+
+	ums = umsc->ums;
+
+	memcpy(cbw.signature, "USBC", 4);
+	cbw.tag = ++ums->seq;
+	cbw.datalen = data->count;
+	cbw.flags = data->write? CbwDataOut: CbwDataIn;
+	cbw.lun = umsc->ScsiReq.lun;
+	if(cmd->count < 1 || cmd->count > 16)
+		fprint(2, "disk: umsrequest: bad cmd count: %ld\n", cmd->count);
+
+	cbw.len = cmd->count;
+	assert(cmd->count <= sizeof(cbw.command));
+	memcpy(cbw.command, cmd->p, cmd->count);
+	memset(cbw.command + cmd->count, 0, sizeof(cbw.command) - cmd->count);
+
+	werrstr("");		/* we use %r later even for n == 0 */
+	if(diskdebug){
+		fprint(2, "disk: cmd: tag %#lx: ", cbw.tag);
+		for(n = 0; n < cbw.len; n++)
+			fprint(2, " %2.2x", cbw.command[n]&0xFF);
+		fprint(2, " datalen: %ld\n", cbw.datalen);
+	}
+
+	/* issue tunnelled scsi command */
+	if(write(ums->epout->dfd, &cbw, CbwLen) != CbwLen){
+		fprint(2, "disk: cmd: %r\n");
+		goto Fail;
+	}
+
+	/* transfer the data */
+	nio = data->count;
+	if(nio != 0){
+		if(data->write)
+			n = write(ums->epout->dfd, data->p, nio);
+		else{
+			n = read(ums->epin->dfd, data->p, nio);
+			left = nio - n;
+			if (n >= 0 && left > 0)	/* didn't fill data->p? */
+				memset(data->p + n, 0, left);
+		}
+		nio = n;
+		if(diskdebug) {
+			if(n < 0)
+				fprint(2, "disk: data: %r\n");
+			else
+				fprint(2, "disk: data: %d bytes\n", n);
+		}
+		if(n <= 0)
+			if(data->write == 0)
+				unstall(ums->dev, ums->epin, Ein);
+	}
+
+	/* read the transfer's status */
+	n = read(ums->epin->dfd, &csw, CswLen);
+	if(n <= 0){
+		/* n == 0 means "stalled" */
+		unstall(ums->dev, ums->epin, Ein);
+		n = read(ums->epin->dfd, &csw, CswLen);
+	}
+
+	if(n != CswLen || strncmp(csw.signature, "USBS", 4) != 0){
+		dprint(2, "disk: read n=%d: status: %r\n", n);
+		goto Fail;
+	}
+	if(csw.tag != cbw.tag){
+		dprint(2, "disk: status tag mismatch\n");
+		goto Fail;
+	}
+	if(csw.status >= CswPhaseErr){
+		dprint(2, "disk: phase error\n");
+		goto Fail;
+	}
+	if(csw.dataresidue == 0 || ums->wrongresidues)
+		csw.dataresidue = data->count - nio;
+	if(diskdebug){
+		fprint(2, "disk: status: %2.2x residue: %ld\n",
+			csw.status, csw.dataresidue);
+		if(cbw.command[0] == ScmdRsense){
+			fprint(2, "sense data:");
+			for(n = 0; n < data->count - csw.dataresidue; n++)
+				fprint(2, " %2.2x", data->p[n]);
+			fprint(2, "\n");
+		}
+	}
+	switch(csw.status){
+	case CswOk:
+		*status = STok;
+		break;
+	case CswFailed:
+		*status = STcheck;
+		break;
+	default:
+		dprint(2, "disk: phase error\n");
+		goto Fail;
+	}
+	ums->nerrs = 0;
+	return data->count - csw.dataresidue;
+
+Fail:
+	*status = STharderr;
+	if(ums->nerrs++ > 15){
+		fprint(2, "disk: %s: too many errors: device detached\n", ums->dev->dir);
+		umsfatal(ums);
+	}else
+		umsrecover(ums);
+	return -1;
+}
+
+static int
+dwalk(Usbfs *fs, Fid *fid, char *name)
+{
+	int i;
+	Qid qid;
+
+	qid = fid->qid;
+	if((qid.type & QTDIR) == 0){
+		werrstr("walk in non-directory");
+		return -1;
+	}
+
+	if(strcmp(name, "..") == 0)
+		return 0;
+
+	for(i = 1; i < nelem(dirtab); i++)
+		if(strcmp(name, dirtab[i].name) == 0){
+			qid.path = i | fs->qid;
+			qid.vers = 0;
+			qid.type = dirtab[i].mode >> 24;
+			fid->qid = qid;
+			return 0;
+		}
+	werrstr(Enotfound);
+	return -1;
+}
+
+static void
+dostat(Usbfs *fs, int path, Dir *d)
+{
+	Dirtab *t;
+	Umsc *lun;
+
+	t = &dirtab[path];
+	d->qid.path = path;
+	d->qid.type = t->mode >> 24;
+	d->mode = t->mode;
+	d->name = t->name;
+	lun = fs->aux;
+	if(path == Qdata)
+		d->length = lun->capacity;
+	else
+		d->length = 0;
+}
+
+static int
+dirgen(Usbfs *fs, Qid _1, int i, Dir *d, void*_2)
+{
+	i++;	/* skip dir */
+	if(i >= Qmax)
+		return -1;
+	else{
+		dostat(fs, i, d);
+		d->qid.path |= fs->qid;
+		return 0;
+	}
+}
+
+static int
+dstat(Usbfs *fs, Qid qid, Dir *d)
+{
+	int path;
+
+	path = qid.path & ~fs->qid;
+	dostat(fs, path, d);
+	d->qid.path |= fs->qid;
+	return 0;
+}
+
+static int
+dopen(Usbfs *fs, Fid *fid, int _1)
+{
+	uint32_t path;
+	Umsc *lun;
+
+	path = fid->qid.path & ~fs->qid;
+	lun = fs->aux;
+	switch(path){
+	case Qraw:
+		lun->phase = Pcmd;
+		break;
+	}
+	return 0;
+}
+
+/*
+ * check i/o parameters and compute values needed later.
+ * we shift & mask manually to avoid run-time calls to _divv and _modv,
+ * since we don't need general division nor its cost.
+ */
+static int
+setup(Umsc *lun, char *data, int count, int64_t offset)
+{
+	int32_t nb, lbsize, lbshift, lbmask;
+	uint64_t bno;
+
+	if(count < 0 || (lun->ScsiReq.lbsize <= 0 && umscapacity(lun) < 0) ||
+	    lun->ScsiReq.lbsize == 0)
+		return -1;
+	lbsize = lun->ScsiReq.lbsize;
+	assert(ispow2(lbsize));
+	lbshift = log2(lbsize);
+	lbmask = lbsize - 1;
+
+	bno = offset >> lbshift;	/* offset / lbsize */
+	nb = ((offset + count + lbsize - 1) >> lbshift) - bno;
+
+	if(bno + nb > lun->blocks)		/* past end of device? */
+		nb = lun->blocks - bno;
+	if(nb * lbsize > Maxiosize)
+		nb = Maxiosize / lbsize;
+	lun->nb = nb;
+	if(bno >= lun->blocks || nb == 0)
+		return 0;
+
+	lun->ScsiReq.offset = bno;
+	lun->off = offset & lbmask;		/* offset % lbsize */
+	if(lun->off == 0 && (count & lbmask) == 0)
+		lun->bufp = data;
+	else
+		/* not transferring full, aligned blocks; need intermediary */
+		lun->bufp = lun->buf;
+	return count;
+}
+
+/*
+ * Upon SRread/SRwrite errors we assume the medium may have changed,
+ * and ask again for the capacity of the media.
+ * BUG: How to proceed to avoid confusing dossrv??
+ *
+ * ctl reads must match the format documented in sd(3) exactly
+ * to interoperate with the rest of the system.
+ */
+static int32_t
+dread(Usbfs *fs, Fid *fid, void *data, int32_t count, int64_t offset)
+{
+	int32_t n;
+	uint32_t path;
+	char buf[1024];
+	char *s, *e;
+	Umsc *lun;
+	Ums *ums;
+	Qid q;
+
+	q = fid->qid;
+	path = fid->qid.path & ~fs->qid;
+	ums = fs->dev->aux;
+	lun = fs->aux;
+
+	qlock(&ums->QLock);
+	switch(path){
+	case Qdir:
+		count = usbdirread(fs, q, data, count, offset, dirgen, nil);
+		break;
+	case Qctl:
+		/*
+		 * Some usb disks need an extra opportunity to divulge their
+		 * capacity (e.g. M-Systems/SanDisk 1GB flash drive).
+		 */
+		if(lun->ScsiReq.lbsize <= 0)
+			umscapacity(lun);
+
+		s = buf;
+		e = buf + sizeof(buf);
+		if(lun->ScsiReq.flags & Finqok)
+			s = seprint(s, e, "inquiry %s lun %ld: %s\n",
+				fs->dev->dir, lun - &ums->lun[0], lun->inq);
+		if(lun->blocks > 0)
+			s = seprint(s, e, "geometry %llu %ld\n",
+				lun->blocks, lun->ScsiReq.lbsize);
+		count = usbreadbuf(data, count, offset, buf, s - buf);
+		break;
+	case Qraw:
+		if(lun->ScsiReq.lbsize <= 0 && umscapacity(lun) < 0){
+			count = -1;
+			break;
+		}
+		switch(lun->phase){
+		case Pcmd:
+			qunlock(&ums->QLock);
+			werrstr("phase error");
+			return -1;
+		case Pdata:
+			lun->ScsiReq.data.p = data;
+			lun->ScsiReq.data.count = count;
+			lun->ScsiReq.data.write = 0;
+			count = umsrequest(lun,&lun->ScsiReq.cmd,&lun->ScsiReq.data,&lun->ScsiReq.status);
+			lun->phase = Pstatus;
+			if(count < 0)
+				lun->ScsiReq.lbsize = 0;  /* medium may have changed */
+			break;
+		case Pstatus:
+			n = snprint(buf, sizeof buf, "%11.0u ", lun->ScsiReq.status);
+			count = usbreadbuf(data, count, 0LL, buf, n);
+			lun->phase = Pcmd;
+			break;
+		}
+		break;
+	case Qdata:
+		count = setup(lun, data, count, offset);
+		if (count <= 0)
+			break;
+		n = SRread(&lun->ScsiReq, lun->bufp, lun->nb * lun->ScsiReq.lbsize);
+		if(n < 0){
+			lun->ScsiReq.lbsize = 0;	/* medium may have changed */
+			count = -1;
+		} else if (lun->bufp == data)
+			count = n;
+		else{
+			/*
+			 * if n == lun->nb*lun->lbsize (as expected),
+			 * just copy count bytes.
+			 */
+			if(lun->off + count > n)
+				count = n - lun->off; /* short read */
+			if(count > 0)
+				memmove(data, lun->bufp + lun->off, count);
+		}
+		break;
+	}
+	qunlock(&ums->QLock);
+	return count;
+}
+
+static int32_t
+dwrite(Usbfs *fs, Fid *fid, void *data, int32_t count, int64_t offset)
+{
+	int32_t len, ocount;
+	uint32_t path;
+	uint64_t bno;
+	Ums *ums;
+	Umsc *lun;
+
+	ums = fs->dev->aux;
+	lun = fs->aux;
+	path = fid->qid.path & ~fs->qid;
+
+	qlock(&ums->QLock);
+	switch(path){
+	default:
+		werrstr(Eperm);
+		count = -1;
+		break;
+	case Qctl:
+		dprint(2, "usb/disk: ctl ignored\n");
+		break;
+	case Qraw:
+		if(lun->ScsiReq.lbsize <= 0 && umscapacity(lun) < 0){
+			count = -1;
+			break;
+		}
+		switch(lun->phase){
+		case Pcmd:
+			if(count != 6 && count != 10){
+				qunlock(&ums->QLock);
+				werrstr("bad command length");
+				return -1;
+			}
+			memmove(lun->rawcmd, data, count);
+			lun->ScsiReq.cmd.p = lun->rawcmd;
+			lun->ScsiReq.cmd.count = count;
+			lun->ScsiReq.cmd.write = 1;
+			lun->phase = Pdata;
+			break;
+		case Pdata:
+			lun->ScsiReq.data.p = data;
+			lun->ScsiReq.data.count = count;
+			lun->ScsiReq.data.write = 1;
+			count = umsrequest(lun,&lun->ScsiReq.cmd,&lun->ScsiReq.data,&lun->ScsiReq.status);
+			lun->phase = Pstatus;
+			if(count < 0)
+				lun->ScsiReq.lbsize = 0;  /* medium may have changed */
+			break;
+		case Pstatus:
+			lun->phase = Pcmd;
+			werrstr("phase error");
+			count = -1;
+			break;
+		}
+		break;
+	case Qdata:
+		len = ocount = count;
+		count = setup(lun, data, count, offset);
+		if (count <= 0)
+			break;
+		bno = lun->ScsiReq.offset;
+		if (lun->bufp == lun->buf) {
+			count = SRread(&lun->ScsiReq, lun->bufp, lun->nb * lun->ScsiReq.lbsize);
+			if(count < 0) {
+				lun->ScsiReq.lbsize = 0;  /* medium may have changed */
+				break;
+			}
+			/*
+			 * if count == lun->nb*lun->lbsize, as expected, just
+			 * copy len (the original count) bytes of user data.
+			 */
+			if(lun->off + len > count)
+				len = count - lun->off; /* short read */
+			if(len > 0)
+				memmove(lun->bufp + lun->off, data, len);
+		}
+
+		lun->ScsiReq.offset = bno;
+		count = SRwrite(&lun->ScsiReq, lun->bufp, lun->nb * lun->ScsiReq.lbsize);
+		if(count < 0)
+			lun->ScsiReq.lbsize = 0;	/* medium may have changed */
+		else{
+			if(lun->off + len > count)
+				count -= lun->off; /* short write */
+			/* never report more bytes written than requested */
+			if(count < 0)
+				count = 0;
+			else if(count > ocount)
+				count = ocount;
+		}
+		break;
+	}
+	qunlock(&ums->QLock);
+	return count;
+}
+
+int
+findendpoints(Ums *ums)
+{
+	Ep *ep;
+	Usbdev *ud;
+	uint32_t csp, sc;
+	int i, epin, epout;
+
+	epin = epout = -1;
+	ud = ums->dev->usb;
+	for(i = 0; i < nelem(ud->ep); i++){
+		if((ep = ud->ep[i]) == nil)
+			continue;
+		csp = ep->iface->csp;
+		sc = Subclass(csp);
+		if(!(Class(csp) == Clstorage && (Proto(csp) == Protobulk)))
+			continue;
+		if(sc != Subatapi && sc != Sub8070 && sc != Subscsi)
+			fprint(2, "disk: subclass %#lx not supported. trying anyway\n", sc);
+		if(ep->type == Ebulk){
+			if(ep->dir == Eboth || ep->dir == Ein)
+				if(epin == -1)
+					epin =  ep->id;
+			if(ep->dir == Eboth || ep->dir == Eout)
+				if(epout == -1)
+					epout = ep->id;
+		}
+	}
+	dprint(2, "disk: ep ids: in %d out %d\n", epin, epout);
+	if(epin == -1 || epout == -1)
+		return -1;
+	ums->epin = openep(ums->dev, epin);
+	if(ums->epin == nil){
+		fprint(2, "disk: openep %d: %r\n", epin);
+		return -1;
+	}
+	if(epout == epin){
+		incref(&ums->epin->Ref);
+		ums->epout = ums->epin;
+	}else
+		ums->epout = openep(ums->dev, epout);
+	if(ums->epout == nil){
+		fprint(2, "disk: openep %d: %r\n", epout);
+		closedev(ums->epin);
+		return -1;
+	}
+	if(ums->epin == ums->epout)
+		opendevdata(ums->epin, ORDWR);
+	else{
+		opendevdata(ums->epin, OREAD);
+		opendevdata(ums->epout, OWRITE);
+	}
+	if(ums->epin->dfd < 0 || ums->epout->dfd < 0){
+		fprint(2, "disk: open i/o ep data: %r\n");
+		closedev(ums->epin);
+		closedev(ums->epout);
+		return -1;
+	}
+	dprint(2, "disk: ep in %s out %s\n", ums->epin->dir, ums->epout->dir);
+
+	devctl(ums->epin, "timeout 2000");
+	devctl(ums->epout, "timeout 2000");
+
+	if(usbdebug > 1 || diskdebug > 2){
+		devctl(ums->epin, "debug 1");
+		devctl(ums->epout, "debug 1");
+		devctl(ums->dev, "debug 1");
+	}
+	return 0;
+}
+
+static int
+usage(void)
+{
+	werrstr("usage: usb/disk [-d] [-N nb]");
+	return -1;
+}
+
+static void
+umsdevfree(void *a)
+{
+	Ums *ums = a;
+
+	if(ums == nil)
+		return;
+	closedev(ums->epin);
+	closedev(ums->epout);
+	ums->epin = ums->epout = nil;
+	free(ums->lun);
+	free(ums);
+}
+
+static Usbfs diskfs = {
+	.walk = dwalk,
+	.open =	 dopen,
+	.read =	 dread,
+	.write = dwrite,
+	.stat =	 dstat,
+};
+
+int
+diskmain(Dev *dev, int argc, char **argv)
+{
+	Ums *ums;
+	Umsc *lun;
+	int i, devid;
+
+	devid = dev->id;
+	ARGBEGIN{
+	case 'd':
+		scsidebug(diskdebug);
+		diskdebug++;
+		break;
+	case 'N':
+		devid = atoi(EARGF(usage()));
+		break;
+	default:
+		return usage();
+	}ARGEND
+	if(argc != 0) {
+		return usage();
+	}
+
+//	notify(ding);
+	ums = dev->aux = emallocz(sizeof(Ums), 1);
+	ums->maxlun = -1;
+	ums->dev = dev;
+	dev->free = umsdevfree;
+	if(findendpoints(ums) < 0){
+		werrstr("disk: endpoints not found");
+		return -1;
+	}
+
+	/*
+	 * SanDISK 512M gets residues wrong.
+	 */
+	if(dev->usb->vid == 0x0781 && dev->usb->did == 0x5150)
+		ums->wrongresidues = 1;
+
+	if(umsinit(ums) < 0){
+		dprint(2, "disk: umsinit: %r\n");
+		return -1;
+	}
+
+	for(i = 0; i <= ums->maxlun; i++){
+		lun = &ums->lun[i];
+		lun->fs = diskfs;
+		snprint(lun->fs.name, sizeof(lun->fs.name), "sdU%d.%d", devid, i);
+		lun->fs.dev = dev;
+		incref(&dev->Ref);
+		lun->fs.aux = lun;
+		usbfsadd(&lun->fs);
+	}
+	return 0;
+}

--- a/sys/src/libusb/disk/scsireq.c
+++ b/sys/src/libusb/disk/scsireq.c
@@ -1,0 +1,998 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+/*
+ * This is /sys/src/cmd/scuzz/scsireq.c
+ * changed to add more debug support, to keep
+ * disk compiling without a scuzz that includes these changes.
+ * Also, this includes minor tweaks for usb:
+ *	we set req.lun/unit to rp->lun/unit in SRreqsense
+ *	we set the rp->sense[0] bit Sd0valid in SRreqsense
+ * This does not use libdisk to retrieve the scsi error to make
+ * user see the diagnostics if we boot with debug enabled.
+ *
+ * BUGS:
+ *	no luns
+ *	and incomplete in many other ways
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <fcall.h>
+#include <disk.h>
+#include <usb/scsireq.h>
+
+enum {
+	Debug = 0,
+};
+
+/*
+ * exabyte tape drives, at least old ones like the 8200 and 8505,
+ * are dumb: you have to read the exact block size on the tape,
+ * they don't take 10-byte SCSI commands, and various other fine points.
+ */
+extern int exabyte, force6bytecmds;
+
+static int debug = Debug;
+
+static char *scmdnames[256] = {
+[ScmdTur] =	"Tur",
+[ScmdRewind] =	"Rewind",
+[ScmdRsense] =	"Rsense",
+[ScmdFormat] =	"Format",
+[ScmdRblimits] =	"Rblimits",
+[ScmdRead] =	"Read",
+[ScmdWrite] =	"Write",
+[ScmdSeek] =	"Seek",
+[ScmdFmark] =	"Fmark",
+[ScmdSpace] =	"Space",
+[ScmdInq] =	"Inq",
+[ScmdMselect6] =	"Mselect6",
+[ScmdMselect10] =	"Mselect10",
+[ScmdMsense6] =	"Msense6",
+[ScmdMsense10] =	"Msense10",
+[ScmdStart] =	"Start",
+[ScmdRcapacity] =	"Rcapacity",
+[ScmdRcapacity16] =	"Rcap16",
+[ScmdExtread] =	"Extread",
+[ScmdExtwrite] =	"Extwrite",
+[ScmdExtseek] =	"Extseek",
+
+[ScmdSynccache] =	"Synccache",
+[ScmdRTOC] =	"RTOC",
+[ScmdRdiscinfo] =	"Rdiscinfo",
+[ScmdRtrackinfo] =	"Rtrackinfo",
+[ScmdReserve] =	"Reserve",
+[ScmdBlank] =	"Blank",
+
+[ScmdCDpause] =	"CDpause",
+[ScmdCDstop] =	"CDstop",
+[ScmdCDplay] =	"CDplay",
+[ScmdCDload] =	"CDload",
+[ScmdCDscan] =	"CDscan",
+[ScmdCDstatus] =	"CDstatus",
+[Scmdgetconf] =	"getconf",
+};
+
+int32_t
+SRready(ScsiReq *rp)
+{
+	uint8_t cmd[6];
+
+	memset(cmd, 0, sizeof cmd);
+	rp->cmd.p = cmd;
+	rp->cmd.count = sizeof cmd;
+	rp->data.p = cmd;
+	rp->data.count = 0;
+	rp->data.write = 1;
+	return SRrequest(rp);
+}
+
+int32_t
+SRrewind(ScsiReq *rp)
+{
+	uint8_t cmd[6];
+
+	memset(cmd, 0, sizeof cmd);
+	cmd[0] = ScmdRewind;
+	rp->cmd.p = cmd;
+	rp->cmd.count = sizeof cmd;
+	rp->data.p = cmd;
+	rp->data.count = 0;
+	rp->data.write = 1;
+	if(SRrequest(rp) >= 0){
+		rp->offset = 0;
+		return 0;
+	}
+	return -1;
+}
+
+int32_t
+SRreqsense(ScsiReq *rp)
+{
+	uint8_t cmd[6];
+	ScsiReq req;
+	int32_t status;
+
+	if(rp->status == Status_SD){
+		rp->status = STok;
+		return 0;
+	}
+	memset(cmd, 0, sizeof cmd);
+	cmd[0] = ScmdRsense;
+	cmd[4] = sizeof(req.sense);
+	memset(&req, 0, sizeof(req));
+	if(rp->flags&Fusb)
+		req.flags |= Fusb;
+	req.lun = rp->lun;
+	req.unit = rp->unit;
+	req.fd = rp->fd;
+	req.umsc = rp->umsc;
+	req.cmd.p = cmd;
+	req.cmd.count = sizeof cmd;
+	req.data.p = rp->sense;
+	req.data.count = sizeof(rp->sense);
+	req.data.write = 0;
+	status = SRrequest(&req);
+	rp->status = req.status;
+	if(status != -1)
+		rp->sense[0] |= Sd0valid;
+	return status;
+}
+
+int32_t
+SRformat(ScsiReq *rp)
+{
+	uint8_t cmd[6];
+
+	memset(cmd, 0, sizeof cmd);
+	cmd[0] = ScmdFormat;
+	rp->cmd.p = cmd;
+	rp->cmd.count = sizeof cmd;
+	rp->data.p = cmd;
+	rp->data.count = 6;
+	rp->data.write = 0;
+	return SRrequest(rp);
+}
+
+int32_t
+SRrblimits(ScsiReq *rp, uint8_t *list)
+{
+	uint8_t cmd[6];
+
+	memset(cmd, 0, sizeof cmd);
+	cmd[0] = ScmdRblimits;
+	rp->cmd.p = cmd;
+	rp->cmd.count = sizeof cmd;
+	rp->data.p = list;
+	rp->data.count = 6;
+	rp->data.write = 0;
+	return SRrequest(rp);
+}
+
+static int
+dirdevrw(ScsiReq *rp, uint8_t *cmd, int32_t nbytes)
+{
+	int32_t n;
+
+	n = nbytes / rp->lbsize;
+	if(rp->offset <= Max24off && n <= 256 && (rp->flags & Frw10) == 0){
+		PUTBE24(cmd+1, rp->offset);
+		cmd[4] = n;
+		cmd[5] = 0;
+		return 6;
+	}
+	cmd[0] |= ScmdExtread;
+	cmd[1] = 0;
+	PUTBELONG(cmd+2, rp->offset);
+	cmd[6] = 0;
+	cmd[7] = n>>8;
+	cmd[8] = n;
+	cmd[9] = 0;
+	return 10;
+}
+
+static int
+seqdevrw(ScsiReq *rp, uint8_t *cmd, int32_t nbytes)
+{
+	int32_t n;
+
+	/* don't set Cmd1sili; we want the ILI bit instead of a fatal error */
+	cmd[1] = rp->flags&Fbfixed? Cmd1fixed: 0;
+	n = nbytes / rp->lbsize;
+	PUTBE24(cmd+2, n);
+	cmd[5] = 0;
+	return 6;
+}
+
+extern int diskdebug;
+
+int32_t
+SRread(ScsiReq *rp, void *buf, int32_t nbytes)
+{
+	uint8_t cmd[10];
+	int32_t n;
+
+	if(rp->lbsize == 0 || (nbytes % rp->lbsize) || nbytes > Maxiosize){
+		if(diskdebug){
+			if (nbytes % rp->lbsize)
+				fprint(2, "disk: i/o size %ld %% %ld != 0\n",
+					nbytes, rp->lbsize);
+			else
+				fprint(2, "disk: i/o size %ld > %d\n",
+					nbytes, Maxiosize);
+		}
+		rp->status = Status_BADARG;
+		return -1;
+	}
+
+	/* set up scsi read cmd */
+	cmd[0] = ScmdRead;
+	if(rp->flags & Fseqdev)
+		rp->cmd.count = seqdevrw(rp, cmd, nbytes);
+	else
+		rp->cmd.count = dirdevrw(rp, cmd, nbytes);
+	rp->cmd.p = cmd;
+	rp->data.p = buf;
+	rp->data.count = nbytes;
+	rp->data.write = 0;
+
+	/* issue it */
+	n = SRrequest(rp);
+	if(n != -1){			/* it worked? */
+		rp->offset += n / rp->lbsize;
+		return n;
+	}
+
+	/* request failed; maybe we just read a short record? */
+	if (exabyte) {
+		fprint(2, "read error\n");
+		rp->status = STcheck;
+		return n;
+	}
+	if(rp->status != Status_SD || !(rp->sense[0] & Sd0valid))
+		return -1;
+	/* compute # of bytes not read */
+	n = GETBELONG(rp->sense+3) * rp->lbsize;
+	if(!(rp->flags & Fseqdev))
+		return -1;
+
+	/* device is a tape or something similar */
+	if (rp->sense[2] == Sd2filemark || rp->sense[2] == 0x08 ||
+	    (rp->sense[2] & Sd2ili && n > 0))
+		rp->data.count = nbytes - n;
+	else
+		return -1;
+	n = rp->data.count;
+	if (!rp->readblock++ || debug)
+		fprint(2, "SRread: tape data count %ld%s\n", n,
+			(rp->sense[2] & Sd2ili? " with ILI": ""));
+	rp->status = STok;
+	rp->offset += n / rp->lbsize;
+	return n;
+}
+
+int32_t
+SRwrite(ScsiReq *rp, void *buf, int32_t nbytes)
+{
+	uint8_t cmd[10];
+	int32_t n;
+
+	if(rp->lbsize == 0 || (nbytes % rp->lbsize) || nbytes > Maxiosize){
+		if(diskdebug){
+			if (nbytes % rp->lbsize)
+				fprint(2, "disk: i/o size %ld %% %ld != 0\n",
+					nbytes, rp->lbsize);
+			else
+				fprint(2, "disk: i/o size %ld > %d\n",
+					nbytes, Maxiosize);
+		}
+		rp->status = Status_BADARG;
+		return -1;
+	}
+
+	/* set up scsi write cmd */
+	cmd[0] = ScmdWrite;
+	if(rp->flags & Fseqdev)
+		rp->cmd.count = seqdevrw(rp, cmd, nbytes);
+	else
+		rp->cmd.count = dirdevrw(rp, cmd, nbytes);
+	rp->cmd.p = cmd;
+	rp->data.p = buf;
+	rp->data.count = nbytes;
+	rp->data.write = 1;
+
+	/* issue it */
+	if((n = SRrequest(rp)) == -1){
+		if (exabyte) {
+			fprint(2, "write error\n");
+			rp->status = STcheck;
+			return n;
+		}
+		if(rp->status != Status_SD || rp->sense[2] != Sd2eom)
+			return -1;
+		if(rp->sense[0] & Sd0valid){
+			n -= GETBELONG(rp->sense+3) * rp->lbsize;
+			rp->data.count = nbytes - n;
+		}
+		else
+			rp->data.count = nbytes;
+		n = rp->data.count;
+	}
+	rp->offset += n / rp->lbsize;
+	return n;
+}
+
+int32_t
+SRseek(ScsiReq *rp, int32_t offset, int type)
+{
+	uint8_t cmd[10];
+
+	switch(type){
+
+	case 0:
+		break;
+
+	case 1:
+		offset += rp->offset;
+		if(offset >= 0)
+			break;
+		/*FALLTHROUGH*/
+
+	default:
+		if(diskdebug)
+			fprint(2, "disk: seek failed\n");
+		rp->status = Status_BADARG;
+		return -1;
+	}
+	memset(cmd, 0, sizeof cmd);
+	if(offset <= Max24off && (rp->flags & Frw10) == 0){
+		cmd[0] = ScmdSeek;
+		PUTBE24(cmd+1, offset & Max24off);
+		rp->cmd.count = 6;
+	}else{
+		cmd[0] = ScmdExtseek;
+		PUTBELONG(cmd+2, offset);
+		rp->cmd.count = 10;
+	}
+	rp->cmd.p = cmd;
+	rp->data.p = cmd;
+	rp->data.count = 0;
+	rp->data.write = 1;
+	SRrequest(rp);
+	if(rp->status == STok) {
+		rp->offset = offset;
+		return offset;
+	}
+	return -1;
+}
+
+int32_t
+SRfilemark(ScsiReq *rp, uint32_t howmany)
+{
+	uint8_t cmd[6];
+
+	memset(cmd, 0, sizeof cmd);
+	cmd[0] = ScmdFmark;
+	PUTBE24(cmd+2, howmany);
+	rp->cmd.p = cmd;
+	rp->cmd.count = sizeof cmd;
+	rp->data.p = cmd;
+	rp->data.count = 0;
+	rp->data.write = 1;
+	return SRrequest(rp);
+}
+
+int32_t
+SRspace(ScsiReq *rp, uint8_t code, int32_t howmany)
+{
+	uint8_t cmd[6];
+
+	memset(cmd, 0, sizeof cmd);
+	cmd[0] = ScmdSpace;
+	cmd[1] = code;
+	PUTBE24(cmd+2, howmany);
+	rp->cmd.p = cmd;
+	rp->cmd.count = sizeof cmd;
+	rp->data.p = cmd;
+	rp->data.count = 0;
+	rp->data.write = 1;
+	/*
+	 * what about rp->offset?
+	 */
+	return SRrequest(rp);
+}
+
+int32_t
+SRinquiry(ScsiReq *rp)
+{
+	uint8_t cmd[6];
+
+	memset(cmd, 0, sizeof cmd);
+	cmd[0] = ScmdInq;
+	cmd[4] = sizeof rp->inquiry;
+	rp->cmd.p = cmd;
+	rp->cmd.count = sizeof cmd;
+	memset(rp->inquiry, 0, sizeof rp->inquiry);
+	rp->data.p = rp->inquiry;
+	rp->data.count = sizeof rp->inquiry;
+	rp->data.write = 0;
+	if(SRrequest(rp) >= 0){
+		rp->flags |= Finqok;
+		return 0;
+	}
+	rp->flags &= ~Finqok;
+	return -1;
+}
+
+int32_t
+SRmodeselect6(ScsiReq *rp, uint8_t *list, int32_t nbytes)
+{
+	uint8_t cmd[6];
+
+	memset(cmd, 0, sizeof cmd);
+	cmd[0] = ScmdMselect6;
+	if((rp->flags & Finqok) && (rp->inquiry[2] & 0x07) >= 2)
+		cmd[1] = 0x10;
+	cmd[4] = nbytes;
+	rp->cmd.p = cmd;
+	rp->cmd.count = sizeof cmd;
+	rp->data.p = list;
+	rp->data.count = nbytes;
+	rp->data.write = 1;
+	return SRrequest(rp);
+}
+
+int32_t
+SRmodeselect10(ScsiReq *rp, uint8_t *list, int32_t nbytes)
+{
+	uint8_t cmd[10];
+
+	memset(cmd, 0, sizeof cmd);
+	if((rp->flags & Finqok) && (rp->inquiry[2] & 0x07) >= 2)
+		cmd[1] = 0x10;
+	cmd[0] = ScmdMselect10;
+	cmd[7] = nbytes>>8;
+	cmd[8] = nbytes;
+	rp->cmd.p = cmd;
+	rp->cmd.count = sizeof cmd;
+	rp->data.p = list;
+	rp->data.count = nbytes;
+	rp->data.write = 1;
+	return SRrequest(rp);
+}
+
+int32_t
+SRmodesense6(ScsiReq *rp, uint8_t page, uint8_t *list, int32_t nbytes)
+{
+	uint8_t cmd[6];
+
+	memset(cmd, 0, sizeof cmd);
+	cmd[0] = ScmdMsense6;
+	cmd[2] = page;
+	cmd[4] = nbytes;
+	rp->cmd.p = cmd;
+	rp->cmd.count = sizeof cmd;
+	rp->data.p = list;
+	rp->data.count = nbytes;
+	rp->data.write = 0;
+	return SRrequest(rp);
+}
+
+int32_t
+SRmodesense10(ScsiReq *rp, uint8_t page, uint8_t *list, int32_t nbytes)
+{
+	uint8_t cmd[10];
+
+	memset(cmd, 0, sizeof cmd);
+	cmd[0] = ScmdMsense10;
+	cmd[2] = page;
+	cmd[7] = nbytes>>8;
+	cmd[8] = nbytes;
+	rp->cmd.p = cmd;
+	rp->cmd.count = sizeof cmd;
+	rp->data.p = list;
+	rp->data.count = nbytes;
+	rp->data.write = 0;
+	return SRrequest(rp);
+}
+
+int32_t
+SRstart(ScsiReq *rp, uint8_t code)
+{
+	uint8_t cmd[6];
+
+	memset(cmd, 0, sizeof cmd);
+	cmd[0] = ScmdStart;
+	cmd[4] = code;
+	rp->cmd.p = cmd;
+	rp->cmd.count = sizeof cmd;
+	rp->data.p = cmd;
+	rp->data.count = 0;
+	rp->data.write = 1;
+	return SRrequest(rp);
+}
+
+int32_t
+SRrcapacity(ScsiReq *rp, uint8_t *data)
+{
+	uint8_t cmd[10];
+
+	memset(cmd, 0, sizeof cmd);
+	cmd[0] = ScmdRcapacity;
+	rp->cmd.p = cmd;
+	rp->cmd.count = sizeof cmd;
+	rp->data.p = data;
+	rp->data.count = 8;
+	rp->data.write = 0;
+	return SRrequest(rp);
+}
+
+int32_t
+SRrcapacity16(ScsiReq *rp, uint8_t *data)
+{
+	uint8_t cmd[16];
+	uint i;
+
+	i = 32;
+	memset(cmd, 0, sizeof cmd);
+	cmd[0] = ScmdRcapacity16;
+	cmd[1] = 0x10;
+	cmd[10] = i>>24;
+	cmd[11] = i>>16;
+	cmd[12] = i>>8;
+	cmd[13] = i;
+
+	rp->cmd.p = cmd;
+	rp->cmd.count = sizeof cmd;
+	rp->data.p = data;
+	rp->data.count = i;
+	rp->data.write = 0;
+	return SRrequest(rp);
+}
+
+void
+scsidebug(int d)
+{
+	debug = d;
+	if(debug)
+		fprint(2, "scsidebug on\n");
+}
+
+static int32_t
+request(int fd, ScsiPtr *cmd, ScsiPtr *data, int *status)
+{
+	int32_t n, r;
+	char buf[16];
+
+	/* this was an experiment but it seems to be a good idea */
+	*status = STok;
+
+	/* send SCSI command */
+	if(write(fd, cmd->p, cmd->count) != cmd->count){
+		fprint(2, "scsireq: write cmd: %r\n");
+		*status = Status_SW;
+		return -1;
+	}
+
+	/* read or write actual data */
+	werrstr("");
+//	alarm(5*1000);
+	if(data->write)
+		n = write(fd, data->p, data->count);
+	else {
+		n = read(fd, data->p, data->count);
+		if (n < 0)
+			memset(data->p, 0, data->count);
+		else if (n < data->count)
+			memset(data->p + n, 0, data->count - n);
+	}
+//	alarm(0);
+	if (n != data->count && n <= 0) {
+		if (debug)
+			fprint(2,
+	"request: tried to %s %ld bytes of data for cmd 0x%x but got %r\n",
+				(data->write? "write": "read"),
+				data->count, cmd->p[0]);
+	} else if (n != data->count && (data->write || debug))
+		fprint(2, "request: %s %ld of %ld bytes of actual data\n",
+			(data->write? "wrote": "read"), n, data->count);
+
+	/* read status */
+	buf[0] = '\0';
+	r = read(fd, buf, sizeof buf-1);
+	if((exabyte && r <= 0) || (!exabyte && r < 0)){
+		fprint(2, "scsireq: read status: %r\n");
+		*status = Status_SW;
+		return -1;
+	}
+	if (r >= 0)
+		buf[r] = '\0';
+	*status = atoi(buf);
+	if(n < 0 && (exabyte || *status != STcheck))
+		fprint(2, "scsireq: status 0x%2.2X: data transfer: %r\n",
+			*status);
+	return n;
+}
+
+static char*
+seprintcmd(char *s, char* e, char *cmd, int count, int args)
+{
+	uint c;
+
+	if(count < 6)
+		return seprint(s, e, "<short cmd>");
+	c = cmd[0];
+	if(scmdnames[c] != nil)
+		s = seprint(s, e, "%s", scmdnames[c]);
+	else
+		s = seprint(s, e, "cmd:%#02uX", c);
+	if(args != 0)
+		switch(c){
+		case ScmdRsense:
+		case ScmdInq:
+		case ScmdMselect6:
+		case ScmdMsense6:
+			s = seprint(s, e, " sz %d", cmd[4]);
+			break;
+		case ScmdSpace:
+			s = seprint(s, e, " code %d", cmd[1]);
+			break;
+		case ScmdStart:
+			s = seprint(s, e, " code %d", cmd[4]);
+			break;
+
+		}
+	return s;
+}
+
+static char*
+seprintdata(char *s, char *se, uint8_t *p, int count)
+{
+	int i;
+
+	if(count == 0)
+		return s;
+	for(i = 0; i < 20 && i < count; i++)
+		s = seprint(s, se, " %02x", p[i]);
+	return s;
+}
+
+static void
+SRdumpReq(ScsiReq *rp)
+{
+	char buf[128];
+	char *s;
+	char *se;
+
+	se = buf+sizeof(buf);
+	s = seprint(buf, se, "lun %d ", rp->lun);
+	s = seprintcmd(s, se, (char*)rp->cmd.p, rp->cmd.count, 1);
+	s = seprint(s, se, " [%ld]", rp->data.count);
+	if(rp->cmd.write)
+		seprintdata(s, se, rp->data.p, rp->data.count);
+	fprint(2, "scsi⇒ %s\n", buf);
+}
+
+static void
+SRdumpRep(ScsiReq *rp)
+{
+	char buf[128];
+	char *s;
+	char *se;
+
+	se = buf+sizeof(buf);
+	s = seprint(buf, se, "lun %d ", rp->lun);
+	s = seprintcmd(s, se, (char*)rp->cmd.p, rp->cmd.count, 0);
+	switch(rp->status){
+	case STok:
+		s = seprint(s, se, " good [%ld] ", rp->data.count);
+		if(rp->cmd.write == 0)
+			s = seprintdata(s, se, rp->data.p, rp->data.count);
+		break;
+	case STnomem:
+		s = seprint(s, se, " buffer allocation failed");
+		break;
+	case STharderr:
+		s = seprint(s, se, " controller error");
+		break;
+	case STtimeout:
+		s = seprint(s, se, " bus timeout");
+		break;
+	case STcheck:
+		s = seprint(s, se, " check condition");
+		break;
+	case STcondmet:
+		s = seprint(s, se, " condition met/good");
+		break;
+	case STbusy:
+		s = seprint(s, se, " busy");
+		break;
+	case STintok:
+		s = seprint(s, se, " intermediate/good");
+		break;
+	case STintcondmet:
+		s = seprint(s, se, " intermediate/condition met/good");
+		break;
+	case STresconf:
+		s = seprint(s, se, " reservation conflict");
+		break;
+	case STterminated:
+		s = seprint(s, se, " command terminated");
+		break;
+	case STqfull:
+		s = seprint(s, se, " queue full");
+		break;
+	default:
+		s = seprint(s, se, " sts=%#x", rp->status);
+	}
+	USED(s);
+	fprint(2, "scsi← %s\n", buf);
+}
+
+static char*
+scsierr(ScsiReq *rp)
+{
+	int ec;
+
+	switch(rp->status){
+	case 0:
+		return "";
+	case Status_SD:
+		ec = (rp->sense[12] << 8) | rp->sense[13];
+		return scsierrmsg(ec);
+	case Status_SW:
+		return "software error";
+	case Status_BADARG:
+		return "bad argument";
+	case Status_RO:
+		return "device is read only";
+	default:
+		return "unknown";
+	}
+}
+
+static void
+SRdumpErr(ScsiReq *rp)
+{
+	char buf[128];
+	char *se;
+
+	se = buf+sizeof(buf);
+	seprintcmd(buf, se, (char*)rp->cmd.p, rp->cmd.count, 0);
+	fprint(2, "\t%s status: %s\n", buf, scsierr(rp));
+}
+
+int32_t
+SRrequest(ScsiReq *rp)
+{
+	int32_t n;
+	int status;
+
+retry:
+	if(debug)
+		SRdumpReq(rp);
+	if(rp->flags&Fusb)
+		n = umsrequest(rp->umsc, &rp->cmd, &rp->data, &status);
+	else
+		n = request(rp->fd, &rp->cmd, &rp->data, &status);
+	rp->status = status;
+	if(status == STok)
+		rp->data.count = n;
+	if(debug)
+		SRdumpRep(rp);
+	switch(status){
+	case STok:
+		break;
+	case STcheck:
+		if(rp->cmd.p[0] != ScmdRsense && SRreqsense(rp) != -1)
+			rp->status = Status_SD;
+		if(debug || exabyte)
+			SRdumpErr(rp);
+		werrstr("%s", scsierr(rp));
+		return -1;
+	case STbusy:
+		sleep(1000);		/* TODO: try a shorter sleep? */
+		goto retry;
+	default:
+		if(debug || exabyte)
+			SRdumpErr(rp);
+		werrstr("%s", scsierr(rp));
+		return -1;
+	}
+	return n;
+}
+
+int
+SRclose(ScsiReq *rp)
+{
+	if((rp->flags & Fopen) == 0){
+		if(diskdebug)
+			fprint(2, "disk: closing closed file\n");
+		rp->status = Status_BADARG;
+		return -1;
+	}
+	close(rp->fd);
+	rp->flags = 0;
+	return 0;
+}
+
+static int
+dirdevopen(ScsiReq *rp)
+{
+	uint64_t blocks;
+	uint8_t data[8+4+20];	/* 16-byte result: lba, blksize, reserved */
+
+	memset(data, 0, sizeof data);
+	if(SRstart(rp, 1) == -1 || SRrcapacity(rp, data) == -1)
+		return -1;
+	rp->lbsize = GETBELONG(data+4);
+	blocks =     GETBELONG(data);
+	if(debug)
+		fprint(2, "disk: dirdevopen: 10-byte logical block size %lu, "
+			"# blocks %llu\n", rp->lbsize, blocks);
+	if(blocks == 0xffffffff){
+		if(SRrcapacity16(rp, data) == -1)
+			return -1;
+		rp->lbsize = GETBELONG(data + 8);
+		blocks = (int64_t)GETBELONG(data)<<32 | GETBELONG(data + 4);
+		if(debug)
+			fprint(2, "disk: dirdevopen: 16-byte logical block size"
+				" %lu, # blocks %llu\n", rp->lbsize, blocks);
+	}
+	/* some newer dev's don't support 6-byte commands */
+	if(blocks > Max24off && !force6bytecmds)
+		rp->flags |= Frw10;
+	return 0;
+}
+
+static int
+seqdevopen(ScsiReq *rp)
+{
+	uint8_t mode[16], limits[6];
+
+	if(SRrblimits(rp, limits) == -1)
+		return -1;
+	if(limits[1] == 0 && limits[2] == limits[4] && limits[3] == limits[5]){
+		rp->flags |= Fbfixed;
+		rp->lbsize = limits[4]<<8 | limits[5];
+		if(debug)
+			fprint(2, "disk: seqdevopen: 10-byte logical block size %lu\n",
+				rp->lbsize);
+		return 0;
+	}
+	/*
+	 * On some older hardware the optional 10-byte
+	 * modeselect command isn't implemented.
+	 */
+	if (force6bytecmds)
+		rp->flags |= Fmode6;
+	if(!(rp->flags & Fmode6)){
+		/* try 10-byte command first */
+		memset(mode, 0, sizeof mode);
+		mode[3] = 0x10;		/* device-specific param. */
+		mode[7] = 8;		/* block descriptor length */
+		/*
+		 * exabytes can't handle this, and
+		 * modeselect(10) is optional.
+		 */
+		if(SRmodeselect10(rp, mode, sizeof mode) != -1){
+			rp->lbsize = 1;
+			return 0;	/* success */
+		}
+		/* can't do 10-byte commands, back off to 6-byte ones */
+		rp->flags |= Fmode6;
+	}
+
+	/* 6-byte command */
+	memset(mode, 0, sizeof mode);
+	mode[2] = 0x10;		/* device-specific param. */
+	mode[3] = 8;		/* block descriptor length */
+	/*
+	 * bsd sez exabytes need this bit (NBE: no busy enable) in
+	 * vendor-specific page (0), but so far we haven't needed it.
+	mode[12] |= 8;
+	 */
+	if(SRmodeselect6(rp, mode, 4+8) == -1)
+		return -1;
+	rp->lbsize = 1;
+	return 0;
+}
+
+static int
+wormdevopen(ScsiReq *rp)
+{
+	int32_t status;
+	uint8_t list[MaxDirData];
+
+	if (SRstart(rp, 1) == -1 ||
+	    (status = SRmodesense10(rp, Allmodepages, list, sizeof list)) == -1)
+		return -1;
+	/* nbytes = list[0]<<8 | list[1]; */
+
+	/* # of bytes of block descriptors of 8 bytes each; not even 1? */
+	if((list[6]<<8 | list[7]) < 8)
+		rp->lbsize = 2048;
+	else
+		/* last 3 bytes of block 0 descriptor */
+		rp->lbsize = GETBE24(list+13);
+	if(debug)
+		fprint(2, "disk: wormdevopen: 10-byte logical block size %lu\n",
+			rp->lbsize);
+	return status;
+}
+
+int
+SRopenraw(ScsiReq *rp, char *unit)
+{
+	char name[128];
+
+	if(rp->flags & Fopen){
+		if(diskdebug)
+			fprint(2, "disk: opening open file\n");
+		rp->status = Status_BADARG;
+		return -1;
+	}
+	memset(rp, 0, sizeof *rp);
+	rp->unit = unit;
+
+	snprint(name, sizeof name, "%s/raw", unit);
+	if((rp->fd = open(name, ORDWR)) == -1){
+		rp->status = STtimeout;
+		return -1;
+	}
+	rp->flags = Fopen;
+	return 0;
+}
+
+int
+SRopen(ScsiReq *rp, char *unit)
+{
+	if(SRopenraw(rp, unit) == -1)
+		return -1;
+	SRready(rp);
+	if(SRinquiry(rp) >= 0){
+		switch(rp->inquiry[0]){
+
+		default:
+			fprint(2, "unknown device type 0x%.2x\n", rp->inquiry[0]);
+			rp->status = Status_SW;
+			break;
+
+		case Devdir:
+		case Devcd:
+		case Devmo:
+			if(dirdevopen(rp) == -1)
+				break;
+			return 0;
+
+		case Devseq:
+			rp->flags |= Fseqdev;
+			if(seqdevopen(rp) == -1)
+				break;
+			return 0;
+
+		case Devprint:
+			rp->flags |= Fprintdev;
+			return 0;
+
+		case Devworm:
+			rp->flags |= Fwormdev;
+			if(wormdevopen(rp) == -1)
+				break;
+			return 0;
+
+		case Devjuke:
+			rp->flags |= Fchanger;
+			return 0;
+		}
+	}
+	SRclose(rp);
+	return -1;
+}

--- a/sys/src/libusb/ether/asix.c
+++ b/sys/src/libusb/ether/asix.c
@@ -1,0 +1,498 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+/*
+ * Asix USB ether adapters
+ * I got no documentation for it, thus the bits
+ * come from other systems; it's likely this is
+ * doing more than needed in some places and
+ * less than required in others.
+ */
+#include <u.h>
+#include <libc.h>
+#include <fcall.h>
+#include <thread.h>
+#include <usb/usb.h>
+#include <usb/usbfs.h>
+#include <usb/ether.h>
+
+enum
+{
+
+	/* Asix commands */
+	Cswmii		= 0x06,		/* set sw mii */
+	Crmii		= 0x07,		/* read mii reg */
+	Cwmii		= 0x08,		/* write mii reg */
+	Chwmii		= 0x0a,		/* set hw mii */
+	Creeprom	= 0x0b,		/* read eeprom */
+	Cwdis		= 0x0e,		/* write disable */
+	Cwena		= 0x0d,		/* write enable */
+	Crrxctl		= 0x0f,		/* read rx ctl */
+	Cwrxctl		= 0x10,		/* write rx ctl */
+	Cwipg		= 0x12,		/* write ipg */
+	Crmac		= 0x13,		/* read mac addr */
+	Crphy		= 0x19,		/* read phy id */
+	Cwmedium		= 0x1b,		/* write medium mode */
+	Crgpio		= 0x1e,		/* read gpio */
+	Cwgpio		= 0x1f,		/* write gpios */
+	Creset		= 0x20,		/* reset */
+	Cwphy		= 0x22,		/* select phy */
+
+	/* reset codes */
+	Rclear		= 0x00,
+	Rprte		= 0x04,
+	Rprl		= 0x08,
+	Riprl		= 0x20,
+	Rippd		= 0x40,
+
+	Gpiogpo1en	= 0x04,	/* gpio1 enable */
+	Gpiogpo1		= 0x08,	/* gpio1 value */
+	Gpiogpo2en	= 0x10,	/* gpio2 enable */
+	Gpiogpo2		= 0x20,	/* gpio2 value */
+	Gpiorse		= 0x80,	/* gpio reload serial eeprom */
+
+	Pmask		= 0x1F,
+	Pembed		= 0x10,			/* embedded phy */
+
+	Mfd		= 0x002,		/* media */
+	Mac		= 0x004,
+	Mrfc		= 0x010,
+	Mtfc		= 0x020,
+	Mjfe		= 0x040,
+	Mre		= 0x100,
+	Mps		= 0x200,
+	Mall772		= Mfd|Mrfc|Mtfc|Mps|Mac|Mre,
+	Mall178		= Mps|Mfd|Mac|Mrfc|Mtfc|Mjfe|Mre,
+
+	Ipgdflt		= 0x15|0x0c|0x12,	/* default ipg0, 1, 2 */
+	Rxctlso		= 0x80,
+	Rxctlab		= 0x08,
+	Rxctlsep	= 0x04,
+	Rxctlamall	= 0x02,			/* all multicast */
+	Rxctlprom	= 0x01,			/* promiscuous */
+
+	/* MII */
+	Miibmcr			= 0x00,		/* basic mode ctrl reg. */
+		Bmcrreset	= 0x8000,	/* reset */
+		Bmcranena	= 0x1000,	/* auto neg. enable */
+		Bmcrar		= 0x0200,	/* announce restart */
+
+	Miiad			= 0x04,		/* advertise reg. */
+		Adcsma		= 0x0001,
+		Ad1000f		= 0x0200,
+		Ad1000h		= 0x0100,
+		Ad10h		= 0x0020,
+		Ad10f		= 0x0040,
+		Ad100h		= 0x0080,
+		Ad100f		= 0x0100,
+		Adpause		= 0x0400,
+		Adall		= Ad10h|Ad10f|Ad100h|Ad100f,
+
+	Miimctl			= 0x14,		/* marvell ctl */
+		Mtxdly		= 0x02,
+		Mrxdly		= 0x80,
+		Mtxrxdly	= 0x82,
+
+	Miic1000			= 0x09,
+
+};
+
+static int
+asixset(Dev *d, int c, int v)
+{
+	int r;
+	int ec;
+
+	r = Rh2d|Rvendor|Rdev;
+	ec = usbcmd(d, r, c, v, 0, nil, 0);
+	if(ec < 0)
+		deprint(2, "%s: asixset %x %x: %r\n", argv0, c, v);
+	return ec;
+}
+
+static int
+asixget(Dev *d, int c, uint8_t *buf, int l)
+{
+	int r;
+	int ec;
+
+	r = Rd2h|Rvendor|Rdev;
+	ec = usbcmd(d, r, c, 0, 0, buf, l);
+	if(ec < 0)
+		deprint(2, "%s: asixget %x: %r\n", argv0, c);
+	return ec;
+}
+
+static int
+getgpio(Dev *d)
+{
+	uint8_t c;
+
+	if(asixget(d, Crgpio, &c, 1) < 0)
+		return -1;
+	return c;
+}
+
+static int
+getphy(Dev *d)
+{
+	uint8_t buf[2];
+
+	if(asixget(d, Crphy, buf, sizeof(buf)) < 0)
+		return -1;
+	deprint(2, "%s: phy addr %#x\n", argv0, buf[1]);
+	return buf[1];
+}
+
+static int
+getrxctl(Dev *d)
+{
+	uint8_t buf[2];
+	int r;
+
+	memset(buf, 0, sizeof(buf));
+	if(asixget(d, Crrxctl, buf, sizeof(buf)) < 0)
+		return -1;
+	r = GET2(buf);
+	deprint(2, "%s: rxctl %#x\n", argv0, r);
+	return r;
+}
+
+static int
+getmac(Dev *d, uint8_t buf[])
+{
+	if(asixget(d, Crmac, buf, Eaddrlen) < 0)
+		return -1;
+	return Eaddrlen;
+}
+
+static int
+miiread(Dev *d, int phy, int reg)
+{
+	int r;
+	uint8_t v[2];
+
+	r = Rd2h|Rvendor|Rdev;
+	if(usbcmd(d, r, Crmii, phy, reg, v, 2) < 0){
+		dprint(2, "%s: miiwrite: %r\n", argv0);
+		return -1;
+	}
+	r = GET2(v);
+	if(r == 0xFFFF)
+		return -1;
+	return r;
+}
+
+
+static int
+miiwrite(Dev *d, int phy, int reg, int val)
+{
+	int r;
+	uint8_t v[2];
+
+	if(asixset(d, Cswmii, 0) < 0)
+		return -1;
+	r = Rh2d|Rvendor|Rdev;
+	PUT2(v, val);
+	if(usbcmd(d, r, Cwmii, phy, reg, v, 2) < 0){
+		deprint(2, "%s: miiwrite: %#x %#x %r\n", argv0, reg, val);
+		return -1;
+	}
+	if(asixset(d, Chwmii, 0) < 0)
+		return -1;
+	return 0;
+}
+
+static int
+eepromread(Dev *d, int i)
+{
+	int r;
+	int ec;
+	uint8_t buf[2];
+
+	r = Rd2h|Rvendor|Rdev;
+	ec = usbcmd(d, r, Creeprom, i, 0, buf, sizeof(buf));
+	if(ec < 0)
+		deprint(2, "%s: eepromread %d: %r\n", argv0, i);
+	ec = GET2(buf);
+	deprint(2, "%s: eeprom %#x = %#x\n", argv0, i, ec);
+	if(ec == 0xFFFF)
+		ec = -1;
+	return ec;
+}
+
+/*
+ * No doc. we are doing what Linux does as closely
+ * as we can.
+ */
+static int
+ctlrinit(Ether *ether)
+{
+	Dev *d;
+	int i;
+	int bmcr;
+	int gpio;
+	int ee17;
+	int rc;
+
+	d = ether->dev;
+	switch(ether->cid){
+	case A8817x:
+	case A88179:
+		fprint(2, "%s: card known but not implemented\n", argv0);
+		/* fall through */
+	default:
+		return -1;
+
+	case A88178:
+		deprint(2, "%s: setting up A88178\n", argv0);
+		gpio = getgpio(d);
+		if(gpio < 0)
+			return -1;
+		deprint(2, "%s: gpio sts %#x\n", argv0, gpio);
+		asixset(d, Cwena, 0);
+		ee17 = eepromread(d, 0x0017);
+		asixset(d, Cwdis, 0);
+		asixset(d, Cwgpio, Gpiorse|Gpiogpo1|Gpiogpo1en);
+		if((ee17 >> 8) != 1){
+			asixset(d, Cwgpio, 0x003c);
+			asixset(d, Cwgpio, 0x001c);
+			asixset(d, Cwgpio, 0x003c);
+		}else{
+			asixset(d, Cwgpio, Gpiogpo1en);
+			asixset(d, Cwgpio, Gpiogpo1|Gpiogpo1en);
+		}
+		asixset(d, Creset, Rclear);
+		sleep(150);
+		asixset(d, Creset, Rippd|Rprl);
+		sleep(150);
+		asixset(d, Cwrxctl, 0);
+		if(getmac(d, ether->addr) < 0)
+			return -1;
+		ether->phy = getphy(d);
+		if(ee17 < 0 || (ee17 & 0x7) == 0){
+			miiwrite(d, ether->phy, Miimctl, Mtxrxdly);
+			sleep(60);
+		}
+		miiwrite(d, ether->phy, Miibmcr, Bmcrreset|Bmcranena);
+		miiwrite(d, ether->phy, Miiad, Adall|Adcsma|Adpause);
+		miiwrite(d, ether->phy, Miic1000, Ad1000f);
+		bmcr = miiread(d, ether->phy, Miibmcr);
+		if((bmcr & Bmcranena) != 0){
+			bmcr |= Bmcrar;
+			miiwrite(d, ether->phy, Miibmcr, bmcr);
+		}
+		asixset(d, Cwmedium, Mall178);
+		asixset(d, Cwrxctl, Rxctlso|Rxctlab);
+		break;
+
+	case A88772:
+		deprint(2, "%s: setting up A88772\n", argv0);
+		if(asixset(d, Cwgpio, Gpiorse|Gpiogpo2|Gpiogpo2en) < 0)
+			return -1;
+		ether->phy = getphy(d);
+		dprint(2, "%s: phy %#x\n", argv0, ether->phy);
+		if((ether->phy & Pmask) == Pembed){
+			/* embedded 10/100 ethernet */
+			rc = asixset(d, Cwphy, 1);
+		}else
+			rc = asixset(d, Cwphy, 0);
+		if(rc < 0)
+			return -1;
+		if(asixset(d, Creset, Rippd|Rprl) < 0)
+			return -1;
+		sleep(150);
+		if((ether->phy & Pmask) == Pembed)
+			rc = asixset(d, Creset, Riprl);
+		else
+			rc = asixset(d, Creset, Rprte);
+		if(rc < 0)
+			return -1;
+		sleep(150);
+		rc = getrxctl(d);
+		deprint(2, "%s: rxctl is %#x\n", argv0, rc);
+		if(asixset(d, Cwrxctl, 0) < 0)
+			return -1;
+		if(getmac(d, ether->addr) < 0)
+			return -1;
+
+
+		if(asixset(d, Creset, Rprl) < 0)
+			return -1;
+		sleep(150);
+		if(asixset(d, Creset, Riprl|Rprl) < 0)
+			return -1;
+		sleep(150);
+
+		miiwrite(d, ether->phy, Miibmcr, Bmcrreset);
+		miiwrite(d, ether->phy, Miiad, Adall|Adcsma);
+		bmcr = miiread(d, ether->phy, Miibmcr);
+		if((bmcr & Bmcranena) != 0){
+			bmcr |= Bmcrar;
+			miiwrite(d, ether->phy, Miibmcr, bmcr);
+		}
+		if(asixset(d, Cwmedium, Mall772) < 0)
+			return -1;
+		if(asixset(d, Cwipg, Ipgdflt) < 0)
+			return -1;
+		if(asixset(d, Cwrxctl, Rxctlso|Rxctlab) < 0)
+			return -1;
+		deprint(2, "%s: final rxctl: %#x\n", argv0, getrxctl(d));
+		break;
+	}
+
+	if(etherdebug){
+		fprint(2, "%s: ether: phy %#x addr ", argv0, ether->phy);
+		for(i = 0; i < sizeof(ether->addr); i++)
+			fprint(2, "%02x", ether->addr[i]);
+		fprint(2, "\n");
+	}
+	return 0;
+}
+
+
+static int32_t
+asixbread(Ether *e, Buf *bp)
+{
+	uint32_t nr;
+	uint32_t hd;
+	Buf *rbp;
+
+	rbp = e->Etherops.aux;
+	if(rbp == nil || rbp->ndata < 4){
+		rbp->rp = rbp->data;
+		rbp->ndata = read(e->epin->dfd, rbp->rp, sizeof(bp->data));
+		if(rbp->ndata < 0)
+			return -1;
+	}
+	if(rbp->ndata < 4){
+		werrstr("short frame");
+		deprint(2, "%s: asixbread got %d bytes\n", argv0, rbp->ndata);
+		rbp->ndata = 0;
+		return 0;
+	}
+	hd = GET4(rbp->rp);
+	nr = hd & 0xFFFF;
+	hd = (hd>>16) & 0xFFFF;
+	if(nr != (~hd & 0xFFFF)){
+		if(0)deprint(2, "%s: asixread: bad header %#lx %#lx\n",
+			argv0, nr, (~hd & 0xFFFF));
+		werrstr("bad usb packet header");
+		rbp->ndata = 0;
+		return 0;
+	}
+	rbp->rp += 4;
+	if(nr < 6 || nr > Epktlen){
+		if(nr < 6)
+			werrstr("short frame");
+		else
+			werrstr("long frame");
+		deprint(2, "%s: asixbread %r (%ld)\n", argv0, nr);
+		rbp->ndata = 0;
+		return 0;
+	}
+	bp->rp = bp->data + Hdrsize;
+	memmove(bp->rp, rbp->rp, nr);
+	bp->ndata = nr;
+	rbp->rp += 4 + nr;
+	rbp->ndata -= (4 + nr);
+	return bp->ndata;
+}
+
+static int32_t
+asixbwrite(Ether *e, Buf *bp)
+{
+	uint32_t len;
+	int32_t n;
+
+	deprint(2, "%s: asixbwrite %d bytes\n", argv0, bp->ndata);
+	assert(bp->rp - bp->data >= Hdrsize);
+	bp->ndata &= 0xFFFF;
+	len = (0xFFFF0000 & ~(bp->ndata<<16))  | bp->ndata;
+	bp->rp -= 4;
+	PUT4(bp->rp, len);
+	bp->ndata += 4;
+	if((bp->ndata % e->epout->maxpkt) == 0){
+		PUT4(bp->rp+bp->ndata, 0xFFFF0000);
+		bp->ndata += 4;
+	}
+	n = write(e->epout->dfd, bp->rp, bp->ndata);
+	deprint(2, "%s: asixbwrite wrote %ld bytes\n", argv0, n);
+	if(n <= 0)
+		return n;
+	return n;
+}
+
+static int
+asixpromiscuous(Ether *e, int on)
+{
+	int rxctl;
+
+	deprint(2, "%s: asixpromiscuous %d\n", argv0, on);
+	rxctl = getrxctl(e->dev);
+	if(on != 0)
+		rxctl |= Rxctlprom;
+	else
+		rxctl &= ~Rxctlprom;
+	return asixset(e->dev, Cwrxctl, rxctl);
+}
+
+static int
+asixmulticast(Ether *e, uint8_t *addr, int on)
+{
+	int rxctl;
+
+	USED(addr);
+	USED(on);
+	/* BUG: should write multicast filter */
+	rxctl = getrxctl(e->dev);
+	if(e->nmcasts != 0)
+		rxctl |= Rxctlamall;
+	else
+		rxctl &= ~Rxctlamall;
+	deprint(2, "%s: asixmulticast %d\n", argv0, e->nmcasts);
+	return asixset(e->dev, Cwrxctl, rxctl);
+}
+
+static void
+asixfree(Ether *ether)
+{
+	deprint(2, "%s: aixfree %#p\n", argv0, ether);
+	free(ether->Etherops.aux);
+	ether->Etherops.aux = nil;
+}
+
+int
+asixreset(Ether *ether)
+{
+	Cinfo *ip;
+	Dev *dev;
+
+	dev = ether->dev;
+	for(ip = cinfo; ip->vid != 0; ip++)
+		if(ip->vid == dev->usb->vid && ip->did == dev->usb->did){
+			ether->cid = ip->cid;
+			if(ctlrinit(ether) < 0){
+				deprint(2, "%s: asix init failed: %r\n", argv0);
+				return -1;
+			}
+			deprint(2, "%s: asix reset done\n", argv0);
+			ether->Etherops.name = "asix";
+			ether->Etherops.aux = emallocz(sizeof(Buf), 1);
+			ether->Etherops.bufsize = Hdrsize+Maxpkt;
+			ether->Etherops.bread = asixbread;
+			ether->Etherops.bwrite = asixbwrite;
+			ether->Etherops.free = asixfree;
+			ether->Etherops.promiscuous = asixpromiscuous;
+			ether->Etherops.multicast = asixmulticast;
+			ether->mbps = 100;	/* BUG */
+			return 0;
+		}
+	return -1;
+}

--- a/sys/src/libusb/ether/cdc.c
+++ b/sys/src/libusb/ether/cdc.c
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+/*
+ * Standard usb ethernet communications device.
+ */
+#include <u.h>
+#include <libc.h>
+#include <fcall.h>
+#include <thread.h>
+#include <usb/usb.h>
+#include <usb/usbfs.h>
+#include <usb/ether.h>
+
+static int
+okclass(Iface *iface)
+{
+	return Class(iface->csp) == Clcomms && Subclass(iface->csp) == Scether;
+}
+
+static int
+getmac(Ether *ether)
+{
+	int i;
+	Usbdev *ud;
+	uint8_t *b;
+	Desc *dd;
+	char *mac;
+
+	ud = ether->dev->usb;
+
+	for(i = 0; i < nelem(ud->ddesc); i++)
+		if((dd = ud->ddesc[i]) != nil && okclass(dd->iface)){
+			b = (uint8_t*)&dd->data;
+			if(b[1] == Dfunction && b[2] == Fnether){
+				mac = loaddevstr(ether->dev, b[3]);
+				if(mac != nil && strlen(mac) != 12){
+					free(mac);
+					mac = nil;
+				}
+				if(mac != nil){
+					parseaddr(ether->addr, mac);
+					free(mac);
+					return 0;
+				}
+			}
+		}
+	return -1;
+}
+
+int
+cdcreset(Ether *ether)
+{
+	/*
+	 * Assume that all communication devices are going to
+	 * be std. ethernet communication devices. Specific controllers
+	 * must have been probed first.
+	 * NB: This ignores unions.
+	 */
+	if(ether->dev->usb->class == Clcomms)
+		return getmac(ether);
+	return -1;
+}

--- a/sys/src/libusb/ether/ether.c
+++ b/sys/src/libusb/ether/ether.c
@@ -1,0 +1,1251 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+/*
+ * usb/ether - usb ethernet adapter.
+ * BUG: This should use /dev/etherfile to
+ * use the kernel ether device code.
+ */
+#include <u.h>
+#include <libc.h>
+#include <fcall.h>
+#include <thread.h>
+#include <usb/usb.h>
+#include <usb/usbfs.h>
+#include <usb/ether.h>
+
+typedef struct Dirtab Dirtab;
+
+enum
+{
+	/* Qids. Maintain order (relative to dirtabs structs) */
+	Qroot	= 0,
+	Qclone,
+	Qaddr,
+	Qifstats,
+	Qstats,
+	Qndir,
+	Qndata,
+	Qnctl,
+	Qnifstats,
+	Qnstats,
+	Qntype,
+	Qmax,
+};
+
+struct Dirtab
+{
+	char	*name;
+	int	qid;
+	int	mode;
+};
+
+typedef int (*Resetf)(Ether*);
+
+/*
+ * Controllers by vid/vid. Used to locate
+ * specific adapters that do not implement cdc ethernet
+ * Keep null terminated.
+ */
+Cinfo cinfo[] =
+{
+	/* Asix controllers.
+	 * Only A88178 and A88772 are implemented.
+	 * Others are easy to add by borrowing code
+	 * from other systems.
+	 */
+	{0x0411, 0x003d, A8817x},	/* buffalo */
+	{0x0411, 0x006e, A88178},
+	{0x04f1, 0x3008, A8817x},
+	{0x050d, 0x5055, A88178},
+	{0x0557, 0x2009, A8817x},
+	{0x05ac, 0x1402, A88772},	/* Apple */
+	{0x077b, 0x2226, A8817x},
+	{0x07aa, 0x0017, A8817x},
+	{0x07d1, 0x3c05, A88772},
+	{0x0b95, 0x1720, A8817x},	/* asix */
+	{0x0b95, 0x1780, A88178},	/* Geoff */
+	{0x0b95, 0x7720, A88772},
+	{0x0b95, 0x772a, A88772},
+	{0x0db0, 0xa877, A88772},
+	{0x1189, 0x0893, A8817x},
+	{0x13b1, 0x0018, A88772},
+	{0x14ea, 0xab11, A88178},
+	{0x1557, 0x7720, A88772},
+	{0x1631, 0x6200, A8817x},
+	{0x1737, 0x0039, A88178},
+	{0x2001, 0x3c05, A88772},
+	{0x6189, 0x182d, A8817x},
+
+	/* SMSC controllers.
+	 * LAN95xx family
+	 */
+	{0x0424, 0xec00, S95xx},	/* LAN9512 (as in raspberry pi) */
+	{0x0424, 0x9500, S95xx},
+	{0x0424, 0x9505, S95xx},
+	{0x0424, 0x9E00, S95xx},
+	{0x0424, 0x9E01, S95xx},
+	{0, 0, 0},
+};
+
+/*
+ * Each etherU%d is the root of our file system,
+ * which is added to the usb root directory. We only
+ * have to concern ourselfs with each /etherU%d subtree.
+ *
+ * NB: Maintain order in dirtabs, relative to the Qids enum.
+ */
+
+static Dirtab rootdirtab[] =
+{
+	{"/",		Qroot,		DMDIR|0555},	/* etherU%d */
+	{"clone",	Qclone,		0666},
+	{"addr",	Qaddr,		0444},
+	{"ifstats",	Qifstats,	0444},
+	{"stats",	Qstats,		0444},
+	/* one dir per connection here */
+	{nil, 0, 0},
+};
+
+static Dirtab conndirtab[] =
+{
+	{"%d",		Qndir,		DMDIR|0555},
+	{"data",	Qndata,		0666},
+	{"ctl",		Qnctl,		0666},
+	{"ifstats",	Qnifstats,	0444},
+	{"stats",	Qnstats,	0444},
+	{"type",	Qntype,		0444},
+	{nil, 0, 0},
+};
+
+int etherdebug;
+
+Resetf ethers[] =
+{
+	asixreset,
+	smscreset,
+	cdcreset,	/* keep last */
+};
+
+static int
+qtype(int64_t q)
+{
+	return q&0xFF;
+}
+
+static int
+qnum(int64_t q)
+{
+	return (q >> 8) & 0xFFFFFF;
+}
+
+static uint64_t
+mkqid(int n, int t)
+{
+	uint64_t q;
+
+	q = ((n&0xFFFFFF) << 8) | (t&0xFF);
+	return q;
+}
+
+static void
+freebuf(Ether *e, Buf *bp)
+{
+	if(0)deprint(2, "%s: freebuf %#p\n", argv0, bp);
+	if(bp != nil){
+		qlock(&e->QLock);
+		e->nbufs--;
+		qunlock(&e->QLock);
+		sendp(e->bc, bp);
+	}
+}
+
+static Buf*
+allocbuf(Ether *e)
+{
+	Buf *bp;
+
+	bp = nbrecvp(e->bc);
+	if(bp == nil){
+		qlock(&e->QLock);
+		if(e->nabufs < Nbufs){
+			bp = emallocz(sizeof(Buf), 1);
+			e->nabufs++;
+			setmalloctag(bp, getcallerpc());
+			deprint(2, "%s: %d buffers\n", argv0, e->nabufs);
+		}
+		qunlock(&e->QLock);
+	}
+	if(bp == nil){
+		deprint(2, "%s: blocked waiting for allocbuf\n", argv0);
+		bp = recvp(e->bc);
+	}
+	bp->rp = bp->data + Hdrsize;
+	bp->ndata = 0;
+	if(0)deprint(2, "%s: allocbuf %#p\n", argv0, bp);
+	qlock(&e->QLock);
+	e->nbufs++;
+	qunlock(&e->QLock);
+	return bp;
+}
+
+static Conn*
+newconn(Ether *e)
+{
+	int i;
+	Conn *c;
+
+	qlock(&e->QLock);
+	for(i = 0; i < nelem(e->conns); i++){
+		c = e->conns[i];
+		if(c == nil || c->Ref.ref == 0){
+			if(c == nil){
+				c = emallocz(sizeof(Conn), 1);
+				c->rc = chancreate(sizeof(Buf*), 16);
+				c->nb = i;
+			}
+			c->Ref.ref = 1;
+			if(i == e->nconns)
+				e->nconns++;
+			e->conns[i] = c;
+			deprint(2, "%s: newconn %d\n", argv0, i);
+			qunlock(&e->QLock);
+			return c;
+		}
+	}
+	qunlock(&e->QLock);
+	return nil;
+}
+
+static char*
+seprintaddr(char *s, char *se, uint8_t *addr)
+{
+	int i;
+
+	for(i = 0; i < Eaddrlen; i++)
+		s = seprint(s, se, "%02x", addr[i]);
+	return s;
+}
+
+void
+dumpframe(char *tag, void *p, int n)
+{
+	Etherpkt *ep;
+	char buf[128];
+	char *s, *se;
+	int i;
+
+	ep = p;
+	if(n < Eaddrlen * 2 + 2){
+		fprint(2, "short packet (%d bytes)\n", n);
+		return;
+	}
+	se = buf+sizeof(buf);
+	s = seprint(buf, se, "%s [%d]: ", tag, n);
+	s = seprintaddr(s, se, ep->s);
+	s = seprint(s, se, " -> ");
+	s = seprintaddr(s, se, ep->d);
+	s = seprint(s, se, " type 0x%02x%02x ", ep->type[0], ep->type[1]);
+	n -= Eaddrlen * 2 + 2;
+	for(i = 0; i < n && i < 16; i++)
+		s = seprint(s, se, "%02x", ep->data[i]);
+	if(n >= 16)
+		fprint(2, "%s...\n", buf);
+	else
+		fprint(2, "%s\n", buf);
+}
+
+static char*
+seprintstats(char *s, char *se, Ether *e)
+{
+	qlock(&e->QLock);
+	s = seprint(s, se, "in: %ld\n", e->nin);
+	s = seprint(s, se, "out: %ld\n", e->nout);
+	s = seprint(s, se, "input errs: %ld\n", e->nierrs);
+	s = seprint(s, se, "output errs: %ld\n", e->noerrs);
+	s = seprint(s, se, "mbps: %d\n", e->mbps);
+	s = seprint(s, se, "prom: %ld\n", e->prom.ref);
+	s = seprint(s, se, "addr: ");
+	s = seprintaddr(s, se, e->addr);
+	s = seprint(s, se, "\n");
+	qunlock(&e->QLock);
+	return s;
+}
+
+static char*
+seprintifstats(char *s, char *se, Ether *e)
+{
+	int i;
+	Conn *c;
+
+	qlock(&e->QLock);
+	s = seprint(s, se, "ctlr id: %#x\n", e->cid);
+	s = seprint(s, se, "phy: %#x\n", e->phy);
+	s = seprint(s, se, "exiting: %s\n", e->exiting ? "y" : "n");
+	s = seprint(s, se, "conns: %d\n", e->nconns);
+	s = seprint(s, se, "allocated bufs: %d\n", e->nabufs);
+	s = seprint(s, se, "used bufs: %d\n", e->nbufs);
+	for(i = 0; i < nelem(e->conns); i++){
+		c = e->conns[i];
+		if(c == nil)
+			continue;
+		if(c->Ref.ref == 0)
+			s = seprint(s, se, "c[%d]: free\n", i);
+		else{
+			s = seprint(s, se, "c[%d]: refs %ld t %#x h %d p %d\n",
+				c->nb, c->Ref.ref, c->type, c->headersonly, c->prom);
+		}
+	}
+	qunlock(&e->QLock);
+	return s;
+}
+
+static void
+etherdump(Ether *e)
+{
+	char buf[256];
+
+	if(etherdebug == 0)
+		return;
+	seprintifstats(buf, buf+sizeof(buf), e);
+	fprint(2, "%s: ether %#p:\n%s\n", argv0, e, buf);
+}
+
+static Conn*
+getconn(Ether *e, int i, int idleok)
+{
+	Conn *c;
+
+	qlock(&e->QLock);
+	if(i < 0 || i >= e->nconns)
+		c = nil;
+	else{
+		c = e->conns[i];
+		if(idleok == 0 && c != nil && c->Ref.ref == 0)
+			c = nil;
+	}
+	qunlock(&e->QLock);
+	return c;
+}
+
+static void
+filldir(Usbfs *fs, Dir *d, Dirtab *tab, int cn)
+{
+	d->qid.path = mkqid(cn, tab->qid);
+	d->qid.path |= fs->qid;
+	d->mode = tab->mode;
+	if((d->mode & DMDIR) != 0)
+		d->qid.type = QTDIR;
+	else
+		d->qid.type = QTFILE;
+	if(tab->qid == Qndir)
+		snprint(d->name, Namesz, "%d", cn);
+	else
+		d->name = tab->name;
+}
+
+static int
+rootdirgen(Usbfs *fs, Qid _1, int i, Dir *d, void *_2)
+{
+	Ether *e;
+	Dirtab *tab;
+	int cn;
+
+	e = fs->aux;
+	i++;				/* skip root */
+	cn = 0;
+	if(i < nelem(rootdirtab) - 1)	/* null terminated */
+		tab = &rootdirtab[i];
+	else{
+		cn = i - nelem(rootdirtab) + 1;
+		if(cn < e->nconns)
+			tab = &conndirtab[0];
+		else
+			return -1;
+	}
+	filldir(fs, d, tab, cn);
+	return 0;
+}
+
+static int
+conndirgen(Usbfs *fs, Qid q, int i, Dir *d, void *_1)
+{
+	Dirtab *tab;
+
+	i++;				/* skip root */
+	if(i < nelem(conndirtab) - 1)	/* null terminated */
+		tab = &conndirtab[i];
+	else
+		return -1;
+	filldir(fs, d, tab, qnum(q.path));
+	return 0;
+}
+
+static int
+fswalk(Usbfs *fs, Fid *fid, char *name)
+{
+	int cn, i;
+	char *es;
+	Dirtab *tab;
+	Ether *e;
+	Qid qid;
+
+	e = fs->aux;
+	qid = fid->qid;
+	qid.path &= ~fs->qid;
+	if((qid.type & QTDIR) == 0){
+		werrstr("walk in non-directory");
+		return -1;
+	}
+
+	if(strcmp(name, "..") == 0){
+		/* must be /etherU%d; i.e. our root dir. */
+		fid->qid.path = mkqid(0, Qroot) | fs->qid;
+		fid->qid.vers = 0;
+		fid->qid.type = QTDIR;
+		return 0;
+	}
+	switch(qtype(qid.path)){
+	case Qroot:
+		if(name[0] >= '0' && name[0] <= '9'){
+			es = name;
+			cn = strtoul(name, &es, 10);
+			if(cn >= e->nconns || *es != 0){
+				werrstr(Enotfound);
+				return -1;
+			}
+			fid->qid.path = mkqid(cn, Qndir) | fs->qid;
+			fid->qid.vers = 0;
+			return 0;
+		}
+		/* fall */
+	case Qndir:
+		if(qtype(qid.path) == Qroot)
+			tab = rootdirtab;
+		else
+			tab = conndirtab;
+		cn = qnum(qid.path);
+		for(i = 0; tab[i].name != nil; tab++)
+			if(strcmp(tab[i].name, name) == 0){
+				fid->qid.path = mkqid(cn, tab[i].qid)|fs->qid;
+				fid->qid.vers = 0;
+				if((tab[i].mode & DMDIR) != 0)
+					fid->qid.type = QTDIR;
+				else
+					fid->qid.type = QTFILE;
+				return 0;
+			}
+		break;
+	default:
+		sysfatal("usb: ether: fswalk bug");
+	}
+	return -1;
+}
+
+static Dirtab*
+qdirtab(int64_t q)
+{
+	int i, qt;
+	Dirtab *tab;
+
+	qt = qtype(q);
+	if(qt < nelem(rootdirtab) - 1){	/* null terminated */
+		tab = rootdirtab;
+		i = qt;
+	}else{
+		tab = conndirtab;
+		i = qt - (nelem(rootdirtab) - 1);
+		assert(i < nelem(conndirtab) - 1);
+	}
+	return &tab[i];
+}
+
+static int
+fsstat(Usbfs *fs, Qid qid, Dir *d)
+{
+	filldir(fs, d, qdirtab(qid.path), qnum(qid.path));
+	return 0;
+}
+
+static int
+fsopen(Usbfs *fs, Fid *fid, int omode)
+{
+	int qt;
+	int64_t qid;
+	Conn *c;
+	Dirtab *tab;
+	Ether *e;
+
+	qid = fid->qid.path & ~fs->qid;
+	e = fs->aux;
+	qt = qtype(qid);
+	tab = qdirtab(qid);
+	omode &= 3;
+	if(omode != OREAD && (tab->mode&0222) == 0){
+		werrstr(Eperm);
+		return -1;
+	}
+	switch(qt){
+	case Qclone:
+		c = newconn(e);
+		if(c == nil){
+			werrstr("no more connections");
+			return -1;
+		}
+		fid->qid.type = QTFILE;
+		fid->qid.path = mkqid(c->nb, Qnctl)|fs->qid;
+		fid->qid.vers = 0;
+		break;
+	case Qndata:
+	case Qnctl:
+	case Qnifstats:
+	case Qnstats:
+	case Qntype:
+		c = getconn(e, qnum(qid), 1);
+		if(c == nil)
+			sysfatal("usb: ether: fsopen bug");
+		incref(&c->Ref);
+		break;
+	}
+	etherdump(e);
+	return 0;
+}
+
+static int
+prom(Ether *e, int set)
+{
+	if(e->Etherops.promiscuous != nil)
+		return e->Etherops.promiscuous(e, set);
+	return 0;
+}
+
+static void
+fsclunk(Usbfs *fs, Fid *fid)
+{
+	int qt;
+	int64_t qid;
+	Buf *bp;
+	Conn *c;
+	Ether *e;
+
+	e = fs->aux;
+	qid = fid->qid.path & ~fs->qid;
+	qt = qtype(qid);
+	switch(qt){
+	case Qndata:
+	case Qnctl:
+	case Qnifstats:
+	case Qnstats:
+	case Qntype:
+		if(fid->omode != ONONE){
+			c = getconn(e, qnum(qid), 0);
+			if(c == nil)
+				sysfatal("usb: ether: fsopen bug");
+			if(decref(&c->Ref) == 0){
+				while((bp = nbrecvp(c->rc)) != nil)
+					freebuf(e, bp);
+				qlock(&e->QLock);
+				if(c->prom != 0)
+					if(decref(&e->prom) == 0)
+						prom(e, 0);
+				c->prom = c->type = 0;
+				qunlock(&e->QLock);
+			}
+		}
+		break;
+	}
+	etherdump(e);
+}
+
+int
+parseaddr(uint8_t *m, char *s)
+{
+	int i, n;
+	uint8_t v;
+
+	if(strlen(s) < 12)
+		return -1;
+	if(strlen(s) > 12 && strlen(s) < 17)
+		return -1;
+	for(i = n = 0; i < strlen(s); i++){
+		if(s[i] == ':')
+			continue;
+		if(s[i] >= 'A' && s[i] <= 'F')
+			v = 10 + s[i] - 'A';
+		else if(s[i] >= 'a' && s[i] <= 'f')
+			v = 10 + s[i] - 'a';
+		else if(s[i] >= '0' && s[i] <= '9')
+			v = s[i] - '0';
+		else
+			return -1;
+		if(n&1)
+			m[n/2] |= v;
+		else
+			m[n/2] = v<<4;
+		n++;
+	}
+	return 0;
+}
+
+static int32_t
+fsread(Usbfs *fs, Fid *fid, void *data, int32_t count, int64_t offset)
+{
+	int cn, qt;
+	char *s, *se;
+	char buf[2048];		/* keep this large for ifstats */
+	Buf *bp;
+	Conn *c;
+	Ether *e;
+	Qid q;
+
+	q = fid->qid;
+	q.path &= ~fs->qid;
+	e = fs->aux;
+	s = buf;
+	se = buf+sizeof(buf);
+	qt = qtype(q.path);
+	cn = qnum(q.path);
+	switch(qt){
+	case Qroot:
+		count = usbdirread(fs, q, data, count, offset, rootdirgen, nil);
+		break;
+	case Qaddr:
+		s = seprintaddr(s, se, e->addr);
+		count = usbreadbuf(data, count, offset, buf, s - buf);
+		break;
+	case Qnifstats:
+		/* BUG */
+	case Qifstats:
+		s = seprintifstats(s, se, e);
+		if(e->Etherops.seprintstats != nil)
+			s = e->Etherops.seprintstats(s, se, e);
+		count = usbreadbuf(data, count, offset, buf, s - buf);
+		break;
+	case Qnstats:
+		/* BUG */
+	case Qstats:
+		s = seprintstats(s, se, e);
+		count = usbreadbuf(data, count, offset, buf, s - buf);
+		break;
+
+	case Qndir:
+		count = usbdirread(fs, q, data, count, offset, conndirgen, nil);
+		break;
+	case Qndata:
+		c = getconn(e, cn, 0);
+		if(c == nil){
+			werrstr(Eio);
+			return -1;
+		}
+		bp = recvp(c->rc);
+		if(bp == nil)
+			return -1;
+		if(etherdebug > 1)
+			dumpframe("etherin", bp->rp, bp->ndata);
+		count = usbreadbuf(data, count, 0LL, bp->rp, bp->ndata);
+		freebuf(e, bp);
+		break;
+	case Qnctl:
+		s = seprint(s, se, "%11d ", cn);
+		count = usbreadbuf(data, count, offset, buf, s - buf);
+		break;
+	case Qntype:
+		c = getconn(e, cn, 0);
+		if(c == nil)
+			s = seprint(s, se, "%11d ", 0);
+		else
+			s = seprint(s, se, "%11d ", c->type);
+		count = usbreadbuf(data, count, offset, buf, s - buf);
+		break;
+	default:
+		sysfatal("usb: ether: fsread bug");
+	}
+	return count;
+}
+
+static int
+typeinuse(Ether *e, int t)
+{
+	int i;
+
+	for(i = 0; i < e->nconns; i++)
+		if(e->conns[i]->Ref.ref > 0 && e->conns[i]->type == t)
+			return 1;
+	return 0;
+}
+
+static int
+isloopback(Ether *e, Buf *_1)
+{
+	return e->prom.ref > 0; /* BUG: also loopbacks and broadcasts */
+}
+
+static int
+etherctl(Ether *e, Conn *c, char *buf)
+{
+	uint8_t addr[Eaddrlen];
+	int t;
+
+	deprint(2, "%s: etherctl: %s\n", argv0, buf);
+	if(strncmp(buf, "connect ", 8) == 0){
+		t = atoi(buf+8);
+		qlock(&e->QLock);
+		if(typeinuse(e, t)){
+			werrstr("type already in use");
+			qunlock(&e->QLock);
+			return -1;
+		}
+		c->type = atoi(buf+8);
+		qunlock(&e->QLock);
+		return 0;
+	}
+	if(strncmp(buf, "nonblocking", 11) == 0){
+		if(buf[11] == '\n' || buf[11] == 0)
+			e->nblock = 1;
+		else
+			e->nblock = atoi(buf + 12);
+		deprint(2, "%s: nblock %d\n", argv0, e->nblock);
+		return 0;
+	}
+	if(strncmp(buf, "promiscuous", 11) == 0){
+		if(c->prom == 0)
+			incref(&e->prom);
+		c->prom = 1;
+		return prom(e, 1);
+	}
+	if(strncmp(buf, "headersonly", 11) == 0){
+		c->headersonly = 1;
+		return 0;
+	}
+	if(strncmp(buf, "addmulti ", 9) == 0 || strncmp(buf, "remmulti ", 9) == 0){
+		if(parseaddr(addr, buf+9) < 0){
+			werrstr("bad address");
+			return -1;
+		}
+		if(e->Etherops.multicast == nil)
+			return 0;
+		if(strncmp(buf, "add", 3) == 0){
+			e->nmcasts++;
+			return e->Etherops.multicast(e, addr, 1);
+		}else{
+			e->nmcasts--;
+			return e->Etherops.multicast(e, addr, 0);
+		}
+	}
+
+	if(e->Etherops.ctl != nil)
+		return e->Etherops.ctl(e, buf);
+	werrstr(Ebadctl);
+	return -1;
+}
+
+static int32_t
+etherbread(Ether *e, Buf *bp)
+{
+	deprint(2, "%s: etherbread\n", argv0);
+	bp->rp = bp->data + Hdrsize;
+	bp->ndata = -1;
+	bp->ndata = read(e->epin->dfd, bp->rp, sizeof(bp->data)-Hdrsize);
+	if(bp->ndata < 0){
+		deprint(2, "%s: etherbread: %r\n", argv0);	/* keep { and }  */
+	}else
+		deprint(2, "%s: etherbread: got %d bytes\n", argv0, bp->ndata);
+	return bp->ndata;
+}
+
+static int32_t
+etherbwrite(Ether *e, Buf *bp)
+{
+	int32_t n;
+
+	deprint(2, "%s: etherbwrite %d bytes\n", argv0, bp->ndata);
+	n = write(e->epout->dfd, bp->rp, bp->ndata);
+	if(n < 0){
+		deprint(2, "%s: etherbwrite: %r\n", argv0);	/* keep { and }  */
+	}else
+		deprint(2, "%s: etherbwrite wrote %ld bytes\n", argv0, n);
+	if(n <= 0)
+		return n;
+	if((bp->ndata % e->epout->maxpkt) == 0){
+		deprint(2, "%s: short pkt write\n", argv0);
+		write(e->epout->dfd, "", 1);
+	}
+	return n;
+}
+
+static int32_t
+fswrite(Usbfs *fs, Fid *fid, void *data, int32_t count, int64_t _1)
+{
+	int cn, qt;
+	char buf[128];
+	Buf *bp;
+	Conn *c;
+	Ether *e;
+	Qid q;
+
+	q = fid->qid;
+	q.path &= ~fs->qid;
+	e = fs->aux;
+	qt = qtype(q.path);
+	cn = qnum(q.path);
+	switch(qt){
+	case Qndata:
+		c = getconn(e, cn, 0);
+		if(c == nil){
+			werrstr(Eio);
+			return -1;
+		}
+		bp = allocbuf(e);
+		if(count > sizeof(bp->data)-Hdrsize)
+			count = sizeof(bp->data)-Hdrsize;
+		memmove(bp->rp, data, count);
+		bp->ndata = count;
+		if(etherdebug > 1)
+			dumpframe("etherout", bp->rp, bp->ndata);
+		if(e->nblock == 0)
+			sendp(e->wc, bp);
+		else if(nbsendp(e->wc, bp) == 0){
+			deprint(2, "%s: (out) packet lost\n", argv0);
+			e->noerrs++;
+			freebuf(e, bp);
+		}
+		break;
+	case Qnctl:
+		c = getconn(e, cn, 0);
+		if(c == nil){
+			werrstr(Eio);
+			return -1;
+		}
+		if(count > sizeof(buf) - 1)
+			count = sizeof(buf) - 1;
+		memmove(buf, data, count);
+		buf[count] = 0;
+		if(etherctl(e, c, buf) < 0)
+			return -1;
+		break;
+	default:
+		sysfatal("usb: ether: fsread bug");
+	}
+	return count;
+}
+
+static int
+openeps(Ether *e, int epin, int epout)
+{
+	e->epin = openep(e->dev, epin);
+	if(e->epin == nil){
+		fprint(2, "ether: in: openep %d: %r\n", epin);
+		return -1;
+	}
+	if(epout == epin){
+		incref(&e->epin->Ref);
+		e->epout = e->epin;
+	}else
+		e->epout = openep(e->dev, epout);
+	if(e->epout == nil){
+		fprint(2, "ether: out: openep %d: %r\n", epout);
+		closedev(e->epin);
+		return -1;
+	}
+	if(e->epin == e->epout)
+		opendevdata(e->epin, ORDWR);
+	else{
+		opendevdata(e->epin, OREAD);
+		opendevdata(e->epout, OWRITE);
+	}
+	if(e->epin->dfd < 0 || e->epout->dfd < 0){
+		fprint(2, "ether: open i/o ep data: %r\n");
+		closedev(e->epin);
+		closedev(e->epout);
+		return -1;
+	}
+	dprint(2, "ether: ep in %s maxpkt %d; ep out %s maxpkt %d\n",
+		e->epin->dir, e->epin->maxpkt, e->epout->dir, e->epout->maxpkt);
+
+	/* time outs are not activated for I/O endpoints */
+
+	if(usbdebug > 2 || etherdebug > 2){
+		devctl(e->epin, "debug 1");
+		devctl(e->epout, "debug 1");
+		devctl(e->dev, "debug 1");
+	}
+
+	return 0;
+}
+
+static int
+usage(void)
+{
+	werrstr("usage: usb/ether [-a addr] [-d] [-N nb]");
+	return -1;
+}
+
+static Usbfs etherfs = {
+	.walk = fswalk,
+	.open =	 fsopen,
+	.read =	 fsread,
+	.write = fswrite,
+	.stat =	 fsstat,
+	.clunk = fsclunk,
+};
+
+static void
+shutdownchan(Channel *c)
+{
+	Buf *bp;
+
+	while((bp=nbrecvp(c)) != nil)
+		free(bp);
+	chanfree(c);
+}
+
+static void
+etherfree(Ether *e)
+{
+	int i;
+	Buf *bp;
+
+	if(e->Etherops.free != nil)
+		e->Etherops.free(e);
+	closedev(e->epin);
+	closedev(e->epout);
+	if(e->rc == nil){	/* not really started */
+		free(e);
+		return;
+	}
+	for(i = 0; i < e->nconns; i++)
+		if(e->conns[i] != nil){
+			while((bp = nbrecvp(e->conns[i]->rc)) != nil)
+				free(bp);
+			chanfree(e->conns[i]->rc);
+			free(e->conns[i]);
+		}
+	shutdownchan(e->bc);
+	shutdownchan(e->rc);
+	shutdownchan(e->wc);
+	e->epin = e->epout = nil;
+	devctl(e->dev, "detach");
+	free(e);
+}
+
+static void
+etherdevfree(void *a)
+{
+	Ether *e = a;
+
+	if(e != nil)
+		etherfree(e);
+}
+
+/* must return 1 if c wants bp; 0 if not */
+static int
+cwantsbp(Conn *c, Buf *bp)
+{
+	if(c->Ref.ref != 0 && (c->prom != 0 || c->type < 0 || c->type == bp->type))
+		return 1;
+	return 0;
+}
+
+static void
+etherwriteproc(void *a)
+{
+	Ether *e = a;
+	Buf *bp;
+	Channel *wc;
+
+	threadsetname("etherwrite");
+	wc = e->wc;
+	while(e->exiting == 0){
+		bp = recvp(wc);
+		if(bp == nil || e->exiting != 0){
+			free(bp);
+			break;
+		}
+		e->nout++;
+		if(e->Etherops.bwrite(e, bp) < 0)
+			e->noerrs++;
+		if(isloopback(e, bp) && e->exiting == 0)
+			sendp(e->rc, bp); /* send to input queue */
+		else
+			freebuf(e, bp);
+	}
+	deprint(2, "%s: writeproc exiting\n", argv0);
+	closedev(e->dev);
+}
+
+static void
+setbuftype(Buf *bp)
+{
+	uint8_t *p;
+
+	bp->type = 0;
+	if(bp->ndata >= Ehdrsize){
+		p = bp->rp + Eaddrlen*2;
+		bp->type = p[0]<<8 | p[1];
+	}
+}
+
+static void
+etherexiting(Ether *e)
+{
+	devctl(e->dev, "detach");
+	e->exiting = 1;
+	close(e->epin->dfd);
+	e->epin->dfd = -1;
+	close(e->epout->dfd);
+	e->epout->dfd = -1;
+	nbsend(e->wc, nil);
+}
+
+static void
+etherreadproc(void *a)
+{
+	int i, n, nwants;
+	Buf *bp, *dbp;
+	Ether *e = a;
+
+	threadsetname("etherread");
+	while(e->exiting == 0){
+		bp = nbrecvp(e->rc);
+		if(bp == nil){
+			bp = allocbuf(e);	/* leak() may think we leak */
+			if(e->Etherops.bread(e, bp) < 0){
+				freebuf(e, bp);
+				break;
+			}
+			if(bp->ndata == 0){
+				/* may be a short packet; continue */
+				if(0)dprint(2, "%s: read: short\n", argv0);
+				freebuf(e, bp);
+				continue;
+			}else
+				setbuftype(bp);
+		}
+		e->nin++;
+		nwants = 0;
+		for(i = 0; i < e->nconns; i++)
+			nwants += cwantsbp(e->conns[i], bp);
+		for(i = 0; nwants > 0 && i < e->nconns; i++)
+			if(cwantsbp(e->conns[i], bp)){
+				n = bp->ndata;
+				if(e->conns[i]->type == -2 && n > 64)
+					n = 64;
+				if(nwants-- == 1){
+					bp->ndata = n;
+					dbp = bp;
+					bp = nil;
+				}else{
+					dbp = allocbuf(e);
+					memmove(dbp->rp, bp->rp, n);
+					dbp->ndata = n;
+					dbp->type = bp->type;
+				}
+				if(nbsendp(e->conns[i]->rc, dbp) == 0){
+					deprint(2, "%s: (in) packet lost\n", argv0);
+					e->nierrs++;
+					freebuf(e, dbp);
+				}
+			}
+		freebuf(e, bp);
+	}
+	deprint(2, "%s: writeproc exiting\n", argv0);
+	etherexiting(e);
+	closedev(e->dev);
+	usbfsdel(&e->fs);
+}
+
+static void
+setalt(Dev *d, int ifcid, int altid)
+{
+	if(usbcmd(d, Rh2d|Rstd|Riface, Rsetiface, altid, ifcid, nil, 0) < 0)
+		dprint(2, "%s: setalt ifc %d alt %d: %r\n", argv0, ifcid, altid);
+}
+
+static int
+ifaceinit(Ether *e, Iface *ifc, int *ei, int *eo)
+{
+	Ep *ep;
+	int epin, epout, i;
+
+	if(ifc == nil)
+		return -1;
+
+	epin = epout = -1;
+	for(i = 0; (epin < 0 || epout < 0) && i < nelem(ifc->ep); i++)
+		if((ep = ifc->ep[i]) != nil && ep->type == Ebulk){
+			if(ep->dir == Eboth || ep->dir == Ein)
+				if(epin == -1)
+					epin =  ep->id;
+			if(ep->dir == Eboth || ep->dir == Eout)
+				if(epout == -1)
+					epout = ep->id;
+		}
+	if(epin == -1 || epout == -1)
+		return -1;
+
+	dprint(2, "ether: ep ids: in %d out %d\n", epin, epout);
+	for(i = 0; i < nelem(ifc->altc); i++)
+		if(ifc->altc[i] != nil)
+			setalt(e->dev, ifc->id, i);
+
+	*ei = epin;
+	*eo = epout;
+	return 0;
+}
+
+static int
+etherinit(Ether *e, int *ei, int *eo)
+{
+	int ctlid, datid, i, j;
+	Conf *c;
+	Desc *desc;
+	Iface *ctlif, *datif;
+	Usbdev *ud;
+
+	*ei = *eo = -1;
+	ud = e->dev->usb;
+
+	/* look for union descriptor with ethernet ctrl interface */
+	for(i = 0; i < nelem(ud->ddesc); i++){
+		if((desc = ud->ddesc[i]) == nil)
+			continue;
+		if(desc->data.bLength < 5 || desc->data.bbytes[0] != Cdcunion)
+			continue;
+
+		ctlid = desc->data.bbytes[1];
+		datid = desc->data.bbytes[2];
+
+		if((c = desc->conf) == nil)
+			continue;
+
+		ctlif = datif = nil;
+		for(j = 0; j < nelem(c->iface); j++){
+			if(c->iface[j] == nil)
+				continue;
+			if(c->iface[j]->id == ctlid)
+				ctlif = c->iface[j];
+			if(c->iface[j]->id == datid)
+				datif = c->iface[j];
+
+			if(datif != nil && ctlif != nil){
+				if(Subclass(ctlif->csp) == Scether &&
+				    ifaceinit(e, datif, ei, eo) != -1)
+					return 0;
+				break;
+			}
+		}
+	}
+	/* try any other one that seems to be ok */
+	for(i = 0; i < nelem(ud->conf); i++)
+		if((c = ud->conf[i]) != nil)
+			for(j = 0; j < nelem(c->iface); j++)
+				if(ifaceinit(e, c->iface[j], ei, eo) != -1)
+					return 0;
+	dprint(2, "%s: no valid endpoints", argv0);
+	return -1;
+}
+
+static int
+kernelproxy(Ether *e)
+{
+	int ctlfd, n;
+	char eaddr[13];
+
+	ctlfd = open("#l0/ether0/clone", ORDWR);
+	if(ctlfd < 0){
+		deprint(2, "%s: etherusb bind #l0: %r\n", argv0);
+		return -1;
+	}
+	close(e->epin->dfd);
+	close(e->epout->dfd);
+	seprintaddr(eaddr, eaddr+sizeof(eaddr), e->addr);
+	n = fprint(ctlfd, "bind %s #u/usb/ep%d.%d/data #u/usb/ep%d.%d/data %s %d %d",
+		e->Etherops.name, e->dev->id, e->epin->id, e->dev->id, e->epout->id,
+		eaddr, e->Etherops.bufsize, e->epout->maxpkt);
+	if(n < 0){
+		deprint(2, "%s: etherusb bind #l0: %r\n", argv0);
+		opendevdata(e->epin, OREAD);
+		opendevdata(e->epout, OWRITE);
+		close(ctlfd);
+		return -1;
+	}
+	close(ctlfd);
+	return 0;
+}
+
+int
+ethermain(Dev *dev, int argc, char **argv)
+{
+	int epin, epout, i, devid;
+	Ether *e;
+	uint8_t ea[Eaddrlen];
+
+	devid = dev->id;
+	memset(ea, 0, Eaddrlen);
+	ARGBEGIN{
+	case 'a':
+		if(parseaddr(ea, EARGF(usage())) < 0)
+			return usage();
+		break;
+	case 'd':
+		if(etherdebug == 0)
+			fprint(2, "ether debug on\n");
+		etherdebug++;
+		break;
+	case 'N':
+		devid = atoi(EARGF(usage()));
+		break;
+	default:
+		return usage();
+	}ARGEND
+	if(argc != 0) {
+		return usage();
+	}
+	e = dev->aux = emallocz(sizeof(Ether), 1);
+	e->dev = dev;
+	dev->free = etherdevfree;
+	memmove(e->addr, ea, Eaddrlen);
+	e->Etherops.name = "cdc";
+
+	for(i = 0; i < nelem(ethers); i++)
+		if(ethers[i](e) == 0)
+			break;
+	if(i == nelem(ethers))
+		return -1;
+	if(e->Etherops.init == nil)
+		e->Etherops.init = etherinit;
+	if(e->Etherops.init(e, &epin, &epout) < 0)
+		return -1;
+	if(e->Etherops.bwrite == nil)
+		e->Etherops.bwrite = etherbwrite;
+	if(e->Etherops.bread == nil)
+		e->Etherops.bread = etherbread;
+	if(e->Etherops.bufsize == 0)
+		e->Etherops.bufsize = Maxpkt;
+
+	if(openeps(e, epin, epout) < 0)
+		return -1;
+	if(kernelproxy(e) == 0)
+		return 0;
+	e->fs = etherfs;
+	snprint(e->fs.name, sizeof(e->fs.name), "etherU%d", devid);
+	e->fs.dev = dev;
+	e->fs.aux = e;
+	e->bc = chancreate(sizeof(Buf*), Nbufs);
+	e->rc = chancreate(sizeof(Buf*), Nconns/2);
+	e->wc = chancreate(sizeof(Buf*), Nconns*2);
+	incref(&e->dev->Ref);
+	proccreate(etherwriteproc, e, 16*1024);
+	incref(&e->dev->Ref);
+	proccreate(etherreadproc, e, 16*1024);
+	deprint(2, "%s: dev ref %ld\n", argv0, dev->Ref.ref);
+	incref(&e->dev->Ref);
+	usbfsadd(&e->fs);
+	return 0;
+}

--- a/sys/src/libusb/ether/smsc.c
+++ b/sys/src/libusb/ether/smsc.c
@@ -1,0 +1,408 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+/*
+ * SMSC LAN95XX
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <fcall.h>
+#include <thread.h>
+#include <usb/usb.h>
+#include <usb/usbfs.h>
+#include <usb/ether.h>
+
+enum {
+	Doburst		= 1,
+	Resettime	= 1000,
+	E2pbusytime	= 1000,
+	Afcdefault	= 0xF830A1,
+//	Hsburst		= 37,	/* from original linux driver */
+	Hsburst		= 8,
+	Fsburst		= 129,
+	Defbulkdly	= 0x2000,
+
+	Ethp8021q	= 0x8100,
+	MACoffset 	= 1,
+	PHYinternal	= 1,
+	Rxerror		= 0x8000,
+	Txfirst		= 0x2000,
+	Txlast		= 0x1000,
+
+	/* USB vendor requests */
+	Writereg	= 0xA0,
+	Readreg		= 0xA1,
+
+	/* device registers */
+	Intsts		= 0x08,
+	Txcfg		= 0x10,
+		Txon	= 1<<2,
+	Hwcfg		= 0x14,
+		Bir	= 1<<12,
+		Rxdoff	= 3<<9,
+		Mef	= 1<<5,
+		Lrst	= 1<<3,
+		Bce	= 1<<1,
+	Pmctrl		= 0x20,
+		Phyrst	= 1<<4,
+	Ledgpio		= 0x24,
+		Ledspd	= 1<<24,
+		Ledlnk	= 1<<20,
+		Ledfdx	= 1<<16,
+	Afccfg		= 0x2C,
+	E2pcmd		= 0x30,
+		Busy	= 1<<31,
+		Timeout	= 1<<10,
+		Read	= 0,
+	E2pdata		= 0x34,
+	Burstcap	= 0x38,
+	Intepctl	= 0x68,
+		Phyint	= 1<<15,
+	Bulkdelay	= 0x6C,
+	Maccr		= 0x100,
+		Mcpas	= 1<<19,
+		Prms	= 1<<18,
+		Hpfilt	= 1<<13,
+		Txen	= 1<<3,
+		Rxen	= 1<<2,
+	Addrh		= 0x104,
+	Addrl		= 0x108,
+	Hashh		= 0x10C,
+	Hashl		= 0x110,
+	MIIaddr		= 0x114,
+		MIIwrite= 1<<1,
+		MIIread	= 0<<1,
+		MIIbusy	= 1<<0,
+	MIIdata		= 0x118,
+	Flow		= 0x11C,
+	Vlan1		= 0x120,
+	Coecr		= 0x130,
+		Txcoe	= 1<<16,
+		Rxcoemd	= 1<<1,
+		Rxcoe	= 1<<0,
+
+	/* MII registers */
+	Bmcr		= 0,
+		Bmcrreset= 1<<15,
+		Speed100= 1<<13,
+		Anenable= 1<<12,
+		Anrestart= 1<<9,
+		Fulldpx	= 1<<8,
+	Bmsr		= 1,
+	Advertise	= 4,
+		Adcsma	= 0x0001,
+		Ad10h	= 0x0020,
+		Ad10f	= 0x0040,
+		Ad100h	= 0x0080,
+		Ad100f	= 0x0100,
+		Adpause	= 0x0400,
+		Adpauseasym= 0x0800,
+		Adall	= Ad10h|Ad10f|Ad100h|Ad100f,
+	Phyintsrc	= 29,
+	Phyintmask	= 30,
+		Anegcomp= 1<<6,
+		Linkdown= 1<<4,
+};
+
+static int
+wr(Dev *d, int reg, int val)
+{
+	int ret;
+
+	ret = usbcmd(d, Rh2d|Rvendor|Rdev, Writereg, 0, reg,
+		(uint8_t*)&val, sizeof(val));
+	if(ret < 0)
+		deprint(2, "%s: wr(%x, %x): %r", argv0, reg, val);
+	return ret;
+}
+
+static int
+rr(Dev *d, int reg)
+{
+	int ret, rval;
+
+	ret = usbcmd(d, Rd2h|Rvendor|Rdev, Readreg, 0, reg,
+		(uint8_t*)&rval, sizeof(rval));
+	if(ret < 0){
+		fprint(2, "%s: rr(%x): %r", argv0, reg);
+		return 0;
+	}
+	return rval;
+}
+
+static int
+miird(Dev *d, int idx)
+{
+	while(rr(d, MIIaddr) & MIIbusy)
+		;
+	wr(d, MIIaddr, PHYinternal<<11 | idx<<6 | MIIread);
+	while(rr(d, MIIaddr) & MIIbusy)
+		;
+	return rr(d, MIIdata);
+}
+
+static void
+miiwr(Dev *d, int idx, int val)
+{
+	while(rr(d, MIIaddr) & MIIbusy)
+		;
+	wr(d, MIIdata, val);
+	wr(d, MIIaddr, PHYinternal<<11 | idx<<6 | MIIwrite);
+	while(rr(d, MIIaddr) & MIIbusy)
+		;
+}
+
+static int
+eepromr(Dev *d, int off, uint8_t *buf, int len)
+{
+	int i, v;
+
+	for(i = 0; i < E2pbusytime; i++)
+		if((rr(d, E2pcmd) & Busy) == 0)
+			break;
+	if(i == E2pbusytime)
+		return -1;
+	for(i = 0; i < len; i++){
+		wr(d, E2pcmd, Busy|Read|(i+off));
+		while((v = rr(d, E2pcmd) & (Busy|Timeout)) == Busy)
+			;
+		if(v & Timeout)
+			return -1;
+		buf[i] = rr(d, E2pdata);
+	}
+	return 0;
+}
+
+static void
+phyinit(Dev *d)
+{
+	int i;
+
+	miiwr(d, Bmcr, Bmcrreset|Anenable);
+	for(i = 0; i < Resettime/10; i++){
+		if((miird(d, Bmcr) & Bmcrreset) == 0)
+			break;
+		sleep(10);
+	}
+	miiwr(d, Advertise, Adcsma|Adall|Adpause|Adpauseasym);
+//	miiwr(d, Advertise, Adcsma|Ad10f|Ad10h|Adpause|Adpauseasym);
+	miird(d, Phyintsrc);
+	miiwr(d, Phyintmask, Anegcomp|Linkdown);
+	miiwr(d, Bmcr, miird(d, Bmcr)|Anenable|Anrestart);
+}
+
+
+static int
+doreset(Dev *d, int reg, int bit)
+{
+	int i;
+
+	if(wr(d, reg, bit) < 0)
+		return -1;
+	for(i = 0; i < Resettime/10; i++){
+		 if((rr(d, reg) & bit) == 0)
+			return 1;
+		sleep(10);
+	}
+	return 0;
+}
+
+static int
+getmac(Dev *d, uint8_t buf[])
+{
+	int i;
+	uint8_t ea[Eaddrlen];
+
+	if(eepromr(d, MACoffset, ea, Eaddrlen) < 0)
+		return -1;
+	for(i = 0; i < Eaddrlen; i++)
+		if(ea[i] != 0 && ea[i] != 0xFF){
+			memmove(buf, ea, Eaddrlen);
+			break;
+		}
+	return Eaddrlen;
+}
+
+static int
+smscinit(Ether *ether)
+{
+	Dev *d;
+
+	if(ether->cid != S95xx)
+		return -1;
+	d = ether->dev;
+	deprint(2, "%s: setting up SMSC95XX\n", argv0);
+	if(!doreset(d, Hwcfg, Lrst) || !doreset(d, Pmctrl, Phyrst))
+		return -1;
+	if(getmac(d, ether->addr) < 0)
+		return -1;
+	wr(d, Addrl, GET4(ether->addr));
+	wr(d, Addrh, GET2(ether->addr+4));
+	if(Doburst){
+		wr(d, Hwcfg, (rr(d,Hwcfg)&~Rxdoff)|Bir|Mef|Bce);
+		wr(d, Burstcap, Hsburst);
+	}else{
+		wr(d, Hwcfg, (rr(d,Hwcfg)&~(Rxdoff|Mef|Bce))|Bir);
+		wr(d, Burstcap, 0);
+	}
+	wr(d, Bulkdelay, Defbulkdly);
+	wr(d, Intsts, ~0);
+	wr(d, Ledgpio, Ledspd|Ledlnk|Ledfdx);
+	wr(d, Flow, 0);
+	wr(d, Afccfg, Afcdefault);
+	wr(d, Vlan1, Ethp8021q);
+	wr(d, Coecr, rr(d,Coecr)&~(Txcoe|Rxcoe)); /* TODO could offload checksums? */
+
+	wr(d, Hashh, 0);
+	wr(d, Hashl, 0);
+	wr(d, Maccr, rr(d,Maccr)&~(Prms|Mcpas|Hpfilt));
+
+	phyinit(d);
+
+	wr(d, Intepctl, rr(d, Intepctl)|Phyint);
+	wr(d, Maccr, rr(d, Maccr)|Txen|Rxen);
+	wr(d, Txcfg, Txon);
+
+	return 0;
+}
+
+static int32_t
+smscbread(Ether *e, Buf *bp)
+{
+	uint hd;
+	int n, m;
+	Buf *rbp;
+
+	rbp = e->Etherops.aux;
+	if(rbp->ndata < 4){
+		rbp->rp = rbp->data;
+		rbp->ndata = read(e->epin->dfd, rbp->rp, Doburst? Hsburst*512:
+			Maxpkt);
+		if(rbp->ndata < 0)
+			return -1;
+	}
+	if(rbp->ndata < 4){
+		werrstr("short frame");
+		fprint(2, "smsc short frame %d bytes\n", rbp->ndata);
+		return 0;
+	}
+	hd = GET4(rbp->rp);
+	n = hd >> 16;
+	m = (n + 4 + 3) & ~3;
+	if(n < 6 || m > rbp->ndata){
+		werrstr("frame length");
+		fprint(2, "smsc length error packet %d buf %d\n", n, rbp->ndata);
+		rbp->ndata = 0;
+		return 0;
+	}
+	if(hd & Rxerror){
+		fprint(2, "smsc rx error %8.8x\n", hd);
+		n = 0;
+	}else{
+		bp->rp = bp->data + Hdrsize;
+		memmove(bp->rp, rbp->rp+4, n);
+	}
+	bp->ndata = n;
+	rbp->rp += m;
+	rbp->ndata -= m;
+	return n;
+}
+
+static int32_t
+smscbwrite(Ether *e, Buf *bp)
+{
+	int n;
+
+	n = bp->ndata & 0x7FF;
+	bp->rp -= 8;
+	bp->ndata += 8;
+	PUT4(bp->rp, n | Txfirst | Txlast);
+	PUT4(bp->rp+4, n);
+	n = write(e->epout->dfd, bp->rp, bp->ndata);
+	return n;
+}
+
+static int
+smscpromiscuous(Ether *e, int on)
+{
+
+#ifdef TODO		/* copied from asix */
+	int rxctl;
+
+	deprint(2, "%s: smscpromiscuous %d\n", argv0, on);
+	rxctl = getrxctl(e->dev);
+	if(on != 0)
+		rxctl |= Rxctlprom;
+	else
+		rxctl &= ~Rxctlprom;
+	return wr(e->dev, Cwrxctl, rxctl);
+#endif
+	return -1;
+}
+
+static int
+smscmulticast(Ether *e, uint8_t *addr, int on)
+{
+#ifdef TODO		/* needed for ipv6; copied from asix */
+	int rxctl;
+
+	/* BUG: should write multicast filter */
+	rxctl = getrxctl(e->dev);
+	if(e->nmcasts != 0)
+		rxctl |= Rxctlamall;
+	else
+		rxctl &= ~Rxctlamall;
+	deprint(2, "%s: smscmulticast %d\n", argv0, e->nmcasts);
+	return wr(e->dev, Cwrxctl, rxctl);
+#endif
+	return -1;
+}
+
+static void
+smscfree(Ether *ether)
+{
+	free(ether->Etherops.aux);
+	ether->Etherops.aux = nil;
+}
+
+int
+smscreset(Ether *ether)
+{
+	Cinfo *ip;
+	Dev *dev;
+
+	dev = ether->dev;
+	for(ip = cinfo; ip->vid != 0; ip++)
+		if(ip->vid == dev->usb->vid && ip->did == dev->usb->did){
+			ether->cid = ip->cid;
+			if(smscinit(ether) < 0){
+				deprint(2, "%s: smsc init failed: %r\n", argv0);
+				return -1;
+			}
+			deprint(2, "%s: smsc reset done\n", argv0);
+			ether->Etherops.name = "smsc";
+			if(Doburst){
+				ether->Etherops.bufsize = Hsburst*512;
+				ether->Etherops.aux = emallocz(sizeof(Buf) +
+					ether->Etherops.bufsize - Maxpkt, 1);
+			}else{
+				ether->Etherops.bufsize = Maxpkt;
+				ether->Etherops.aux = emallocz(sizeof(Buf), 1);
+			}
+			ether->Etherops.free = smscfree;
+			ether->Etherops.bread = smscbread;
+			ether->Etherops.bwrite = smscbwrite;
+			ether->Etherops.promiscuous = smscpromiscuous;
+			ether->Etherops.multicast = smscmulticast;
+			ether->mbps = 100;	/* BUG */
+			return 0;
+		}
+	return -1;
+}

--- a/sys/src/libusb/kb/hid.c
+++ b/sys/src/libusb/kb/hid.c
@@ -1,0 +1,243 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <usb/usb.h>
+#include <usb/hid.h>
+
+/*
+ * Rough hid descriptor parsing and interpretation for mice
+ *
+ * Chain and its operations build the infrastructure needed
+ * to manipulate non-aligned fields, which do appear (sigh!).
+ */
+
+/* Get, at most, 8 bits*/
+static uint8_t
+get8bits(Chain *ch, int nbits)
+{
+	int b, nbyb, nbib, nlb;
+	uint8_t low, high;
+
+	b = ch->b + nbits - 1;
+	nbib = ch->b % 8;
+	nbyb = ch->b / 8;
+	nlb = 8 - nbib;
+	if(nlb > nbits)
+		nlb = nbits;
+
+	low = MSK(nlb) & (ch->buf[nbyb] >> nbib);
+	if(IsCut(ch->b, b))
+		high = (ch->buf[nbyb + 1] & MSK(nbib)) << nlb;
+	else
+		high = 0;
+	ch->b += nbits;
+	return MSK(nbits)&(high | low);
+}
+
+static void
+getbits(void *p, Chain *ch, int nbits)
+{
+	int nby, nbi, i;
+	uint8_t *vp;
+
+	assert(ch->e >= ch->b);
+	nby = nbits / 8;
+	nbi = nbits % 8;
+
+	vp = p;
+	for(i = 0; i < nby; i++)
+		*vp++ = get8bits(ch, 8);
+
+	if(nbi != 0)
+		*vp = get8bits(ch, nbi);
+}
+
+int
+parsereportdesc(HidRepTempl *temp, uint8_t *repdesc, int repsz)
+{
+	int i, j, l, n, isptr, hasxy, hasbut, nk, ncoll, dsize;
+	uint8_t ks[MaxVals+1];
+	HidInterface *ifs;
+
+	ifs = temp->ifcs;
+	isptr = 0;
+	hasxy = hasbut = 0;
+	ncoll = 0;
+	n = 0;
+	nk = 0;
+	memset(ifs, 0, sizeof *ifs * MaxIfc);
+	for(i = 0; i < repsz; i += dsize+1){
+		dsize = (1 << (repdesc[i] & 03)) >> 1;
+		if(nk > MaxVals){
+			fprint(2, "bad report: too many input types\n");
+			return -1;
+		}
+		if(n == MaxIfc)
+			break;
+		if(repdesc[i] == HidEnd){
+			ncoll--;
+			if(ncoll == 0)
+				break;
+		}
+
+		switch(repdesc[i]){
+		case HidReportId:
+			switch(repdesc[i+1]){
+			case HidReportIdPtr:
+				temp->id = repdesc[i+1];
+				break;
+			default:
+				fprint(2, "report type %#x bad\n",
+					repdesc[i+1]);
+				return -1;
+			}
+			break;
+		case HidTypeUsg:
+			switch(repdesc[i+1]){
+			case HidX:
+				hasxy++;
+				ks[nk++] = KindX;
+				break;
+			case HidY:
+				hasxy++;
+				ks[nk++] = KindY;
+				break;
+			case HidZ:
+				ks[nk++] = KindPad;
+				break;
+			case HidWheel:
+				ks[nk++] = KindWheel;
+				break;
+			case HidPtr:
+				isptr++;
+				break;
+			}
+			break;
+		case HidTypeUsgPg:
+			switch(repdesc[i+1]){
+			case HidPgButts:
+				hasbut++;
+				ks[nk++] = KindButtons;
+				break;
+			}
+			break;
+		case HidTypeRepSz:
+			ifs[n].nbits = repdesc[i+1];
+			break;
+		case HidTypeCnt:
+			ifs[n].count = repdesc[i+1];
+			break;
+		case HidInput:
+			if(ifs[n].count > MaxVals){
+				fprint(2, "bad report: input count too big\n");
+				return -1;
+			}
+			for(j = 0; j <nk; j++)
+				ifs[n].kind[j] = ks[j];
+			if(nk != 0 && nk < ifs[n].count)
+				for(l = j; l <ifs[n].count; l++)
+					ifs[n].kind[l] = ks[j-1];
+			n++;
+			if(n < MaxIfc){
+				ifs[n].count = ifs[n-1].count;	/* inherit values */
+				ifs[n].nbits = ifs[n-1].nbits;
+				if(ifs[n].nbits == 0)
+					ifs[n].nbits = 1;
+			}
+			nk = 0;
+			break;
+		case HidCollection:
+			ncoll++;
+			break;
+		}
+	}
+	temp->nifcs = n;
+	for(i = 0; i < n; i++)
+		temp->sz += temp->ifcs[i].nbits * temp->ifcs[i].count;
+	temp->sz = (temp->sz + 7) / 8;
+
+	if(isptr && hasxy && hasbut)
+		return 0;
+	fprint(2, "bad report: isptr %d, hasxy %d, hasbut %d\n",
+		isptr, hasxy, hasbut);
+	return -1;
+}
+
+int
+parsereport(HidRepTempl *templ, Chain *rep)
+{
+	int i, j, k, ifssz;
+	uint32_t u;
+	uint8_t *p;
+	HidInterface *ifs;
+
+	ifssz = templ->nifcs;
+	ifs = templ->ifcs;
+	for(i = 0; i < ifssz; i++)
+		for(j = 0; j < ifs[i].count; j++){
+			if(ifs[i].nbits > 8 * sizeof ifs[i].v[0]){
+				fprint(2, "ptr: bad bits in parsereport");
+				return -1;
+			}
+			u =0;
+			getbits(&u, rep, ifs[i].nbits);
+			p = (uint8_t *)&u;
+			/* le to host */
+			ifs[i].v[j] = p[3]<<24 | p[2]<<16 | p[1]<<8 | p[0]<<0;
+			k = ifs[i].kind[j];
+			if(k == KindX || k == KindY || k == KindWheel){
+				/* propagate sign */
+				if(ifs[i].v[j] & (1 << (ifs[i].nbits - 1)))
+					ifs[i].v[j] |= ~MSK(ifs[i].nbits);
+			}
+		}
+	return 0;
+}
+
+/* TODO: fmt representation */
+void
+dumpreport(HidRepTempl *templ)
+{
+	int i, j, ifssz;
+	HidInterface *ifs;
+
+	ifssz = templ->nifcs;
+	ifs = templ->ifcs;
+	for(i = 0; i < ifssz; i++){
+		fprint(2, "\tcount %#x", ifs[i].count);
+		fprint(2, " nbits %d ", ifs[i].nbits);
+		fprint(2, "\n");
+		for(j = 0; j < ifs[i].count; j++){
+			fprint(2, "\t\tkind %#x ", ifs[i].kind[j]);
+			fprint(2, "v %#lx\n", ifs[i].v[j]);
+		}
+		fprint(2, "\n");
+	}
+	fprint(2, "\n");
+}
+
+/* could precalculate indices after parsing the descriptor */
+int
+hidifcval(HidRepTempl *templ, int kind, int n)
+{
+	int i, j, ifssz;
+	HidInterface *ifs;
+
+	ifssz = templ->nifcs;
+	ifs = templ->ifcs;
+	assert(n <= nelem(ifs[i].v));
+	for(i = 0; i < ifssz; i++)
+		for(j = 0; j < ifs[i].count; j++)
+			if(ifs[i].kind[j] == kind && n-- == 0)
+				return (int)ifs[i].v[j];
+	return 0;		/* least damage (no buttons, no movement) */
+}

--- a/sys/src/libusb/kb/kb.c
+++ b/sys/src/libusb/kb/kb.c
@@ -1,0 +1,773 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+/*
+ * USB Human Interaction Device: keyboard and mouse.
+ *
+ * If there's no usb keyboard, it tries to setup the mouse, if any.
+ * It should be started at boot time.
+ *
+ * Mouse events are converted to the format of mouse(3)'s mousein file.
+ * Keyboard keycodes are translated to scan codes and sent to kbin(3).
+ *
+ * If there is no keyboard, it tries to setup the mouse properly, else it falls
+ * back to boot protocol.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <usb/usb.h>
+#include <usb/hid.h>
+
+enum
+{
+	Awakemsg= 0xdeaddead,
+	Diemsg	= 0xbeefbeef,
+	Dwcidle	= 8,
+};
+
+typedef struct KDev KDev;
+typedef struct Kin Kin;
+
+struct KDev
+{
+	Dev*	dev;		/* usb device*/
+	Dev*	ep;		/* endpoint to get events */
+	Kin*	in;		/* used to send events to kernel */
+	int	idle;		/* min time between reports (× 4ms) */
+	Channel*repeatc;	/* only for keyboard */
+	int	accel;		/* only for mouse */
+	int	bootp;		/* has associated keyboard */
+	int	debug;
+	HidRepTempl templ;
+	int	(*ptrvals)(KDev *kd, Chain *ch, int *px, int *py, int *pb);
+};
+
+/*
+ * Kbdin and mousein files must be shared among all instances.
+ */
+struct Kin
+{
+	int	ref;
+	int	fd;
+	char*	name;
+};
+
+/*
+ * Map for the logitech bluetooth mouse with 8 buttons and wheels.
+ *	{ ptr ->mouse}
+ *	{ 0x01, 0x01 },	// left
+ *	{ 0x04, 0x02 },	// middle
+ *	{ 0x02, 0x04 },	// right
+ *	{ 0x40, 0x08 },	// up
+ *	{ 0x80, 0x10 },	// down
+ *	{ 0x10, 0x08 },	// side up
+ *	{ 0x08, 0x10 },	// side down
+ *	{ 0x20, 0x02 }, // page
+ * besides wheel and regular up/down report the 4th byte as 1/-1
+ */
+
+/*
+ * key code to scan code; for the page table used by
+ * the logitech bluetooth keyboard.
+ */
+static char sctab[256] =
+{
+[0x00] =	0x0,	0x0,	0x0,	0x0,	0x1e,	0x30,	0x2e,	0x20,
+[0x08] =	0x12,	0x21,	0x22,	0x23,	0x17,	0x24,	0x25,	0x26,
+[0x10] =	0x32,	0x31,	0x18,	0x19,	0x10,	0x13,	0x1f,	0x14,
+[0x18] =	0x16,	0x2f,	0x11,	0x2d,	0x15,	0x2c,	0x2,	0x3,
+[0x20] =	0x4,	0x5,	0x6,	0x7,	0x8,	0x9,	0xa,	0xb,
+[0x28] =	0x1c,	0x1,	0xe,	0xf,	0x39,	0xc,	0xd,	0x1a,
+[0x30] =	0x1b,	0x2b,	0x2b,	0x27,	0x28,	0x29,	0x33,	0x34,
+[0x38] =	0x35,	0x3a,	0x3b,	0x3c,	0x3d,	0x3e,	0x3f,	0x40,
+[0x40] =	0x41,	0x42,	0x43,	0x44,	0x57,	0x58,	0x63,	0x46,
+[0x48] =	0x77,	0x52,	0x47,	0x49,	0x53,	0x4f,	0x51,	0x4d,
+[0x50] =	0x4b,	0x50,	0x48,	0x45,	0x35,	0x37,	0x4a,	0x4e,
+[0x58] =	0x1c,	0x4f,	0x50,	0x51,	0x4b,	0x4c,	0x4d,	0x47,
+[0x60] =	0x48,	0x49,	0x52,	0x53,	0x56,	0x7f,	0x74,	0x75,
+[0x68] =	0x55,	0x59,	0x5a,	0x5b,	0x5c,	0x5d,	0x5e,	0x5f,
+[0x70] =	0x78,	0x79,	0x7a,	0x7b,	0x0,	0x0,	0x0,	0x0,
+[0x78] =	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x71,
+[0x80] =	0x73,	0x72,	0x0,	0x0,	0x0,	0x7c,	0x0,	0x0,
+[0x88] =	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,
+[0x90] =	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,
+[0x98] =	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,
+[0xa0] =	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,
+[0xa8] =	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,
+[0xb0] =	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,
+[0xb8] =	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,
+[0xc0] =	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,
+[0xc8] =	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,
+[0xd0] =	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,
+[0xd8] =	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,
+[0xe0] =	0x1d,	0x2a,	0x38,	0x7d,	0x61,	0x36,	0x64,	0x7e,
+[0xe8] =	0x0,	0x0,	0x0,	0x0,	0x0,	0x73,	0x72,	0x71,
+[0xf0] =	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,
+[0xf8] =	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,	0x0,
+};
+
+static QLock inlck;
+static Kin kbdin =
+{
+	.ref = 0,
+	.name = "#Ι/kbin",
+	.fd = -1,
+};
+static Kin ptrin =
+{
+	.ref = 0,
+	.name = "#m/mousein",
+	.fd = -1,
+};
+
+static int ptrbootpvals(KDev *kd, Chain *ch, int *px, int *py, int *pb);
+static int ptrrepvals(KDev *kd, Chain *ch, int *px, int *py, int *pb);
+
+static int
+setbootproto(KDev* f, int eid, uint8_t *_1, int _2)
+{
+	int nr, r, id;
+
+	f->ptrvals = ptrbootpvals;
+	r = Rh2d|Rclass|Riface;
+	dprint(2, "setting boot protocol\n");
+	id = f->dev->usb->ep[eid]->iface->id;
+	nr = usbcmd(f->dev, r, Setproto, Bootproto, id, nil, 0);
+	if(nr < 0)
+		return -1;
+	usbcmd(f->dev, r, Setidle, f->idle<<8, id, nil, 0);
+	return nr;
+}
+
+static uint8_t ignoredesc[128];
+
+static int
+setfirstconfig(KDev* f, int eid, uint8_t *desc, int descsz)
+{
+	int nr, r, id, i;
+
+	dprint(2, "setting first config\n");
+	if(desc == nil){
+		descsz = sizeof ignoredesc;
+		desc = ignoredesc;
+	}
+	id = f->dev->usb->ep[eid]->iface->id;
+	r = Rh2d | Rstd | Rdev;
+	nr = usbcmd(f->dev,  r, Rsetconf, 1, 0, nil, 0);
+	if(nr < 0)
+		return -1;
+	r = Rh2d | Rclass | Riface;
+	nr = usbcmd(f->dev, r, Setidle, f->idle<<8, id, nil, 0);
+	if(nr < 0)
+		return -1;
+	r = Rd2h | Rstd | Riface;
+	nr=usbcmd(f->dev,  r, Rgetdesc, Dreport<<8, id, desc, descsz);
+	if(nr <= 0)
+		return -1;
+	if(f->debug){
+		fprint(2, "report descriptor:");
+		for(i = 0; i < nr; i++){
+			if(i%8 == 0)
+				fprint(2, "\n\t");
+			fprint(2, "%#2.2x ", desc[i]);
+		}
+		fprint(2, "\n");
+	}
+	f->ptrvals = ptrrepvals;
+	return nr;
+}
+
+/*
+ * Try to recover from a babble error. A port reset is the only way out.
+ * BUG: we should be careful not to reset a bundle with several devices.
+ */
+static void
+recoverkb(KDev *f)
+{
+	int i;
+
+	close(f->dev->dfd);		/* it's for usbd now */
+	devctl(f->dev, "reset");
+	for(i = 0; i < 10; i++){
+		if(i == 5)
+			f->bootp++;
+		sleep(500);
+		if(opendevdata(f->dev, ORDWR) >= 0){
+			if(f->bootp)
+				/* TODO func pointer */
+				setbootproto(f, f->ep->id, nil, 0);
+			else
+				setfirstconfig(f, f->ep->id, nil, 0);
+			break;
+		}
+		/* else usbd still working... */
+	}
+}
+
+static void
+kbfatal(KDev *kd, char *sts)
+{
+	Dev *dev;
+
+	if(sts != nil)
+		fprint(2, "kb: fatal: %s\n", sts);
+	else
+		fprint(2, "kb: exiting\n");
+	if(kd->repeatc != nil)
+		nbsendul(kd->repeatc, Diemsg);
+	dev = kd->dev;
+	kd->dev = nil;
+	if(kd->ep != nil)
+		closedev(kd->ep);
+	kd->ep = nil;
+	devctl(dev, "detach");
+	closedev(dev);
+	/*
+	 * free(kd); done by closedev.
+	 */
+	threadexits(sts);
+}
+
+static int
+scale(KDev *f, int x)
+{
+	int sign = 1;
+
+	if(x < 0){
+		sign = -1;
+		x = -x;
+	}
+	switch(x){
+	case 0:
+	case 1:
+	case 2:
+	case 3:
+		break;
+	case 4:
+		x = 6 + (f->accel>>2);
+		break;
+	case 5:
+		x = 9 + (f->accel>>1);
+		break;
+	default:
+		x *= MaxAcc;
+		break;
+	}
+	return sign*x;
+}
+
+/*
+ * ps2 mouse is processed mostly at interrupt time.
+ * for usb we do what we can.
+ */
+static void
+sethipri(void)
+{
+	char fn[30];
+	int fd;
+
+	snprint(fn, sizeof fn, "/proc/%d/ctl", getpid());
+	fd = open(fn, OWRITE);
+	if(fd >= 0) {
+		fprint(fd, "pri 13");
+		close(fd);
+	}
+}
+
+static int
+ptrrepvals(KDev *kd, Chain *ch, int *px, int *py, int *pb)
+{
+	int i, x, y, b, c;
+	static char buts[] = {0x0, 0x2, 0x1};
+
+	c = ch->e / 8;
+
+	/* sometimes there is a report id, sometimes not */
+	if(c == kd->templ.sz + 1) {
+		if(ch->buf[0] == kd->templ.id)
+			ch->b += 8;
+		else
+			return -1;
+	}
+	parsereport(&kd->templ, ch);
+
+	if(kd->debug > 1)
+		dumpreport(&kd->templ);
+	if(c < 3)
+		return -1;
+	x = hidifcval(&kd->templ, KindX, 0);
+	y = hidifcval(&kd->templ, KindY, 0);
+	b = 0;
+	for(i = 0; i<sizeof buts; i++)
+		b |= (hidifcval(&kd->templ, KindButtons, i) & 1) << buts[i];
+	if(c > 3 && hidifcval(&kd->templ, KindWheel, 0) > 0)	/* up */
+		b |= 0x08;
+	if(c > 3 && hidifcval(&kd->templ, KindWheel, 0) < 0)	/* down */
+		b |= 0x10;
+
+	*px = x;
+	*py = y;
+	*pb = b;
+	return 0;
+}
+
+static int
+ptrbootpvals(KDev *kd, Chain *ch, int *px, int *py, int *pb)
+{
+	int b, c;
+	char x, y;
+	static char maptab[] = {0x0, 0x1, 0x4, 0x5, 0x2, 0x3, 0x6, 0x7};
+
+	c = ch->e / 8;
+	if(c < 3)
+		return -1;
+	if(kd->templ.nifcs){
+		x = hidifcval(&kd->templ, KindX, 0);
+		y = hidifcval(&kd->templ, KindY, 0);
+	}else{
+		/* no report descriptor for boot protocol */
+		x = ((signed char*)ch->buf)[1];
+		y = ((signed char*)ch->buf)[2];
+	}
+
+	b = maptab[ch->buf[0] & 0x7];
+	if(c > 3 && ch->buf[3] == 1)		/* up */
+		b |= 0x08;
+	if(c > 3 && ch->buf[3] == 0xff)		/* down */
+		b |= 0x10;
+	*px = x;
+	*py = y;
+	*pb = b;
+	return 0;
+}
+
+static void
+ptrwork(void* a)
+{
+	int hipri, mfd, nerrs, x, y, b, c, ptrfd;
+	char mbuf[80];
+	Chain ch;
+	KDev* f = a;
+
+	threadsetname("ptr %s", f->ep->dir);
+	hipri = nerrs = 0;
+	ptrfd = f->ep->dfd;
+	mfd = f->in->fd;
+	if(f->ep->maxpkt < 3 || f->ep->maxpkt > MaxChLen)
+		kbfatal(f, "weird mouse maxpkt");
+	for(;;){
+		memset(ch.buf, 0, MaxChLen);
+		if(f->ep == nil)
+			kbfatal(f, nil);
+		c = read(ptrfd, ch.buf, f->ep->maxpkt);
+		assert(f->dev != nil);
+		assert(f->ep != nil);
+		if(c < 0){
+			dprint(2, "kb: mouse: %s: read: %r\n", f->ep->dir);
+			if(++nerrs < 3){
+				recoverkb(f);
+				continue;
+			}
+		}
+		if(c <= 0)
+			kbfatal(f, nil);
+		ch.b = 0;
+		ch.e = 8 * c;
+		if(f->ptrvals(f, &ch, &x, &y, &b) < 0)
+			continue;
+		if(f->accel){
+			x = scale(f, x);
+			y = scale(f, y);
+		}
+		if(f->debug > 1)
+			fprint(2, "kb: m%11d %11d %11d\n", x, y, b);
+		seprint(mbuf, mbuf+sizeof(mbuf), "m%11d %11d %11d", x, y,b);
+		if(write(mfd, mbuf, strlen(mbuf)) < 0)
+			kbfatal(f, "mousein i/o");
+		if(hipri == 0){
+			sethipri();
+			hipri = 1;
+		}
+	}
+}
+
+static void
+stoprepeat(KDev *f)
+{
+	sendul(f->repeatc, Awakemsg);
+}
+
+static void
+startrepeat(KDev *f, uint8_t esc1, uint8_t sc)
+{
+	uint32_t c;
+
+	if(esc1)
+		c = SCesc1 << 8 | (sc & 0xff);
+	else
+		c = sc;
+	sendul(f->repeatc, c);
+}
+
+static void
+putscan(KDev *f, uint8_t esc, uint8_t sc)
+{
+	int kbinfd;
+	uint8_t s[2] = {SCesc1, 0};
+
+	kbinfd = f->in->fd;
+	if(sc == 0x41){
+		f->debug += 2;
+		return;
+	}
+	if(sc == 0x42){
+		f->debug = 0;
+		return;
+	}
+	if(f->debug > 1)
+		fprint(2, "sc: %x %x\n", (esc? SCesc1: 0), sc);
+	s[1] = sc;
+	if(esc && sc != 0)
+		write(kbinfd, s, 2);
+	else if(sc != 0)
+		write(kbinfd, s+1, 1);
+}
+
+static void
+repeatproc(void* a)
+{
+	KDev *f;
+	Channel *repeatc;
+	uint32_t l, t, i;
+	uint8_t esc1, sc;
+
+	threadsetname("kbd repeat");
+	/*
+	 * too many jumps here.
+	 * Rewrite instead of debug, if needed.
+	 */
+	f = a;
+	repeatc = f->repeatc;
+	l = Awakemsg;
+Repeat:
+	if(l == Diemsg)
+		goto Abort;
+	while(l == Awakemsg)
+		l = recvul(repeatc);
+	if(l == Diemsg)
+		goto Abort;
+	esc1 = l >> 8;
+	sc = l;
+	t = 160;
+	for(;;){
+		for(i = 0; i < t; i += 5){
+			if((l = nbrecvul(repeatc)) != 0)
+				goto Repeat;
+			sleep(5);
+		}
+		putscan(f, esc1, sc);
+		t = 30;
+	}
+Abort:
+	chanfree(repeatc);
+	threadexits("aborted");
+
+}
+
+
+#define hasesc1(sc)	((sc) >= 0x47 || (sc) == 0x38)
+
+static void
+putmod(KDev *f, uint8_t mods, uint8_t omods, uint8_t mask, uint8_t esc,
+       uint8_t sc)
+{
+	/* BUG: Should be a single write */
+	if((mods&mask) && !(omods&mask))
+		putscan(f, esc, sc);
+	if(!(mods&mask) && (omods&mask))
+		putscan(f, esc, Keyup|sc);
+}
+
+/*
+ * This routine diffs the state with the last known state
+ * and invents the scan codes that would have been sent
+ * by a non-usb keyboard in that case. This also requires supplying
+ * the extra esc1 byte as well as keyup flags.
+ * The aim is to allow future addition of other keycode pages
+ * for other keyboards.
+ */
+static uint8_t
+putkeys(KDev *f, uint8_t buf[], uint8_t obuf[], int n, uint8_t dk)
+{
+	int i, j;
+	uint8_t uk;
+
+	putmod(f, buf[0], obuf[0], Mctrl, 0, SCctrl);
+	putmod(f, buf[0], obuf[0], (1<<Mlshift), 0, SClshift);
+	putmod(f, buf[0], obuf[0], (1<<Mrshift), 0, SCrshift);
+	putmod(f, buf[0], obuf[0], Mcompose, 0, SCcompose);
+	putmod(f, buf[0], obuf[0], Maltgr, 1, SCcompose);
+
+	/* Report key downs */
+	for(i = 2; i < n; i++){
+		for(j = 2; j < n; j++)
+			if(buf[i] == obuf[j])
+			 	break;
+		if(j == n && buf[i] != 0){
+			dk = sctab[buf[i]];
+			putscan(f, hasesc1(dk), dk);
+			startrepeat(f, hasesc1(dk), dk);
+		}
+	}
+
+	/* Report key ups */
+	uk = 0;
+	for(i = 2; i < n; i++){
+		for(j = 2; j < n; j++)
+			if(obuf[i] == buf[j])
+				break;
+		if(j == n && obuf[i] != 0){
+			uk = sctab[obuf[i]];
+			putscan(f, hasesc1(uk), uk|Keyup);
+		}
+	}
+	if(uk && (dk == 0 || dk == uk)){
+		stoprepeat(f);
+		dk = 0;
+	}
+	return dk;
+}
+
+static int
+kbdbusy(uint8_t* buf, int n)
+{
+	int i;
+
+	for(i = 1; i < n; i++)
+		if(buf[i] == 0 || buf[i] != buf[0])
+			return 0;
+	return 1;
+}
+
+static void
+kbdwork(void *a)
+{
+	int c, i, kbdfd, nerrs;
+	uint8_t dk, buf[64], lbuf[64];
+	char err[128];
+	KDev *f = a;
+
+	threadsetname("kbd %s", f->ep->dir);
+	kbdfd = f->ep->dfd;
+
+	if(f->ep->maxpkt < 3 || f->ep->maxpkt > sizeof buf)
+		kbfatal(f, "weird maxpkt");
+
+	f->repeatc = chancreate(sizeof(uint32_t), 0);
+	if(f->repeatc == nil)
+		kbfatal(f, "chancreate failed");
+
+	proccreate(repeatproc, f, Stack);
+	memset(lbuf, 0, sizeof lbuf);
+	dk = nerrs = 0;
+	for(;;){
+		memset(buf, 0, sizeof buf);
+		c = read(kbdfd, buf, f->ep->maxpkt);
+		assert(f->dev != nil);
+		assert(f->ep != nil);
+		if(c < 0){
+			rerrstr(err, sizeof(err));
+			fprint(2, "kb: %s: read: %s\n", f->ep->dir, err);
+			if(strstr(err, "babble") != 0 && ++nerrs < 3){
+				recoverkb(f);
+				continue;
+			}
+		}
+		if(c <= 0)
+			kbfatal(f, nil);
+		if(c < 3)
+			continue;
+		if(kbdbusy(buf + 2, c - 2))
+			continue;
+		if(usbdebug > 2 || f->debug > 1){
+			fprint(2, "kbd mod %x: ", buf[0]);
+			for(i = 2; i < c; i++)
+				fprint(2, "kc %x ", buf[i]);
+			fprint(2, "\n");
+		}
+		dk = putkeys(f, buf, lbuf, f->ep->maxpkt, dk);
+		memmove(lbuf, buf, c);
+		nerrs = 0;
+	}
+}
+
+static void
+freekdev(void *a)
+{
+	KDev *kd;
+
+	kd = a;
+	if(kd->in != nil){
+		qlock(&inlck);
+		if(--kd->in->ref == 0){
+			close(kd->in->fd);
+			kd->in->fd = -1;
+		}
+		qunlock(&inlck);
+	}
+	dprint(2, "freekdev\n");
+	free(kd);
+}
+
+static void
+kbstart(Dev *d, Ep *ep, Kin *in, void (*f)(void*), KDev *kd)
+{
+	uint8_t desc[512];
+	int n, res;
+
+	qlock(&inlck);
+	if(in->fd < 0){
+		in->fd = open(in->name, OWRITE);
+		if(in->fd < 0){
+			fprint(2, "kb: %s: %r\n", in->name);
+			qunlock(&inlck);
+			return;
+		}
+	}
+	in->ref++;	/* for kd->in = in */
+	qunlock(&inlck);
+	d->free = freekdev;
+	kd->in = in;
+	kd->dev = d;
+	res = -1;
+	kd->ep = openep(d, ep->id);
+	if(kd->ep == nil){
+		fprint(2, "kb: %s: openep %d: %r\n", d->dir, ep->id);
+		return;
+	}
+	if(in == &kbdin){
+		/*
+		 * DWC OTG controller misses some split transaction inputs.
+		 * Set nonzero idle time to return more frequent reports
+		 * of keyboard state, to avoid losing key up/down events.
+		 */
+		n = read(d->cfd, desc, sizeof desc - 1);
+		if(n > 0){
+			desc[n] = 0;
+			if(strstr((char*)desc, "dwcotg") != nil)
+				kd->idle = Dwcidle;
+		}
+	}
+	if(!kd->bootp)
+		res= setfirstconfig(kd, ep->id, desc, sizeof desc);
+	if(res > 0)
+		res = parsereportdesc(&kd->templ, desc, sizeof desc);
+	/* if we could not set the first config, we give up */
+	if(kd->bootp || res < 0){
+		kd->bootp = 1;
+		if(setbootproto(kd, ep->id, nil, 0) < 0){
+			fprint(2, "kb: %s: bootproto: %r\n", d->dir);
+			return;
+		}
+	}else if(kd->debug)
+		dumpreport(&kd->templ);
+	if(opendevdata(kd->ep, OREAD) < 0){
+		fprint(2, "kb: %s: opendevdata: %r\n", kd->ep->dir);
+		closedev(kd->ep);
+		kd->ep = nil;
+		return;
+	}
+
+	incref(&d->Ref);
+	proccreate(f, kd, Stack);
+}
+
+static int
+usage(void)
+{
+	werrstr("usage: usb/kb [-bdkm] [-a n] [-N nb]");
+	return -1;
+}
+
+int
+kbmain(Dev *d, int argc, char* argv[])
+{
+	int bootp, i, kena, pena, accel, devid, debug;
+	Ep *ep;
+	KDev *kd;
+	Usbdev *ud;
+
+	kena = pena = 1;
+	bootp = 0;
+	accel = 0;
+	debug = 0;
+	devid = d->id;
+	ARGBEGIN{
+	case 'a':
+		accel = strtol(EARGF(usage()), nil, 0);
+		break;
+	case 'd':
+		debug++;
+		break;
+	case 'k':
+		kena = 1;
+		pena = 0;
+		break;
+	case 'm':
+		kena = 0;
+		pena = 1;
+		break;
+	case 'N':
+		devid = atoi(EARGF(usage()));		/* ignore dev number */
+		break;
+	case 'b':
+		bootp++;
+		break;
+	default:
+		return usage();
+	}ARGEND;
+	if(argc != 0)
+		return usage();
+	USED(devid);
+	ud = d->usb;
+	d->aux = nil;
+	dprint(2, "kb: main: dev %s ref %ld\n", d->dir, d->Ref.ref);
+
+	if(kena) {
+		for(i = 0; i < nelem(ud->ep); i++)
+			if((ep = ud->ep[i]) == nil)
+				break;
+			else if(ep->iface->csp == KbdCSP)
+				bootp = 1;
+	}
+
+	for(i = 0; i < nelem(ud->ep); i++){
+		if((ep = ud->ep[i]) == nil)
+			continue;
+		if(kena && ep->type == Eintr && ep->dir == Ein &&
+		    ep->iface->csp == KbdCSP){
+			kd = d->aux = emallocz(sizeof(KDev), 1);
+			kd->accel = 0;
+			kd->bootp = 1;
+			kd->debug = debug;
+			kbstart(d, ep, &kbdin, kbdwork, kd);
+		}
+		if(pena && ep->type == Eintr && ep->dir == Ein &&
+		    ep->iface->csp == PtrCSP){
+			kd = d->aux = emallocz(sizeof(KDev), 1);
+			kd->accel = accel;
+			kd->bootp = bootp;
+			kd->debug = debug;
+			kbstart(d, ep, &ptrin, ptrwork, kd);
+		}
+	}
+	return 0;
+}

--- a/sys/src/libusb/lib/dev.c
+++ b/sys/src/libusb/lib/dev.c
@@ -1,0 +1,504 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <usb/usb.h>
+
+/*
+ * epN.M -> N
+ */
+static int
+nameid(char *s)
+{
+	char *r;
+	char nm[20];
+
+	r = strrchr(s, 'p');
+	if(r == nil)
+		return -1;
+	strecpy(nm, nm+sizeof(nm), r+1);
+	r = strchr(nm, '.');
+	if(r == nil)
+		return -1;
+	*r = 0;
+	return atoi(nm);
+}
+
+Dev*
+openep(Dev *d, int id)
+{
+	char *mode;	/* How many modes? */
+	Ep *ep;
+	Altc *ac;
+	Dev *epd;
+	Usbdev *ud;
+	char name[40];
+
+	if(access("/dev/usb", AEXIST) < 0 && bind("#u", "/dev", MBEFORE) < 0)
+		return nil;
+	if(d->cfd < 0 || d->usb == nil){
+		werrstr("device not configured");
+		return nil;
+	}
+	ud = d->usb;
+	if(id < 0 || id >= nelem(ud->ep) || ud->ep[id] == nil){
+		werrstr("bad enpoint number");
+		return nil;
+	}
+	ep = ud->ep[id];
+	mode = "rw";
+	if(ep->dir == Ein)
+		mode = "r";
+	if(ep->dir == Eout)
+		mode = "w";
+	snprint(name, sizeof(name), "/dev/usb/ep%d.%d", d->id, id);
+	if(access(name, AEXIST) == 0){
+		dprint(2, "%s: %s already exists; trying to open\n", argv0, name);
+		epd = opendev(name);
+		if(epd != nil)
+			epd->maxpkt = ep->maxpkt;	/* guess */
+		return epd;
+	}
+	if(devctl(d, "new %d %d %s", id, ep->type, mode) < 0){
+		dprint(2, "%s: %s: new: %r\n", argv0, d->dir);
+		return nil;
+	}
+	epd = opendev(name);
+	if(epd == nil)
+		return nil;
+	epd->id = id;
+	if(devctl(epd, "maxpkt %d", ep->maxpkt) < 0)
+		fprint(2, "%s: %s: openep: maxpkt: %r\n", argv0, epd->dir);
+	else
+		dprint(2, "%s: %s: maxpkt %d\n", argv0, epd->dir, ep->maxpkt);
+	epd->maxpkt = ep->maxpkt;
+	ac = ep->iface->altc[0];
+	if(ep->ntds > 1 && devctl(epd, "ntds %d", ep->ntds) < 0)
+		fprint(2, "%s: %s: openep: ntds: %r\n", argv0, epd->dir);
+	else
+		dprint(2, "%s: %s: ntds %d\n", argv0, epd->dir, ep->ntds);
+
+	/*
+	 * For iso endpoints and high speed interrupt endpoints the pollival is
+	 * actually 2ⁿ and not n.
+	 * The kernel usb driver must take that into account.
+	 * It's simpler this way.
+	 */
+
+	if(ac != nil && (ep->type == Eintr || ep->type == Eiso) && ac->interval != 0)
+		if(devctl(epd, "pollival %d", ac->interval) < 0)
+			fprint(2, "%s: %s: openep: pollival: %r\n", argv0, epd->dir);
+	return epd;
+}
+
+Dev*
+opendev(char *fn)
+{
+	Dev *d;
+	int l;
+
+	if(access("/dev/usb", AEXIST) < 0 && bind("#u", "/dev", MBEFORE) < 0)
+		return nil;
+	d = emallocz(sizeof(Dev), 1);
+	incref(&d->Ref);
+
+	l = strlen(fn);
+	d->dfd = -1;
+	/*
+	 * +30 to allocate extra size to concat "/<epfilename>"
+	 * we should probably remove that feature from the manual
+	 * and from the code after checking out that nobody relies on
+	 * that.
+	 */
+	d->dir = emallocz(l + 30, 0);
+	strcpy(d->dir, fn);
+	strcpy(d->dir+l, "/ctl");
+	d->cfd = open(d->dir, ORDWR|OCEXEC);
+	d->dir[l] = 0;
+	d->id = nameid(fn);
+	if(d->cfd < 0){
+		werrstr("can't open endpoint %s: %r", d->dir);
+		free(d->dir);
+		free(d);
+		return nil;
+	}
+	dprint(2, "%s: opendev %#p %s\n", argv0, d, fn);
+	return d;
+}
+
+int
+opendevdata(Dev *d, int mode)
+{
+	char buf[80]; /* more than enough for a usb path */
+
+	seprint(buf, buf+sizeof(buf), "%s/data", d->dir);
+	d->dfd = open(buf, mode|OCEXEC);
+	return d->dfd;
+}
+
+enum
+{
+	/*
+	 * Max device conf is also limited by max control request size as
+	 * limited by Maxctllen in the kernel usb.h (both limits are arbitrary).
+	 */
+	Maxdevconf = 4 * 1024,	/* asking for 16K kills Newsham's disk */
+};
+
+int
+loaddevconf(Dev *d, int n)
+{
+	uint8_t *buf;
+	int nr;
+	int type;
+
+	if(n >= nelem(d->usb->conf)){
+		werrstr("loaddevconf: bug: out of configurations in device");
+		fprint(2, "%s: %r\n", argv0);
+		return -1;
+	}
+	buf = emallocz(Maxdevconf, 0);
+	type = Rd2h|Rstd|Rdev;
+	nr = usbcmd(d, type, Rgetdesc, Dconf<<8|n, 0, buf, Maxdevconf);
+	if(nr < Dconflen){
+		free(buf);
+		return -1;
+	}
+	if(d->usb->conf[n] == nil)
+		d->usb->conf[n] = emallocz(sizeof(Conf), 1);
+	nr = parseconf(d->usb, d->usb->conf[n], buf, nr);
+	free(buf);
+	return nr;
+}
+
+Ep*
+mkep(Usbdev *d, int id)
+{
+	Ep *ep;
+
+	d->ep[id] = ep = emallocz(sizeof(Ep), 1);
+	ep->id = id;
+	return ep;
+}
+
+static char*
+mkstr(uint8_t *b, int n)
+{
+	Rune r;
+	char *us;
+	char *s;
+	char *e;
+
+	if(n <= 2 || (n & 1) != 0)
+		return strdup("none");
+	n = (n - 2)/2;
+	b += 2;
+	us = s = emallocz(n*UTFmax+1, 0);
+	e = s + n*UTFmax+1;
+	for(; --n >= 0; b += 2){
+		r = GET2(b);
+		s = seprint(s, e, "%C", r);
+	}
+	return us;
+}
+
+char*
+loaddevstr(Dev *d, int sid)
+{
+	uint8_t buf[128];
+	int type;
+	int nr;
+
+	if(sid == 0)
+		return estrdup("none");
+	type = Rd2h|Rstd|Rdev;
+	nr=usbcmd(d, type, Rgetdesc, Dstr<<8|sid, 0, buf, sizeof(buf));
+	return mkstr(buf, nr);
+}
+
+int
+loaddevdesc(Dev *d)
+{
+	uint8_t buf[Ddevlen+255];
+	int nr;
+	int type;
+	Ep *ep0;
+
+	type = Rd2h|Rstd|Rdev;
+	nr = sizeof(buf);
+	memset(buf, 0, Ddevlen);
+	if((nr=usbcmd(d, type, Rgetdesc, Ddev<<8|0, 0, buf, nr)) < 0)
+		return -1;
+	/*
+	 * Several hubs are returning descriptors of 17 bytes, not 18.
+	 * We accept them and leave number of configurations as zero.
+	 * (a get configuration descriptor also fails for them!)
+	 */
+	if(nr < Ddevlen){
+		print("%s: %s: warning: device with short descriptor\n",
+			argv0, d->dir);
+		if(nr < Ddevlen-1){
+			werrstr("short device descriptor (%d bytes)", nr);
+			return -1;
+		}
+	}
+	d->usb = emallocz(sizeof(Usbdev), 1);
+	ep0 = mkep(d->usb, 0);
+	ep0->dir = Eboth;
+	ep0->type = Econtrol;
+	ep0->maxpkt = d->maxpkt = 8;		/* a default */
+	nr = parsedev(d, buf, nr);
+	if(nr >= 0){
+		d->usb->vendor = loaddevstr(d, d->usb->vsid);
+		if(strcmp(d->usb->vendor, "none") != 0){
+			d->usb->product = loaddevstr(d, d->usb->psid);
+			d->usb->serial = loaddevstr(d, d->usb->ssid);
+		}
+	}
+	return nr;
+}
+
+int
+configdev(Dev *d)
+{
+	int i;
+
+	if(d->dfd < 0)
+		opendevdata(d, ORDWR);
+	if(loaddevdesc(d) < 0)
+		return -1;
+	for(i = 0; i < d->usb->nconf; i++)
+		if(loaddevconf(d, i) < 0)
+			return -1;
+	return 0;
+}
+
+static void
+closeconf(Conf *c)
+{
+	int i;
+	int a;
+
+	if(c == nil)
+		return;
+	for(i = 0; i < nelem(c->iface); i++)
+		if(c->iface[i] != nil){
+			for(a = 0; a < nelem(c->iface[i]->altc); a++)
+				free(c->iface[i]->altc[a]);
+			free(c->iface[i]);
+		}
+	free(c);
+}
+
+void
+closedev(Dev *d)
+{
+	int i;
+	Usbdev *ud;
+
+	if(d==nil || decref(&d->Ref) != 0)
+		return;
+	dprint(2, "%s: closedev %#p %s\n", argv0, d, d->dir);
+	if(d->free != nil)
+		d->free(d->aux);
+	if(d->cfd >= 0)
+		close(d->cfd);
+	if(d->dfd >= 0)
+		close(d->dfd);
+	d->cfd = d->dfd = -1;
+	free(d->dir);
+	d->dir = nil;
+	ud = d->usb;
+	d->usb = nil;
+	if(ud != nil){
+		free(ud->vendor);
+		free(ud->product);
+		free(ud->serial);
+		for(i = 0; i < nelem(ud->ep); i++)
+			free(ud->ep[i]);
+		for(i = 0; i < nelem(ud->ddesc); i++)
+			free(ud->ddesc[i]);
+
+		for(i = 0; i < nelem(ud->conf); i++)
+			closeconf(ud->conf[i]);
+		free(ud);
+	}
+	free(d);
+}
+
+static char*
+reqstr(int type, int req)
+{
+	char *s;
+	static char* ds[] = { "dev", "if", "ep", "oth" };
+	static char buf[40];
+
+	if(type&Rd2h)
+		s = seprint(buf, buf+sizeof(buf), "d2h");
+	else
+		s = seprint(buf, buf+sizeof(buf), "h2d");
+	if(type&Rclass)
+		s = seprint(s, buf+sizeof(buf), "|cls");
+	else if(type&Rvendor)
+		s = seprint(s, buf+sizeof(buf), "|vnd");
+	else
+		s = seprint(s, buf+sizeof(buf), "|std");
+	s = seprint(s, buf+sizeof(buf), "|%s", ds[type&3]);
+
+	switch(req){
+	case Rgetstatus: s = seprint(s, buf+sizeof(buf), " getsts"); break;
+	case Rclearfeature: s = seprint(s, buf+sizeof(buf), " clrfeat"); break;
+	case Rsetfeature: s = seprint(s, buf+sizeof(buf), " setfeat"); break;
+	case Rsetaddress: s = seprint(s, buf+sizeof(buf), " setaddr"); break;
+	case Rgetdesc: s = seprint(s, buf+sizeof(buf), " getdesc"); break;
+	case Rsetdesc: s = seprint(s, buf+sizeof(buf), " setdesc"); break;
+	case Rgetconf: s = seprint(s, buf+sizeof(buf), " getcnf"); break;
+	case Rsetconf: s = seprint(s, buf+sizeof(buf), " setcnf"); break;
+	case Rgetiface: s = seprint(s, buf+sizeof(buf), " getif"); break;
+	case Rsetiface: s = seprint(s, buf+sizeof(buf), " setif"); break;
+	}
+	USED(s);
+	return buf;
+}
+
+static int
+cmdreq(Dev *d, int type, int req, int value, int index, uint8_t *data,
+       int count)
+{
+	int ndata, n;
+	uint8_t *wp;
+	uint8_t buf[8];
+	char *hd, *rs;
+
+	assert(d != nil);
+	if(data == nil){
+		wp = buf;
+		ndata = 0;
+	}else{
+		ndata = count;
+		wp = emallocz(8+ndata, 0);
+	}
+	wp[0] = type;
+	wp[1] = req;
+	PUT2(wp+2, value);
+	PUT2(wp+4, index);
+	PUT2(wp+6, count);
+	if(data != nil)
+		memmove(wp+8, data, ndata);
+	if(usbdebug>2){
+		hd = hexstr(wp, ndata+8);
+		rs = reqstr(type, req);
+		fprint(2, "%s: %s val %d|%d idx %d cnt %d out[%d] %s\n",
+			d->dir, rs, value>>8, value&0xFF,
+			index, count, ndata+8, hd);
+		free(hd);
+	}
+	n = write(d->dfd, wp, 8+ndata);
+	if(wp != buf)
+		free(wp);
+	if(n < 0)
+		return -1;
+	if(n != 8+ndata){
+		dprint(2, "%s: cmd: short write: %d\n", argv0, n);
+		return -1;
+	}
+	return n;
+}
+
+static int
+cmdrep(Dev *d, void *buf, int nb)
+{
+	char *hd;
+
+	nb = read(d->dfd, buf, nb);
+	if(nb >0 && usbdebug > 2){
+		hd = hexstr(buf, nb);
+		fprint(2, "%s: in[%d] %s\n", d->dir, nb, hd);
+		free(hd);
+	}
+	return nb;
+}
+
+int
+usbcmd(Dev *d, int type, int req, int value, int index, uint8_t *data,
+       int count)
+{
+	int i, r, nerr;
+	char err[64];
+
+	/*
+	 * Some devices do not respond to commands some times.
+	 * Others even report errors but later work just fine. Retry.
+	 */
+	r = -1;
+	*err = 0;
+	for(i = nerr = 0; i < Uctries; i++){
+		if(type & Rd2h)
+			r = cmdreq(d, type, req, value, index, nil, count);
+		else
+			r = cmdreq(d, type, req, value, index, data, count);
+		if(r > 0){
+			if((type & Rd2h) == 0)
+				break;
+			r = cmdrep(d, data, count);
+			if(r > 0)
+				break;
+			if(r == 0)
+				werrstr("no data from device");
+		}
+		nerr++;
+		if(*err == 0)
+			rerrstr(err, sizeof(err));
+		sleep(Ucdelay);
+	}
+	if(r > 0 && i >= 2)
+		/* let the user know the device is not in good shape */
+		fprint(2, "%s: usbcmd: %s: required %d attempts (%s)\n",
+			argv0, d->dir, i, err);
+	return r;
+}
+
+int
+unstall(Dev *dev, Dev *ep, int dir)
+{
+	int r;
+
+	if(dir == Ein)
+		dir = 0x80;
+	else
+		dir = 0;
+	r = Rh2d|Rstd|Rep;
+	if(usbcmd(dev, r, Rclearfeature, Fhalt, ep->id|dir, nil, 0)<0){
+		werrstr("unstall: %s: %r", ep->dir);
+		return -1;
+	}
+	if(devctl(ep, "clrhalt") < 0){
+		werrstr("clrhalt: %s: %r", ep->dir);
+		return -1;
+	}
+	return 0;
+}
+
+/*
+ * To be sure it uses a single write.
+ */
+int
+devctl(Dev *dev, char *fmt, ...)
+{
+	char buf[128];
+	va_list arg;
+	char *e;
+
+	va_start(arg, fmt);
+	e = vseprint(buf, buf+sizeof(buf), fmt, arg);
+	va_end(arg);
+	return write(dev->cfd, buf, e-buf);
+}

--- a/sys/src/libusb/lib/devs.c
+++ b/sys/src/libusb/lib/devs.c
@@ -1,0 +1,169 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <usb/usb.h>
+
+typedef struct Parg Parg;
+
+enum {
+	Ndevs = 32,
+	Arglen = 500,
+	Nargs = 64,
+	Stack = 16 * 1024,
+};
+
+struct Parg {
+	char*	args;
+	Dev*	dev;
+	int 	(*f)(Dev*,int,char**);
+	Channel*rc;
+};
+
+static void
+workproc(void *a)
+{
+	Parg *pa;
+	char args[Arglen];
+	char *argv[Nargs];
+	int argc;
+	Channel *rc;
+	Dev *d;
+	int (*f)(Dev*,int,char**);
+
+	pa = a;
+	threadsetname("workproc %s", pa->dev->dir);
+	strecpy(args, args+sizeof(args), pa->args);	/* don't leak */
+	d = pa->dev;
+	f = pa->f;
+	rc = pa->rc;
+	free(pa->args);
+	free(pa);
+	argc = tokenize(args, argv, nelem(argv)-1);
+	argv[argc] = nil;
+	if(f(d, argc, argv) < 0){
+		closedev(d);
+		fprint(2, "%s: devmain: %r\n", argv0);
+		sendul(rc, -1);
+		threadexits("devmain: %r");
+	}
+	sendul(rc, 0);
+	threadexits(nil);
+
+}
+
+int
+matchdevcsp(char *info, void *a)
+{
+	char sbuf[40];
+	int *csps;
+
+	csps = a;
+	for(; *csps != 0; csps++){
+		snprint(sbuf, sizeof(sbuf), "csp %#08x", *csps);
+		if(strstr(info, sbuf) != nil)
+			return 0;
+	}
+	return -1;
+}
+
+int
+finddevs(int (*matchf)(char*,void*), void *farg, char** dirs, int ndirs)
+{
+	int fd, i, n, nd, nr;
+	char *nm;
+	char dbuf[512], fbuf[40];
+	Dir *d;
+
+	fd = open("/dev/usb", OREAD);
+	if(fd < 0)
+		sysfatal("/dev/usb: %r");
+	nd = dirreadall(fd, &d);
+	close(fd);
+	if(nd < 2)
+		sysfatal("/dev/usb: no devs");
+	for(i = n = 0; i < nd && n < ndirs; i++){
+		nm = d[i].name;
+		if(strcmp(nm, "ctl") == 0 || strstr(nm, ".0") == nil)
+			continue;
+		snprint(fbuf, sizeof(fbuf), "/dev/usb/%s/ctl", nm);
+		fd = open(fbuf, OREAD);
+		if(fd < 0)
+			continue;	/* may be gone */
+		nr = read(fd, dbuf, sizeof(dbuf)-1);
+		close(fd);
+		if(nr < 0)
+			continue;
+		dbuf[nr] = 0;
+		if(strstr(dbuf, "enabled ") != nil && strstr(dbuf, " busy") == nil)
+			if(matchf(dbuf, farg) == 0)
+				dirs[n++] = smprint("/dev/usb/%s", nm);
+	}
+	free(d);
+	if(usbdebug > 1)
+		for(nd = 0; nd < n; nd++)
+			fprint(2, "finddevs: %s\n", dirs[nd]);
+	return n;
+}
+
+void
+startdevs(char *args, char *argv[], int argc, int (*mf)(char*, void*),
+	void *ma, int (*df)(Dev*, int, char**))
+{
+	int i, ndirs, ndevs;
+	char *dirs[Ndevs];
+	char **dp;
+	Parg *parg;
+	Dev *dev;
+	Channel *rc;
+
+	if(access("/dev/usb", AEXIST) < 0 && bind("#u", "/dev", MBEFORE) < 0)
+		sysfatal("#u: %r");
+
+	if(argc > 0){
+		ndirs = argc;
+		dp = argv;
+	}else{
+		dp = dirs;
+		ndirs = finddevs(mf, ma, dp, Ndevs);
+		if(ndirs == nelem(dirs))
+			fprint(2, "%s: too many devices\n", argv0);
+	}
+	ndevs = 0;
+	rc = chancreate(sizeof(uint32_t), 0);
+	if(rc == nil)
+		sysfatal("no memory");
+	for(i = 0; i < ndirs; i++){
+		fprint(2, "%s: startdevs: opening #%d %s\n", argv0, i, dp[i]);
+		dev = opendev(dp[i]);
+		if(dev == nil)
+			fprint(2, "%s: %s: %r\n", argv0, dp[i]);
+		else if(configdev(dev) < 0){
+			fprint(2, "%s: %s: config: %r\n", argv0, dp[i]);
+			closedev(dev);
+		}else{
+			dprint(2, "%s: %U", argv0, dev);
+			parg = emallocz(sizeof(Parg), 0);
+			parg->args = estrdup(args);
+			parg->dev = dev;
+			parg->rc = rc;
+			parg->f = df;
+			proccreate(workproc, parg, Stack);
+			if(recvul(rc) == 0)
+				ndevs++;
+		}
+		if(dp != argv)
+			free(dirs[i]);
+	}
+	chanfree(rc);
+	if(ndevs == 0)
+		sysfatal("no unhandled devices found");
+}

--- a/sys/src/libusb/lib/dump.c
+++ b/sys/src/libusb/lib/dump.c
@@ -1,0 +1,185 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <bio.h>
+#include <usb/usb.h>
+
+int usbdebug;
+
+static char *edir[] = {"in", "out", "inout"};
+static char *etype[] = {"ctl", "iso", "bulk", "intr"};
+static char* cnames[] =
+{
+	"none", "audio", "comms", "hid", "",
+	"", "", "printer", "storage", "hub", "data"
+};
+/*
+static char* devstates[] =
+{
+	"detached", "attached", "enabled", "assigned", "configured"
+};
+*/
+char*
+classname(int c)
+{
+	static char buf[30];
+
+	if(c >= 0 && c < nelem(cnames))
+		return cnames[c];
+	else{
+		seprint(buf, buf+30, "%d", c);
+		return buf;
+	}
+}
+
+char *
+hexstr(void *a, int n)
+{
+	int i;
+	char *dbuff, *s, *e;
+	uint8_t *b;
+
+	b = a;
+	dbuff = s = emallocz(1024, 0);
+	*s = 0;
+	e = s + 1024;
+	for(i = 0; i < n; i++)
+		s = seprint(s, e, " %.2x", b[i]);
+	if(s == e)
+		fprint(2, "%s: usb/lib: hexdump: bug: small buffer\n", argv0);
+	return dbuff;
+}
+
+static char *
+seprintiface(char *s, char *e, Iface *i)
+{
+	int	j;
+	Altc	*a;
+	Ep	*ep;
+	char	*eds, *ets;
+
+	s = seprint(s, e, "\t\tiface csp %s.%lu.%lu\n",
+		classname(Class(i->csp)), Subclass(i->csp), Proto(i->csp));
+	for(j = 0; j < Naltc; j++){
+		a=i->altc[j];
+		if(a == nil)
+			break;
+		s = seprint(s, e, "\t\t  alt %d attr %d ival %d",
+			j, a->attrib, a->interval);
+		if(a->aux != nil)
+			s = seprint(s, e, " devspec %p\n", a->aux);
+		else
+			s = seprint(s, e, "\n");
+	}
+	for(j = 0; j < Nep; j++){
+		ep = i->ep[j];
+		if(ep == nil)
+			break;
+		eds = ets = "";
+		if(ep->dir <= nelem(edir))
+			eds = edir[ep->dir];
+		if(ep->type <= nelem(etype))
+			ets = etype[ep->type];
+		s = seprint(s, e, "\t\t  ep id %d addr %d dir %s type %s"
+			" itype %d maxpkt %d ntds %d\n",
+			ep->id, ep->addr, eds, ets, ep->isotype,
+			ep->maxpkt, ep->ntds);
+	}
+	return s;
+}
+
+static char*
+seprintconf(char *s, char *e, Usbdev *d, int ci)
+{
+	int i;
+	Conf *c;
+	char *hd;
+
+	c = d->conf[ci];
+	s = seprint(s, e, "\tconf: cval %d attrib %x %d mA\n",
+		c->cval, c->attrib, c->milliamps);
+	for(i = 0; i < Niface; i++)
+		if(c->iface[i] == nil)
+			break;
+		else
+			s = seprintiface(s, e, c->iface[i]);
+	for(i = 0; i < Nddesc; i++)
+		if(d->ddesc[i] == nil)
+			break;
+		else if(d->ddesc[i]->conf == c){
+			hd = hexstr((uint8_t*)&d->ddesc[i]->data,
+				d->ddesc[i]->data.bLength);
+			s = seprint(s, e, "\t\tdev desc %x[%d]: %s\n",
+				d->ddesc[i]->data.bDescriptorType,
+				d->ddesc[i]->data.bLength, hd);
+			free(hd);
+		}
+	return s;
+}
+
+int
+Ufmt(Fmt *f)
+{
+	int i;
+	Dev *d;
+	Usbdev *ud;
+	char buf[1024];
+	char *s, *e;
+
+	s = buf;
+	e = buf+sizeof(buf);
+	d = va_arg(f->args, Dev*);
+	if(d == nil)
+		return fmtprint(f, "<nildev>\n");
+	s = seprint(s, e, "%s", d->dir);
+	ud = d->usb;
+	if(ud == nil)
+		return fmtprint(f, "%s %ld refs\n", buf, d->Ref.ref);
+	s = seprint(s, e, " csp %s.%lu.%lu",
+		classname(Class(ud->csp)), Subclass(ud->csp), Proto(ud->csp));
+	s = seprint(s, e, " vid %#x did %#x", ud->vid, ud->did);
+	s = seprint(s, e, " refs %ld\n", d->Ref.ref);
+	s = seprint(s, e, "\t%s %s %s\n", ud->vendor, ud->product, ud->serial);
+	for(i = 0; i < Nconf; i++){
+		if(ud->conf[i] == nil)
+			break;
+		else
+			s = seprintconf(s, e, ud, i);
+	}
+	return fmtprint(f, "%s", buf);
+}
+
+char*
+estrdup(char *s)
+{
+	char *d;
+
+	d = strdup(s);
+	if(d == nil)
+		sysfatal("strdup: %r");
+	setmalloctag(d, getcallerpc());
+	return d;
+}
+
+void*
+emallocz(uint32_t size, int zero)
+{
+	void *x;
+
+	x = malloc(size);
+	if(x == nil)
+		sysfatal("malloc: %r");
+	if(zero)
+		memset(x, 0, size);
+	setmalloctag(x, getcallerpc());
+	return x;
+}

--- a/sys/src/libusb/lib/fs.c
+++ b/sys/src/libusb/lib/fs.c
@@ -1,0 +1,689 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+/*
+ * Framework for USB devices that provide a file tree.
+ * The main process (usbd or the driver's main proc)
+ * calls fsinit() to start FS operation.
+ *
+ * One or more drivers call fsstart/fsend to register
+ * or unregister their operations for their subtrees.
+ *
+ * root dir has qids with 0 in high 32 bits.
+ * for other files we keep the device id in there.
+ * The low 32 bits for directories at / must be 0.
+ */
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <fcall.h>
+#include <usb/usb.h>
+#include <usb/usbfs.h>
+
+#undef dprint
+#define dprint if(usbfsdebug)fprint
+
+typedef struct Rpc Rpc;
+
+enum
+{
+	Nproc = 3,		/* max nb. of cached FS procs */
+
+	Nofid = ~0,		/* null value for fid number */
+	Notag = ~0,		/* null value for tags */
+	Dietag = 0xdead,		/* fake tag to ask outproc to die */
+
+	Stack = 16 * 1024,
+
+	/* Fsproc requests */
+	Run = 0,		/* call f(r) */
+	Exit,			/* terminate */
+
+};
+
+struct Rpc
+{
+	Fcall	t;
+	Fcall	r;
+	Fid*	fid;
+	int	flushed;
+	Rpc*	next;
+	char	data[Bufsize];
+};
+
+int usbfsdebug;
+
+char Enotfound[] = "file not found";
+char Etoosmall[] = "parameter too small";
+char Eio[] = "i/o error";
+char Eperm[] = "permission denied";
+char Ebadcall[] = "unknown fs call";
+char Ebadfid[] = "fid not found";
+char Einuse[] = "fid already in use";
+char Eisopen[] = "it is already open";
+char Ebadctl[] = "unknown control request";
+
+static char *user;
+static uint32_t epoch;
+static uint32_t msgsize = Msgsize;
+static int fsfd = -1;
+static Channel *outc;	/* of Rpc* */
+
+static QLock rpclck;	/* protect vars in this block */
+static Fid *freefids;
+static Fid *fids;
+static Rpc *freerpcs;
+static Rpc *rpcs;
+
+static Channel*procc;
+static Channel*endc;
+
+static Usbfs* fsops;
+
+static void fsioproc(void*);
+
+static void
+schedproc(void*_1)
+{
+	Channel *proc[Nproc];
+	int nproc;
+	Channel *p;
+
+	Alt a[] =
+	{
+		{procc, &proc[0], CHANSND},
+		{endc, &p, CHANRCV},
+		{nil, nil, CHANEND}
+	};
+	memset(proc, 0, sizeof(proc));
+	nproc = 0;
+	for(;;){
+		if(nproc == 0){
+			proc[0] = chancreate(sizeof(Rpc*), 0);
+			proccreate(fsioproc, proc[0], Stack);
+			nproc++;
+		}
+		switch(alt(a)){
+		case 0:
+			proc[0] = nil;
+			if(nproc > 1){
+				proc[0] = proc[nproc-1];
+				proc[nproc-1] = nil;
+			}
+			nproc--;
+			break;
+		case 1:
+			if(nproc < nelem(proc))
+				proc[nproc++] = p;
+			else
+				sendp(p, nil);
+			break;
+		default:
+			sysfatal("alt");
+		}
+	}
+}
+
+static void
+dump(void)
+{
+	Rpc *rpc;
+	Fid *fid;
+
+	qlock(&rpclck);
+	fprint(2, "dump:\n");
+	for(rpc = rpcs; rpc != nil; rpc = rpc->next)
+		fprint(2, "rpc %#p %F next %#p\n", rpc, &rpc->t, rpc->next);
+	for(fid = fids; fid != nil; fid = fid->next)
+		fprint(2, "fid %d qid %#llx omode %d aux %#p\n",
+			fid->fid, fid->qid.path, fid->omode, fid->aux);
+	fprint(2, "\n");
+	qunlock(&rpclck);
+}
+
+static Rpc*
+newrpc(void)
+{
+	Rpc *r;
+
+	qlock(&rpclck);
+	r = freerpcs;
+	if(r != nil)
+		freerpcs = r->next;
+	else
+		r = emallocz(sizeof(Rpc), 0);
+	r->next = rpcs;
+	rpcs = r;
+	r->t.tag = r->r.tag = Notag;
+	r->t.fid = r->r.fid = Nofid;
+	r->t.type = r->r.type = 0;
+	r->flushed = 0;
+	r->fid = nil;
+	r->r.data = (char*)r->data;
+	qunlock(&rpclck);
+	return r;
+}
+
+static void
+freerpc(Rpc *r)
+{
+	Rpc **l;
+	if(r == nil)
+		return;
+	qlock(&rpclck);
+	for(l = &rpcs; *l != nil && *l != r; l = &(*l)->next)
+		;
+	assert(*l == r);
+	*l = r->next;
+	r->next = freerpcs;
+	freerpcs = r;
+	r->t.type = 0;
+	// This is really weird. The tag is 16 bits. Why did this work?
+	// Is something else missing?
+	//r->t.tag = 0x77777777U;
+	r->t.tag = 0x7777;
+	qunlock(&rpclck);
+}
+
+static void
+flushrpc(int tag)
+{
+	Rpc *r;
+
+	qlock(&rpclck);
+	for(r = rpcs; r != nil; r = r->next)
+		if(r->t.tag == tag){
+			r->flushed = 1;
+			break;
+		}
+	qunlock(&rpclck);
+}
+
+static Fid*
+getfid(int fid, int alloc)
+{
+	Fid *f;
+
+	qlock(&rpclck);
+	for(f = fids; f != nil && f->fid != fid; f = f->next)
+		;
+	if(f != nil && alloc != 0){	/* fid in use */
+		qunlock(&rpclck);
+		return nil;
+	}
+	if(f == nil && alloc != 0){
+		if(freefids != nil){
+			f = freefids;
+			freefids = freefids->next;
+		}else
+			f = emallocz(sizeof(Fid), 1);
+		f->fid = fid;
+		f->aux = nil;
+		f->omode = ONONE;
+		f->next = fids;
+		fids = f;
+	}
+	qunlock(&rpclck);
+	return f;
+}
+
+static void
+freefid(Fid *f)
+{
+	Fid **l;
+
+	if(f == nil)
+		return;
+	if(fsops->clunk != nil)
+		fsops->clunk(fsops, f);
+	qlock(&rpclck);
+	for(l = &fids; *l != nil && *l != f; l = &(*l)->next)
+		;
+	assert(*l == f);
+	*l = f->next;
+	f->next = freefids;
+	freefids = f;
+	qunlock(&rpclck);
+}
+
+static Rpc*
+fserror(Rpc *rpc, char* fmt, ...)
+{
+	va_list arg;
+	char *c;
+
+	va_start(arg, fmt);
+	c = (char*)rpc->data;
+	vseprint(c, c+sizeof(rpc->data), fmt, arg);
+	va_end(arg);
+	rpc->r.type = Rerror;
+	rpc->r.ename = (char*)rpc->data;
+	return rpc;
+}
+
+static Rpc*
+fsversion(Rpc *r)
+{
+	if(r->t.msize < 256)
+		return fserror(r, Etoosmall);
+	if(strncmp(r->t.version, "9P2000", 6) != 0)
+		return fserror(r, "wrong version");
+	if(r->t.msize < msgsize)
+		msgsize = r->t.msize;
+	r->r.msize = msgsize;
+	r->r.version = "9P2000";
+	return r;
+}
+
+static Rpc*
+fsattach(Rpc *r)
+{
+	static int already;
+
+	/* Reload user because at boot it could be still none */
+	user=getuser();
+	if(already++ > 0 && strcmp(r->t.uname, user) != 0)
+		return fserror(r, Eperm);
+	if(r->fid == nil)
+		return fserror(r, Einuse);
+
+	r->r.qid.type = QTDIR;
+	r->r.qid.path = fsops->qid;
+	r->r.qid.vers = 0;
+	r->fid->qid = r->r.qid;
+	return r;
+}
+
+static Rpc*
+fswalk(Rpc *r)
+{
+	int i;
+	Fid *nfid, *ofid;
+
+	if(r->fid->omode != ONONE)
+		return fserror(r, Eisopen);
+
+	nfid = nil;
+	ofid = r->fid;
+	if(r->t.newfid != r->t.fid){
+		nfid = getfid(r->t.newfid, 1);
+		if(nfid == nil)
+			return fserror(r, Einuse);
+		nfid->qid = r->fid->qid;
+		if(fsops->clone != nil)
+			fsops->clone(fsops, ofid, nfid);
+		else
+			nfid->aux = r->fid->aux;
+		r->fid = nfid;
+	}
+	r->r.nwqid = 0;
+	for(i = 0; i < r->t.nwname; i++)
+		if(fsops->walk(fsops, r->fid, r->t.wname[i]) < 0)
+			break;
+		else
+			r->r.wqid[i] = r->fid->qid;
+	r->r.nwqid = i;
+	if(i != r->t.nwname && r->t.nwname > 0){
+		if(nfid != nil)
+			freefid(nfid);
+		r->fid = ofid;
+	}
+	if(i == 0 && r->t.nwname > 0)
+		return fserror(r, "%r");
+	return r;
+}
+
+static void
+fsioproc(void* a)
+{
+	int32_t rc;
+	Channel *p = a;
+	Rpc *rpc;
+	Fcall *t, *r;
+	Fid *fid;
+
+	threadsetname("fsioproc");
+	dprint(2, "%s: fsioproc pid %d\n", argv0, getpid());
+	while((rpc = recvp(p)) != nil){
+		t = &rpc->t;
+		r = &rpc->r;
+		fid = rpc->fid;
+		rc = -1;
+		dprint(2, "%s: fsioproc pid %d: req %d\n", argv0, getpid(), t->type);
+		switch(t->type){
+		case Topen:
+			rc = fsops->open(fsops, fid, t->mode);
+			if(rc >= 0){
+				r->iounit = 0;
+				r->qid = fid->qid;
+				fid->omode = t->mode & 3;
+			}
+			break;
+		case Tread:
+			rc = fsops->read(fsops, fid, r->data, t->count, t->offset);
+			if(rc >= 0){
+				if(rc > t->count)
+					print("%s: bug: read %ld bytes > %u wanted\n",
+						argv0, rc, t->count);
+				r->count = rc;
+			}
+			/*
+			 * TODO: if we encounter a long run of continuous read
+			 * errors, we should do something more drastic so that
+			 * our caller doesn't just spin its wheels forever.
+			 */
+			break;
+		case Twrite:
+			rc = fsops->write(fsops, fid, t->data, t->count, t->offset);
+			r->count = rc;
+			break;
+		default:
+			sysfatal("fsioproc: bad type");
+		}
+		if(rc < 0)
+			sendp(outc, fserror(rpc, "%r"));
+		else
+			sendp(outc, rpc);
+		sendp(endc, p);
+	}
+	chanfree(p);
+	dprint(2, "%s: fsioproc %d exiting\n", argv0, getpid());
+	threadexits(nil);
+}
+
+static Rpc*
+fsopen(Rpc *r)
+{
+	Channel *p;
+
+	if(r->fid->omode != ONONE)
+		return fserror(r, Eisopen);
+	if((r->t.mode & 3) != OREAD && (r->fid->qid.type & QTDIR) != 0)
+		return fserror(r, Eperm);
+	p = recvp(procc);
+	sendp(p, r);
+	return nil;
+}
+
+int
+usbdirread(Usbfs*f, Qid q, char *data, int32_t cnt, int64_t off,
+	   Dirgen gen,
+	   void *arg)
+{
+	int i, n, nd;
+	char name[Namesz];
+	Dir d;
+
+	memset(&d, 0, sizeof(d));
+	d.name = name;
+	d.uid = d.gid = d.muid = user;
+	d.atime = time(nil);
+	d.mtime = epoch;
+	d.length = 0;
+	for(i = n = 0; gen(f, q, i, &d, arg) >= 0; i++){
+		if(usbfsdebug > 1)
+			fprint(2, "%s: dir %d q %#llx: %D\n", argv0, i, q.path, &d);
+		nd = convD2M(&d, (uint8_t*)data+n, cnt-n);
+		if(nd <= BIT16SZ)
+			break;
+		if(off > 0)
+			off -= nd;
+		else
+			n += nd;
+		d.name = name;
+		d.uid = d.gid = d.muid = user;
+		d.atime = time(nil);
+		d.mtime = epoch;
+		d.length = 0;
+	}
+	return n;
+}
+
+int32_t
+usbreadbuf(void *data, int32_t count, int64_t offset, void *buf, int32_t n)
+{
+	if(offset >= n)
+		return 0;
+	if(offset + count > n)
+		count = n - offset;
+	memmove(data, (char*)buf + offset, count);
+	return count;
+}
+
+static Rpc*
+fsread(Rpc *r)
+{
+	Channel *p;
+
+	if(r->fid->omode != OREAD && r->fid->omode != ORDWR)
+		return fserror(r, Eperm);
+	p = recvp(procc);
+	sendp(p, r);
+	return nil;
+}
+
+static Rpc*
+fswrite(Rpc *r)
+{
+	Channel *p;
+
+	if(r->fid->omode != OWRITE && r->fid->omode != ORDWR)
+		return fserror(r, Eperm);
+	p = recvp(procc);
+	sendp(p, r);
+	return nil;
+}
+
+static Rpc*
+fsclunk(Rpc *r)
+{
+	freefid(r->fid);
+	return r;
+}
+
+static Rpc*
+fsno(Rpc *r)
+{
+	return fserror(r, Eperm);
+}
+
+static Rpc*
+fsstat(Rpc *r)
+{
+	Dir d;
+	char name[Namesz];
+
+	memset(&d, 0, sizeof(d));
+	d.name = name;
+	d.uid = d.gid = d.muid = user;
+	d.atime = time(nil);
+	d.mtime = epoch;
+	d.length = 0;
+	if(fsops->stat(fsops, r->fid->qid, &d) < 0)
+		return fserror(r, "%r");
+	r->r.stat = (uint8_t*)r->data;
+	r->r.nstat = convD2M(&d, (uint8_t*)r->data, msgsize);
+	return r;
+}
+
+static Rpc*
+fsflush(Rpc *r)
+{
+	/*
+	 * Flag it as flushed and respond.
+	 * Either outproc will reply to the flushed request
+	 * before responding to flush, or it will never reply to it.
+	 * Note that we do NOT abort the ongoing I/O.
+	 * That might leave the affected endpoints in a failed
+	 * state. Instead, we pretend the request is aborted.
+	 *
+	 * Only open, read, and write are processed
+	 * by auxiliary processes and other requests wil never be
+	 * flushed in practice.
+	 */
+	flushrpc(r->t.oldtag);
+	return r;
+}
+
+Rpc* (*fscalls[])(Rpc*) = {
+	[Tversion] =	fsversion,
+	[Tauth] =		fsno,
+	[Tattach] =	fsattach,
+	[Twalk] =		fswalk,
+	[Topen] =		fsopen,
+	[Tcreate] =	fsno,
+	[Tread] =		fsread,
+	[Twrite] =	fswrite,
+	[Tclunk] =	fsclunk,
+	[Tremove] =	fsno,
+	[Tstat] =		fsstat,
+	[Twstat] =	fsno,
+	[Tflush] =	fsflush,
+};
+
+static void
+outproc(void*_1)
+{
+	static uint8_t buf[Bufsize];
+	Rpc *rpc;
+	int nw;
+	static int once = 0;
+
+	if(once++ != 0)
+		sysfatal("more than one outproc");
+	threadsetname("outproc");
+	for(;;){
+		do
+			rpc = recvp(outc);
+		while(rpc == nil);		/* a delayed reply */
+		if(rpc->t.tag == Dietag)
+			break;
+		if(rpc->flushed){
+			dprint(2, "outproc: tag %d flushed\n", rpc->t.tag);
+			freerpc(rpc);
+			continue;
+		}
+		dprint(2, "-> %F\n", &rpc->r);
+		nw = convS2M(&rpc->r, buf, sizeof(buf));
+		if(nw == sizeof(buf))
+			fprint(2, "%s: outproc: buffer is too small\n", argv0);
+		if(nw <= BIT16SZ)
+			fprint(2, "%s: conS2M failed\n", argv0);
+		else if(write(fsfd, buf, nw) != nw){
+			fprint(2, "%s: outproc: write: %r", argv0);
+			/* continue and let the reader abort us */
+		}
+		if(usbfsdebug > 1)
+			dump();
+		freerpc(rpc);
+	}
+	dprint(2, "%s: outproc: exiting\n", argv0);
+}
+
+static void
+usbfs(void*_1)
+{
+	Rpc *rpc;
+	int nr;
+	static int once = 0;
+
+	if(once++ != 0)
+		sysfatal("more than one usbfs proc");
+
+	threadsetname("usbfs");
+	outc = chancreate(sizeof(Rpc*), 1);
+	procc = chancreate(sizeof(Channel*), 0);
+	endc = chancreate(sizeof(Channel*), 0);
+	if(outc == nil || procc == nil || endc == nil)
+		sysfatal("chancreate: %r");
+	threadcreate(schedproc, nil, Stack);
+	proccreate(outproc, nil, Stack);
+	for(;;){
+		rpc = newrpc();
+		do{
+			nr = read9pmsg(fsfd, rpc->data, sizeof(rpc->data));
+		}while(nr == 0);
+		if(nr < 0){
+			dprint(2, "%s: usbfs: read: '%r'", argv0);
+			if(fsops->end != nil)
+				fsops->end(fsops);
+			else
+				closedev(fsops->dev);
+			rpc->t.tag = Dietag;
+			sendp(outc, rpc);
+			break;
+		}
+		if(convM2S((uint8_t*)rpc->data, nr, &rpc->t) <=0){
+			dprint(2, "%s: convM2S failed\n", argv0);
+			freerpc(rpc);
+			continue;
+		}
+		dprint(2, "<- %F\n", &rpc->t);
+		rpc->r.tag = rpc->t.tag;
+		rpc->r.type = rpc->t.type + 1;
+		rpc->r.fid = rpc->t.fid;
+		if(fscalls[rpc->t.type] == nil){
+			sendp(outc, fserror(rpc, Ebadcall));
+			continue;
+		}
+		if(rpc->t.fid != Nofid){
+			if(rpc->t.type == Tattach)
+				rpc->fid = getfid(rpc->t.fid, 1);
+			else
+				rpc->fid = getfid(rpc->t.fid, 0);
+			if(rpc->fid == nil){
+				sendp(outc, fserror(rpc, Ebadfid));
+				continue;
+			}
+		}
+		sendp(outc, fscalls[rpc->t.type](rpc));
+	}
+	dprint(2, "%s: ubfs: eof: exiting\n", argv0);
+}
+
+void
+usbfsinit(char* srv, char *mnt, Usbfs *f, int flag)
+{
+	int fd[2];
+	int sfd;
+	int afd;
+	char sfile[40];
+
+	fsops = f;
+	if(pipe(fd) < 0)
+		sysfatal("pipe: %r");
+	user = getuser();
+	epoch = time(nil);
+
+	fmtinstall('D', dirfmt);
+	fmtinstall('M', dirmodefmt);
+	fmtinstall('F', fcallfmt);
+	fsfd = fd[1];
+	procrfork(usbfs, nil, Stack, RFNAMEG);	/* no RFFDG */
+	if(srv != nil){
+		snprint(sfile, sizeof(sfile), "#s/%s", srv);
+		remove(sfile);
+		sfd = create(sfile, OWRITE, 0660);
+		if(sfd < 0)
+			sysfatal("post: %r");
+		snprint(sfile, sizeof(sfile), "%d", fd[0]);
+		if(write(sfd, sfile, strlen(sfile)) != strlen(sfile))
+			sysfatal("post: %r");
+		close(sfd);
+	}
+	if(mnt != nil){
+		sfd = dup(fd[0], -1);	/* debug */
+		afd = fauth(sfd, "");
+		if(afd >= 0)
+			sysfatal("authentication required??");
+		if(mount(sfd, -1, mnt, flag, "", 'M') < 0)
+			sysfatal("mount: %r");
+	}
+	close(fd[0]);
+}

--- a/sys/src/libusb/lib/fsdir.c
+++ b/sys/src/libusb/lib/fsdir.c
@@ -1,0 +1,428 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <fcall.h>
+#include <usb/usb.h>
+#include <usb/usbfs.h>
+
+typedef struct Rpc Rpc;
+
+enum
+{
+	Incr = 3,	/* increments for fs array */
+	Dtop = 0,	/* high 32 bits for / 	*/
+	Qdir = 0,	/* low 32 bits for /devdir */
+};
+
+QLock fslck;
+static Usbfs** fs;
+static int nfs;
+static int fsused;
+static int exitonclose = 1;
+
+void
+usbfsexits(int y)
+{
+	exitonclose = y;
+}
+
+static int
+qiddev(uint64_t path)
+{
+	return (int)(path>>32) & 0xFF;
+}
+
+static int
+qidfile(uint64_t path)
+{
+	return (int)(path & 0xFFFFFFFFULL);
+}
+
+static uint64_t
+mkqid(int qd, int qf)
+{
+	return ((uint64_t)qd << 32) | (uint64_t)qf;
+}
+
+void
+usbfsdirdump(void)
+{
+	int i;
+
+	qlock(&fslck);
+	fprint(2, "%s: fs list: (%d used %d total)\n", argv0, fsused, nfs);
+	for(i = 1; i < nfs; i++)
+		if(fs[i] != nil) {
+			if(fs[i]->dev != nil)
+				fprint(2, "%s\t%s dev %#p refs %ld\n",
+					argv0, fs[i]->name, fs[i]->dev, fs[i]->dev->Ref.ref);
+			else
+				fprint(2, "%s:\t%s\n", argv0, fs[i]->name);
+		}
+	qunlock(&fslck);
+}
+
+void
+usbfsadd(Usbfs *dfs)
+{
+	int i, j;
+
+	dprint(2, "%s: fsadd %s\n", argv0, dfs->name);
+	qlock(&fslck);
+	for(i = 1; i < nfs; i++)
+		if(fs[i] == nil)
+			break;
+	if(i >= nfs){
+		if((nfs%Incr) == 0){
+			fs = realloc(fs, sizeof(Usbfs*) * (nfs+Incr));
+			if(fs == nil)
+				sysfatal("realloc: %r");
+			for(j = nfs; j < nfs+Incr; j++)
+				fs[j] = nil;
+		}
+		if(nfs == 0)	/* do not use entry 0 */
+			nfs++;
+		fs[nfs++] = dfs;
+	}else
+		fs[i] = dfs;
+	dfs->qid = mkqid(i, 0);
+	fsused++;
+	qunlock(&fslck);
+}
+
+static void
+usbfsdelnth(int i)
+{
+	if(fs[i] != nil){
+		dprint(2, "%s: fsdel %s", argv0, fs[i]->name);
+		if(fs[i]->dev != nil){
+			dprint(2, " dev %#p ref %ld\n",
+				fs[i]->dev, fs[i]->dev->Ref.ref);
+		}else
+			dprint(2, "no dev\n");
+		if(fs[i]->end != nil)
+			fs[i]->end(fs[i]);
+		closedev(fs[i]->dev);
+		fsused--;
+	}
+	fs[i] = nil;
+	if(fsused == 0 && exitonclose != 0){
+		fprint(2, "%s: all file systems gone: exiting\n", argv0);
+		threadexitsall(nil);
+	}
+}
+
+void
+usbfsdel(Usbfs *dfs)
+{
+	int i;
+
+	qlock(&fslck);
+	for(i = 0; i < nfs; i++)
+		if(dfs == nil || fs[i] == dfs){
+			usbfsdelnth(i);
+			if(dfs != nil)
+				break;
+		}
+	qunlock(&fslck);
+}
+
+static void
+fsend(Usbfs*_1)
+{
+	dprint(2, "%s: fsend\n", argv0);
+	usbfsdel(nil);
+}
+
+void
+usbfsgone(char *dir)
+{
+	int i;
+
+	qlock(&fslck);
+	/* devices may have more than one fs */
+	for(i = 0; i < nfs; i++)
+		if(fs[i] != nil && fs[i]->dev != nil)
+		if(strcmp(fs[i]->dev->dir, dir) == 0)
+			usbfsdelnth(i);
+	qunlock(&fslck);
+}
+
+static void
+fsclone(Usbfs*_1, Fid *o, Fid *n)
+{
+	int qd;
+	Dev *dev;
+	void (*xfsclone)(Usbfs *fs, Fid *of, Fid *nf);
+
+	xfsclone = nil;
+	dev = nil;
+	qd = qiddev(o->qid.path);
+	qlock(&fslck);
+	if(qd != Dtop && fs[qd] != nil && fs[qd]->clone != nil){
+		dev = fs[qd]->dev;
+		if(dev != nil)
+			incref(&dev->Ref);
+		xfsclone = fs[qd]->clone;
+	}
+	qunlock(&fslck);
+	if(xfsclone != nil){
+		xfsclone(fs[qd], o, n);
+	}
+	if(dev != nil)
+		closedev(dev);
+}
+
+static int
+fswalk(Usbfs*_1, Fid *fid, char *name)
+{
+	Qid q;
+	int qd, qf;
+	int i;
+	int rc;
+	Dev *dev;
+	Dir d;
+	int (*xfswalk)(Usbfs *fs, Fid *f, char *name);
+
+	q = fid->qid;
+	qd = qiddev(q.path);
+	qf = qidfile(q.path);
+
+	q.type = QTDIR;
+	q.vers = 0;
+	if(strcmp(name, "..") == 0)
+		if(qd == Dtop || qf == Qdir){
+			q.path = mkqid(Dtop, Qdir);
+			fid->qid = q;
+			return 0;
+		}
+	if(qd != 0){
+		qlock(&fslck);
+		if(fs[qd] == nil){
+			qunlock(&fslck);
+			werrstr(Eio);
+			return -1;
+		}
+		dev = fs[qd]->dev;
+		if(dev != nil)
+			incref(&dev->Ref);
+		xfswalk = fs[qd]->walk;
+		qunlock(&fslck);
+		rc = xfswalk(fs[qd], fid, name);
+		if(dev != nil)
+			closedev(dev);
+		return rc;
+	}
+	qlock(&fslck);
+	for(i = 0; i < nfs; i++)
+		if(fs[i] != nil && strcmp(name, fs[i]->name) == 0){
+			q.path = mkqid(i, Qdir);
+			fs[i]->stat(fs[i], q, &d); /* may be a file */
+			fid->qid = d.qid;
+			qunlock(&fslck);
+			return 0;
+		}
+	qunlock(&fslck);
+	werrstr(Enotfound);
+	return -1;
+}
+
+static int
+fsopen(Usbfs*_1, Fid *fid, int mode)
+{
+	int qd;
+	int rc;
+	Dev *dev;
+	int (*xfsopen)(Usbfs *fs, Fid *f, int mode);
+
+	qd = qiddev(fid->qid.path);
+	if(qd == Dtop)
+		return 0;
+	qlock(&fslck);
+	if(fs[qd] == nil){
+		qunlock(&fslck);
+		werrstr(Eio);
+		return -1;
+	}
+	dev = fs[qd]->dev;
+	if(dev != nil)
+		incref(&dev->Ref);
+	xfsopen = fs[qd]->open;
+	qunlock(&fslck);
+	if(xfsopen != nil)
+		rc = xfsopen(fs[qd], fid, mode);
+	else
+		rc = 0;
+	if(dev != nil)
+		closedev(dev);
+	return rc;
+}
+
+static int
+dirgen(Usbfs*_1, Qid _2, int n, Dir *d, void *_3)
+{
+	int i;
+	Dev *dev;
+	char *nm;
+
+	qlock(&fslck);
+	for(i = 0; i < nfs; i++)
+		if(fs[i] != nil && n-- == 0){
+			d->qid.type = QTDIR;
+			d->qid.path = mkqid(i, Qdir);
+			d->qid.vers = 0;
+			dev = fs[i]->dev;
+			if(dev != nil)
+				incref(&dev->Ref);
+			nm = d->name;
+			fs[i]->stat(fs[i], d->qid, d);
+			d->name = nm;
+			strncpy(d->name, fs[i]->name, Namesz);
+			if(dev != nil)
+				closedev(dev);
+			qunlock(&fslck);
+			return 0;
+		}
+	qunlock(&fslck);
+	return -1;
+}
+
+static int32_t
+fsread(Usbfs*_1, Fid *fid, void *data, int32_t cnt, int64_t off)
+{
+	int qd;
+	int rc;
+	Dev *dev;
+	Qid q;
+	int32_t (*xfsread)(Usbfs *fs, Fid *f, void *data, int32_t count,
+			   int64_t );
+
+	q = fid->qid;
+	qd = qiddev(q.path);
+	if(qd == Dtop)
+		return usbdirread(nil, q, data, cnt, off, dirgen, nil);
+	qlock(&fslck);
+	if(fs[qd] == nil){
+		qunlock(&fslck);
+		werrstr(Eio);
+		return -1;
+	}
+	dev = fs[qd]->dev;
+	if(dev != nil)
+		incref(&dev->Ref);
+	xfsread = fs[qd]->read;
+	qunlock(&fslck);
+	rc = xfsread(fs[qd], fid, data, cnt, off);
+	if(dev != nil)
+		closedev(dev);
+	return rc;
+}
+
+static int32_t
+fswrite(Usbfs*_1, Fid *fid, void *data, int32_t cnt, int64_t off)
+{
+	int qd;
+	int rc;
+	Dev *dev;
+	int32_t (*xfswrite)(Usbfs *fs, Fid *f, void *data, int32_t count,
+			    int64_t );
+
+	qd = qiddev(fid->qid.path);
+	if(qd == Dtop)
+		sysfatal("fswrite: not for usbd /");
+	qlock(&fslck);
+	if(fs[qd] == nil){
+		qunlock(&fslck);
+		werrstr(Eio);
+		return -1;
+	}
+	dev = fs[qd]->dev;
+	if(dev != nil)
+		incref(&dev->Ref);
+	xfswrite = fs[qd]->write;
+	qunlock(&fslck);
+	rc = xfswrite(fs[qd], fid, data, cnt, off);
+	if(dev != nil)
+		closedev(dev);
+	return rc;
+}
+
+
+static void
+fsclunk(Usbfs*_1, Fid* fid)
+{
+	int qd;
+	Dev *dev;
+	void (*xfsclunk)(Usbfs *fs, Fid *f);
+
+	dev = nil;
+	qd = qiddev(fid->qid.path);
+	qlock(&fslck);
+	if(qd != Dtop && fs[qd] != nil){
+		dev=fs[qd]->dev;
+		if(dev != nil)
+			incref(&dev->Ref);
+		xfsclunk = fs[qd]->clunk;
+	}else
+		xfsclunk = nil;
+	qunlock(&fslck);
+	if(xfsclunk != nil){
+		xfsclunk(fs[qd], fid);
+	}
+	if(dev != nil)
+		closedev(dev);
+}
+
+static int
+fsstat(Usbfs*_1, Qid qid, Dir *d)
+{
+	int qd;
+	int rc;
+	Dev *dev;
+	int (*xfsstat)(Usbfs *fs, Qid q, Dir *d);
+
+	qd = qiddev(qid.path);
+	if(qd == Dtop){
+		d->qid = qid;
+		d->name = "usb";
+		d->length = 0;
+		d->mode = 0555|DMDIR;
+		return 0;
+	}
+	qlock(&fslck);
+	if(fs[qd] == nil){
+		qunlock(&fslck);
+		werrstr(Eio);
+		return -1;
+	}
+	xfsstat = fs[qd]->stat;
+	dev = fs[qd]->dev;
+	if(dev != nil)
+		incref(&dev->Ref);
+	qunlock(&fslck);
+	rc = xfsstat(fs[qd], qid, d);
+	if(dev != nil)
+		closedev(dev);
+	return rc;
+}
+
+Usbfs usbdirfs =
+{
+	.walk = fswalk,
+	.clone = fsclone,
+	.clunk = fsclunk,
+	.open = fsopen,
+	.read = fsread,
+	.write = fswrite,
+	.stat = fsstat,
+	.end = fsend,
+};

--- a/sys/src/libusb/lib/parse.c
+++ b/sys/src/libusb/lib/parse.c
@@ -1,0 +1,280 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <bio.h>
+#include <usb/usb.h>
+
+int
+parsedev(Dev *xd, uint8_t *b, int n)
+{
+	Usbdev *d;
+	DDev *dd;
+	char *hd;
+
+	d = xd->usb;
+	assert(d != nil);
+	dd = (DDev*)b;
+	if(usbdebug>1){
+		hd = hexstr(b, Ddevlen);
+		fprint(2, "%s: parsedev %s: %s\n", argv0, xd->dir, hd);
+		free(hd);
+	}
+	if(dd->bLength < Ddevlen){
+		werrstr("short dev descr. (%d < %d)", dd->bLength, Ddevlen);
+		return -1;
+	}
+	if(dd->bDescriptorType != Ddev){
+		werrstr("%d is not a dev descriptor", dd->bDescriptorType);
+		return -1;
+	}
+	d->csp = CSP(dd->bDevClass, dd->bDevSubClass, dd->bDevProtocol);
+	d->ep[0]->maxpkt = xd->maxpkt = dd->bMaxPacketSize0;
+	d->class = dd->bDevClass;
+	d->nconf = dd->bNumConfigurations;
+	if(d->nconf == 0)
+		dprint(2, "%s: %s: no configurations\n", argv0, xd->dir);
+	d->vid = GET2(dd->idVendor);
+	d->did = GET2(dd->idProduct);
+	d->dno = GET2(dd->bcdDev);
+	d->vsid = dd->iManufacturer;
+	d->psid = dd->iProduct;
+	d->ssid = dd->iSerialNumber;
+	if(n > Ddevlen && usbdebug>1)
+		fprint(2, "%s: %s: parsedev: %d bytes left",
+			argv0, xd->dir, n - Ddevlen);
+	return Ddevlen;
+}
+
+static int
+parseiface(Usbdev *d, Conf *c, uint8_t *b, int n, Iface **ipp, Altc **app)
+{
+	int class, subclass, proto;
+	int ifid, altid;
+	DIface *dip;
+	Iface *ip;
+
+	assert(d != nil && c != nil);
+	if(n < Difacelen){
+		werrstr("short interface descriptor");
+		return -1;
+	}
+	dip = (DIface *)b;
+	ifid = dip->bInterfaceNumber;
+	if(ifid < 0 || ifid >= nelem(c->iface)){
+		werrstr("bad interface number %d", ifid);
+		return -1;
+	}
+	if(c->iface[ifid] == nil)
+		c->iface[ifid] = emallocz(sizeof(Iface), 1);
+	ip = c->iface[ifid];
+	class = dip->bInterfaceClass;
+	subclass = dip->bInterfaceSubClass;
+	proto = dip->bInterfaceProtocol;
+	ip->csp = CSP(class, subclass, proto);
+	if(d->csp == 0)				/* use csp from 1st iface */
+		d->csp = ip->csp;		/* if device has none */
+	if(d->class == 0)
+		d->class = class;
+	ip->id = ifid;
+	if(c == d->conf[0] && ifid == 0)	/* ep0 was already there */
+		d->ep[0]->iface = ip;
+	altid = dip->bAlternateSetting;
+	if(altid < 0 || altid >= nelem(ip->altc)){
+		werrstr("bad alternate conf. number %d", altid);
+		return -1;
+	}
+	if(ip->altc[altid] == nil)
+		ip->altc[altid] = emallocz(sizeof(Altc), 1);
+	*ipp = ip;
+	*app = ip->altc[altid];
+	return Difacelen;
+}
+
+extern Ep* mkep(Usbdev *, int);
+
+static int
+parseendpt(Usbdev *d, Conf *c, Iface *ip, Altc *altc, uint8_t *b, int n,
+	   Ep **epp)
+{
+	int i, dir, epid;
+	Ep *ep;
+	DEp *dep;
+
+	assert(d != nil && c != nil && ip != nil && altc != nil);
+	if(n < Deplen){
+		werrstr("short endpoint descriptor");
+		return -1;
+	}
+	dep = (DEp *)b;
+	altc->attrib = dep->bmAttributes;	/* here? */
+	altc->interval = dep->bInterval;
+
+	epid = dep->bEndpointAddress & 0xF;
+	assert(epid < nelem(d->ep));
+	if(dep->bEndpointAddress & 0x80)
+		dir = Ein;
+	else
+		dir = Eout;
+	ep = d->ep[epid];
+	if(ep == nil){
+		ep = mkep(d, epid);
+		ep->dir = dir;
+	}else if((ep->addr & 0x80) != (dep->bEndpointAddress & 0x80))
+		ep->dir = Eboth;
+	ep->maxpkt = GET2(dep->wMaxPacketSize);
+	ep->ntds = 1 + ((ep->maxpkt >> 11) & 3);
+	ep->maxpkt &= 0x7FF;
+	ep->addr = dep->bEndpointAddress;
+	ep->type = dep->bmAttributes & 0x03;
+	ep->isotype = (dep->bmAttributes>>2) & 0x03;
+	ep->conf = c;
+	ep->iface = ip;
+	for(i = 0; i < nelem(ip->ep); i++)
+		if(ip->ep[i] == nil)
+			break;
+	if(i == nelem(ip->ep)){
+		werrstr("parseendpt: bug: too many end points on interface "
+			"with csp %#lx", ip->csp);
+		fprint(2, "%s: %r\n", argv0);
+		return -1;
+	}
+	*epp = ip->ep[i] = ep;
+	return Dep;
+}
+
+static char*
+dname(int dtype)
+{
+	switch(dtype){
+	case Ddev:	return "device";
+	case Dconf: 	return "config";
+	case Dstr: 	return "string";
+	case Diface:	return "interface";
+	case Dep:	return "endpoint";
+	case Dreport:	return "report";
+	case Dphysical:	return "phys";
+	default:	return "desc";
+	}
+}
+
+int
+parsedesc(Usbdev *d, Conf *c, uint8_t *b, int n)
+{
+	int	len, nd, tot;
+	Iface	*ip;
+	Ep 	*ep;
+	Altc	*altc;
+	char	*hd;
+
+	assert(d != nil && c != nil);
+	tot = 0;
+	ip = nil;
+	ep = nil;
+	altc = nil;
+	for(nd = 0; nd < nelem(d->ddesc); nd++)
+		if(d->ddesc[nd] == nil)
+			break;
+
+	while(n > 2 && b[0] != 0 && b[0] <= n){
+		len = b[0];
+		if(usbdebug>1){
+			hd = hexstr(b, len);
+			fprint(2, "%s:\t\tparsedesc %s %x[%d] %s\n",
+				argv0, dname(b[1]), b[1], b[0], hd);
+			free(hd);
+		}
+		switch(b[1]){
+		case Ddev:
+		case Dconf:
+			werrstr("unexpected descriptor %d", b[1]);
+			ddprint(2, "%s\tparsedesc: %r", argv0);
+			break;
+		case Diface:
+			if(parseiface(d, c, b, n, &ip, &altc) < 0){
+				ddprint(2, "%s\tparsedesc: %r\n", argv0);
+				return -1;
+			}
+			break;
+		case Dep:
+			if(ip == nil || altc == nil){
+				werrstr("unexpected endpoint descriptor");
+				break;
+			}
+			if(parseendpt(d, c, ip, altc, b, n, &ep) < 0){
+				ddprint(2, "%s\tparsedesc: %r\n", argv0);
+				return -1;
+			}
+			break;
+		default:
+			if(nd == nelem(d->ddesc)){
+				fprint(2, "%s: parsedesc: too many "
+					"device-specific descriptors for device"
+					" %s %s\n",
+					argv0, d->vendor, d->product);
+				break;
+			}
+			d->ddesc[nd] = emallocz(sizeof(Desc)+b[0], 0);
+			d->ddesc[nd]->iface = ip;
+			d->ddesc[nd]->ep = ep;
+			d->ddesc[nd]->altc = altc;
+			d->ddesc[nd]->conf = c;
+			memmove(&d->ddesc[nd]->data, b, len);
+			++nd;
+		}
+		n -= len;
+		b += len;
+		tot += len;
+	}
+	return tot;
+}
+
+int
+parseconf(Usbdev *d, Conf *c, uint8_t *b, int n)
+{
+	DConf* dc;
+	int	l;
+	int	nr;
+	char	*hd;
+
+	assert(d != nil && c != nil);
+	dc = (DConf*)b;
+	if(usbdebug>1){
+		hd = hexstr(b, Dconflen);
+		fprint(2, "%s:\tparseconf  %s\n", argv0, hd);
+		free(hd);
+	}
+	if(dc->bLength < Dconflen){
+		werrstr("short configuration descriptor");
+		return -1;
+	}
+	if(dc->bDescriptorType != Dconf){
+		werrstr("not a configuration descriptor");
+		return -1;
+	}
+	c->cval = dc->bConfigurationValue;
+	c->attrib = dc->bmAttributes;
+	c->milliamps = dc->MaxPower*2;
+	l = GET2(dc->wTotalLength);
+	if(n < l){
+		werrstr("truncated configuration info");
+		return -1;
+	}
+	n -= Dconflen;
+	b += Dconflen;
+	nr = 0;
+	if(n > 0 && (nr=parsedesc(d, c, b, n)) < 0)
+		return -1;
+	n -= nr;
+	if(n > 0 && usbdebug>1)
+		fprint(2, "%s:\tparseconf: %d bytes left\n", argv0, n);
+	return l;
+}

--- a/sys/src/libusb/print/print.c
+++ b/sys/src/libusb/print/print.c
@@ -1,0 +1,100 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+/*
+ * usb/print - usb printer file server
+ * BUG: Assumes the printer will be always connected and
+ * not hot-plugged. (Otherwise should stay running and
+ * listen to errors to keep the device there as long as it has
+ * not failed). Also, this is untested and done ad-hoc to
+ * replace the print script.
+ */
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <usb/usb.h>
+
+enum
+{
+	Qdir = 0,
+	Qctl,
+	Qraw,
+	Qdata,
+	Qmax,
+};
+
+int
+findendpoints(Dev *dev, int devid)
+{
+	Ep *ep;
+	Dev *d;
+	Usbdev *ud;
+	int i, epout;
+
+	epout = -1;
+	ud = dev->usb;
+	for(i = 0; i < nelem(ud->ep); i++){
+		if((ep = ud->ep[i]) == nil)
+			break;
+		if(ep->iface->csp != 0x020107)
+			continue;
+		if(ep->type == Ebulk && (ep->dir == Eboth || ep->dir == Eout))
+			if(epout == -1)
+				epout = ep->id;
+	}
+	dprint(2, "print: ep ids: out %d\n", epout);
+	if(epout == -1)
+		return -1;
+	d = openep(dev, epout);
+	if(d == nil){
+		fprint(2, "print: openep %d: %r\n", epout);
+		return -1;
+	}
+	opendevdata(d, OWRITE);
+	if(d->dfd < 0){
+		fprint(2, "print: open i/o ep data: %r\n");
+		closedev(d);
+		return -1;
+	}
+	dprint(2, "print: ep out %s\n", d->dir);
+	if(usbdebug > 1)
+		devctl(d, "debug 1");
+	devctl(d, "name lp%d", devid);
+	return 0;
+}
+
+static int
+usage(void)
+{
+	werrstr("usage: usb/print [-N id]");
+	return -1;
+}
+
+int
+printmain(Dev *dev, int argc, char **argv)
+{
+	int devid;
+
+	devid = dev->id;
+	ARGBEGIN{
+	case 'N':
+		devid = atoi(EARGF(usage()));
+		break;
+	default:
+		return usage();
+	}ARGEND
+	if(argc != 0)
+		return usage();
+
+	if(findendpoints(dev, devid) < 0){
+		werrstr("print: endpoints not found");
+		return -1;
+	}
+	return 0;
+}

--- a/sys/src/libusb/serial/ftdi.c
+++ b/sys/src/libusb/serial/ftdi.c
@@ -1,0 +1,971 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+/* Future Technology Devices International serial ports */
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <usb/usb.h>
+#include <usb/usbfs.h>
+#include <usb/serial.h>
+#include <usb/ftdi.h>
+
+/*
+ * BUG: This keeps growing, there has to be a better way, but without
+ * devices to try it...  We can probably simply look for FTDI in the
+ * string, or use regular expressions somehow.
+ */
+Cinfo ftinfo[] = {
+	{ FTVid, FTACTZWAVEDid },
+	{ FTSheevaVid, FTSheevaDid },
+	{ FTVid, FTOpenRDUltDid},
+	{ FTVid, FTIRTRANSDid },
+	{ FTVid, FTIPLUSDid },
+	{ FTVid, FTSIODid },
+	{ FTVid, FT8U232AMDid },
+	{ FTVid, FT8U232AMALTDid },
+	{ FTVid, FT8U2232CDid },
+	{ FTVid, FTRELAISDid },
+	{ INTERBIOMVid, INTERBIOMIOBRDDid },
+	{ INTERBIOMVid, INTERBIOMMINIIOBRDDid },
+	{ FTVid, FTXF632Did },
+	{ FTVid, FTXF634Did },
+	{ FTVid, FTXF547Did },
+	{ FTVid, FTXF633Did },
+	{ FTVid, FTXF631Did },
+	{ FTVid, FTXF635Did },
+	{ FTVid, FTXF640Did },
+	{ FTVid, FTXF642Did },
+	{ FTVid, FTDSS20Did },
+	{ FTNFRICVid, FTNFRICDid },
+	{ FTVid, FTVNHCPCUSBDDid },
+	{ FTVid, FTMTXORB0Did },
+	{ FTVid, FTMTXORB1Did },
+	{ FTVid, FTMTXORB2Did },
+	{ FTVid, FTMTXORB3Did },
+	{ FTVid, FTMTXORB4Did },
+	{ FTVid, FTMTXORB5Did },
+	{ FTVid, FTMTXORB6Did },
+	{ FTVid, FTPERLEULTRAPORTDid },
+	{ FTVid, FTPIEGROUPDid },
+	{ SEALEVELVid, SEALEVEL2101Did },
+	{ SEALEVELVid, SEALEVEL2102Did },
+	{ SEALEVELVid, SEALEVEL2103Did },
+	{ SEALEVELVid, SEALEVEL2104Did },
+	{ SEALEVELVid, SEALEVEL22011Did },
+	{ SEALEVELVid, SEALEVEL22012Did },
+	{ SEALEVELVid, SEALEVEL22021Did },
+	{ SEALEVELVid, SEALEVEL22022Did },
+	{ SEALEVELVid, SEALEVEL22031Did },
+	{ SEALEVELVid, SEALEVEL22032Did },
+	{ SEALEVELVid, SEALEVEL24011Did },
+	{ SEALEVELVid, SEALEVEL24012Did },
+	{ SEALEVELVid, SEALEVEL24013Did },
+	{ SEALEVELVid, SEALEVEL24014Did },
+	{ SEALEVELVid, SEALEVEL24021Did },
+	{ SEALEVELVid, SEALEVEL24022Did },
+	{ SEALEVELVid, SEALEVEL24023Did },
+	{ SEALEVELVid, SEALEVEL24024Did },
+	{ SEALEVELVid, SEALEVEL24031Did },
+	{ SEALEVELVid, SEALEVEL24032Did },
+	{ SEALEVELVid, SEALEVEL24033Did },
+	{ SEALEVELVid, SEALEVEL24034Did },
+	{ SEALEVELVid, SEALEVEL28011Did },
+	{ SEALEVELVid, SEALEVEL28012Did },
+	{ SEALEVELVid, SEALEVEL28013Did },
+	{ SEALEVELVid, SEALEVEL28014Did },
+	{ SEALEVELVid, SEALEVEL28015Did },
+	{ SEALEVELVid, SEALEVEL28016Did },
+	{ SEALEVELVid, SEALEVEL28017Did },
+	{ SEALEVELVid, SEALEVEL28018Did },
+	{ SEALEVELVid, SEALEVEL28021Did },
+	{ SEALEVELVid, SEALEVEL28022Did },
+	{ SEALEVELVid, SEALEVEL28023Did },
+	{ SEALEVELVid, SEALEVEL28024Did },
+	{ SEALEVELVid, SEALEVEL28025Did },
+	{ SEALEVELVid, SEALEVEL28026Did },
+	{ SEALEVELVid, SEALEVEL28027Did },
+	{ SEALEVELVid, SEALEVEL28028Did },
+	{ SEALEVELVid, SEALEVEL28031Did },
+	{ SEALEVELVid, SEALEVEL28032Did },
+	{ SEALEVELVid, SEALEVEL28033Did },
+	{ SEALEVELVid, SEALEVEL28034Did },
+	{ SEALEVELVid, SEALEVEL28035Did },
+	{ SEALEVELVid, SEALEVEL28036Did },
+	{ SEALEVELVid, SEALEVEL28037Did },
+	{ SEALEVELVid, SEALEVEL28038Did },
+	{ IDTECHVid, IDTECHIDT1221UDid },
+	{ OCTVid, OCTUS101Did },
+	{ FTVid, FTHETIRA1Did }, /* special quirk div = 240 baud = B38400 rtscts = 1 */
+	{ FTVid, FTUSBUIRTDid }, /* special quirk div = 77, baud = B38400 */
+	{ FTVid, PROTEGOSPECIAL1 },
+	{ FTVid, PROTEGOR2X0 },
+	{ FTVid, PROTEGOSPECIAL3 },
+	{ FTVid, PROTEGOSPECIAL4 },
+	{ FTVid, FTGUDEADSE808Did },
+	{ FTVid, FTGUDEADSE809Did },
+	{ FTVid, FTGUDEADSE80ADid },
+	{ FTVid, FTGUDEADSE80BDid },
+	{ FTVid, FTGUDEADSE80CDid },
+	{ FTVid, FTGUDEADSE80DDid },
+	{ FTVid, FTGUDEADSE80EDid },
+	{ FTVid, FTGUDEADSE80FDid },
+	{ FTVid, FTGUDEADSE888Did },
+	{ FTVid, FTGUDEADSE889Did },
+	{ FTVid, FTGUDEADSE88ADid },
+	{ FTVid, FTGUDEADSE88BDid },
+	{ FTVid, FTGUDEADSE88CDid },
+	{ FTVid, FTGUDEADSE88DDid },
+	{ FTVid, FTGUDEADSE88EDid },
+	{ FTVid, FTGUDEADSE88FDid },
+	{ FTVid, FTELVUO100Did },
+	{ FTVid, FTELVUM100Did },
+	{ FTVid, FTELVUR100Did },
+	{ FTVid, FTELVALC8500Did },
+	{ FTVid, FTPYRAMIDDid },
+	{ FTVid, FTELVFHZ1000PCDid },
+	{ FTVid, FTELVCLI7000Did },
+	{ FTVid, FTELVPPS7330Did },
+	{ FTVid, FTELVTFM100Did },
+	{ FTVid, FTELVUDF77Did },
+	{ FTVid, FTELVUIO88Did },
+	{ FTVid, FTELVUAD8Did },
+	{ FTVid, FTELVUDA7Did },
+	{ FTVid, FTELVUSI2Did },
+	{ FTVid, FTELVT1100Did },
+	{ FTVid, FTELVPCD200Did },
+	{ FTVid, FTELVULA200Did },
+	{ FTVid, FTELVCSI8Did },
+	{ FTVid, FTELVEM1000DLDid },
+	{ FTVid, FTELVPCK100Did },
+	{ FTVid, FTELVRFP500Did },
+	{ FTVid, FTELVFS20SIGDid },
+	{ FTVid, FTELVWS300PCDid },
+	{ FTVid, FTELVFHZ1300PCDid },
+	{ FTVid, FTELVWS500Did },
+	{ FTVid, LINXSDMUSBQSSDid },
+	{ FTVid, LINXMASTERDEVEL2Did },
+	{ FTVid, LINXFUTURE0Did },
+	{ FTVid, LINXFUTURE1Did },
+	{ FTVid, LINXFUTURE2Did },
+	{ FTVid, FTCCSICDU200Did },
+	{ FTVid, FTCCSICDU401Did },
+	{ FTVid, INSIDEACCESSO },
+	{ INTREDidVid, INTREDidVALUECANDid },
+	{ INTREDidVid, INTREDidNEOVIDid },
+	{ FALCOMVid, FALCOMTWISTDid },
+	{ FALCOMVid, FALCOMSAMBADid },
+	{ FTVid, FTSUUNTOSPORTSDid },
+	{ FTVid, FTRMCANVIEWDid },
+	{ BANDBVid, BANDBUSOTL4Did },
+	{ BANDBVid, BANDBUSTL4Did },
+	{ BANDBVid, BANDBUSO9ML2Did },
+	{ FTVid, EVERECOPROCDSDid },
+	{ FTVid, FT4NGALAXYDE0Did },
+	{ FTVid, FT4NGALAXYDE1Did },
+	{ FTVid, FT4NGALAXYDE2Did },
+	{ FTVid, XSENSCONVERTER0Did },
+	{ FTVid, XSENSCONVERTER1Did },
+	{ FTVid, XSENSCONVERTER2Did },
+	{ FTVid, XSENSCONVERTER3Did },
+	{ FTVid, XSENSCONVERTER4Did },
+	{ FTVid, XSENSCONVERTER5Did },
+	{ FTVid, XSENSCONVERTER6Did },
+	{ FTVid, XSENSCONVERTER7Did },
+	{ MOBILITYVid, MOBILITYUSBSERIALDid },
+	{ FTVid, FTACTIVEROBOTSDid },
+	{ FTVid, FTMHAMKWDid },
+	{ FTVid, FTMHAMYSDid },
+	{ FTVid, FTMHAMY6Did },
+	{ FTVid, FTMHAMY8Did },
+	{ FTVid, FTMHAMICDid },
+	{ FTVid, FTMHAMDB9Did },
+	{ FTVid, FTMHAMRS232Did },
+	{ FTVid, FTMHAMY9Did },
+	{ FTVid, FTTERATRONIKVCPDid },
+	{ FTVid, FTTERATRONIKD2XXDid },
+	{ EVOLUTIONVid, EVOLUTIONER1Did },
+	{ FTVid, FTARTEMISDid },
+	{ FTVid, FTATIKATK16Did },
+	{ FTVid, FTATIKATK16CDid },
+	{ FTVid, FTATIKATK16HRDid },
+	{ FTVid, FTATIKATK16HRCDid },
+	{ KOBILVid, KOBILCONVB1Did },
+	{ KOBILVid, KOBILCONVKAANDid },
+	{ POSIFLEXVid, POSIFLEXPP7000Did },
+	{ FTVid, FTTTUSBDid },
+	{ FTVid, FTECLOCOM1WIREDid },
+	{ FTVid, FTWESTREXMODEL777Did },
+	{ FTVid, FTWESTREXMODEL8900FDid },
+	{ FTVid, FTPCDJDAC2Did },
+	{ FTVid, FTRRCIRKITSLOCOBUFFERDid },
+	{ FTVid, FTASKRDR400Did },
+	{ ICOMID1Vid, ICOMID1Did },
+	{ PAPOUCHVid, PAPOUCHTMUDid },
+	{ FTVid, FTACGHFDUALDid },
+	{ FT8U232AMDid, FT4232HDid },
+	{ FTVid, AMONKEYDid },
+	{ 0,	0 },
+};
+
+enum {
+	Packsz		= 64,		/* default size */
+	Maxpacksz	= 512,
+	Bufsiz		= 4 * 1024,
+};
+
+static int
+ftdiread(Serialport *p, int index, int req, uint8_t *buf, int len)
+{
+	int res;
+	Serial *ser;
+
+	ser = p->s;
+
+	if(req != FTGETE2READ)
+		index |= p->interfc + 1;
+	dsprint(2, "serial: ftdiread %#p [%d] req: %#x val: %#x idx:%d buf:%p len:%d\n",
+		p, p->interfc, req, 0, index, buf, len);
+	res = usbcmd(ser->dev,  Rd2h | Rftdireq | Rdev, req, 0, index, buf, len);
+	dsprint(2, "serial: ftdiread res:%d\n", res);
+	return res;
+}
+
+static int
+ftdiwrite(Serialport *p, int val, int index, int req)
+{
+	int res;
+	Serial *ser;
+
+	ser = p->s;
+
+	if(req != FTGETE2READ || req != FTSETE2ERASE || req != FTSETBAUDRATE)
+		index |= p->interfc + 1;
+	dsprint(2, "serial: ftdiwrite %#p [%d] req: %#x val: %#x idx:%d\n",
+		p, p->interfc, req, val, index);
+	res = usbcmd(ser->dev, Rh2d | Rftdireq | Rdev, req, val, index, nil, 0);
+	dsprint(2, "serial: ftdiwrite res:%d\n", res);
+	return res;
+}
+
+static int
+ftmodemctl(Serialport *p, int set)
+{
+	if(set == 0){
+		p->mctl = 0;
+		ftdiwrite(p, 0, 0, FTSETMODEMCTRL);
+		return 0;
+	}
+	p->mctl = 1;
+	ftdiwrite(p, 0, FTRTSCTSHS, FTSETFLOWCTRL);
+	return 0;
+}
+
+static uint16_t
+ft232ambaudbase2div(int baud, int base)
+{
+	int divisor3;
+	uint16_t divisor;
+
+	divisor3 = (base / 2) / baud;
+	if((divisor3 & 7) == 7)
+		divisor3++;			/* round x.7/8 up to x+1 */
+	divisor = divisor3 >> 3;
+	divisor3 &= 7;
+
+	if(divisor3 == 1)
+		divisor |= 0xc000;		/*	0.125 */
+	else if(divisor3 >= 4)
+		divisor |= 0x4000;		/*	0.5	*/
+	else if(divisor3 != 0)
+		divisor |= 0x8000;		/*	0.25	*/
+	if( divisor == 1)
+		divisor = 0;		/* special case for maximum baud rate */
+	return divisor;
+}
+
+enum{
+	ClockNew	= 48000000,
+	ClockOld	= 12000000 / 16,
+	HetiraDiv	= 240,
+	UirtDiv		= 77,
+};
+
+static uint16_t
+ft232ambaud2div(int baud)
+{
+	return ft232ambaudbase2div(baud, ClockNew);
+}
+
+static uint32_t divfrac[8] = { 0, 3, 2, 4, 1, 5, 6, 7};
+
+static uint32_t
+ft232bmbaudbase2div(int baud, int base)
+{
+	int divisor3;
+	uint32_t divisor;
+
+	divisor3 = (base / 2) / baud;
+	divisor = divisor3 >> 3 | divfrac[divisor3 & 7] << 14;
+
+	/* Deal with special cases for highest baud rates. */
+	if( divisor == 1)
+		divisor = 0;			/* 1.0 */
+	else if( divisor == 0x4001)
+		divisor = 1;			/* 1.5 */
+	return divisor;
+}
+
+static uint32_t
+ft232bmbaud2div (int baud)
+{
+	return ft232bmbaudbase2div (baud, ClockNew);
+}
+
+static int
+customdiv(Serial *ser)
+{
+	if(ser->dev->usb->vid == FTVid && ser->dev->usb->did == FTHETIRA1Did)
+		return HetiraDiv;
+	else if(ser->dev->usb->vid == FTVid && ser->dev->usb->did == FTUSBUIRTDid)
+		return UirtDiv;
+
+	fprint(2, "serial: weird custom divisor\n");
+	return 0;		/* shouldn't happen, break as much as I can */
+}
+
+static uint32_t
+ftbaudcalcdiv(Serial *ser, int baud)
+{
+	int cusdiv;
+	uint32_t divval;
+
+	if(baud == 38400 && (cusdiv = customdiv(ser)) != 0)
+		baud = ser->baudbase / cusdiv;
+
+	if(baud == 0)
+		baud = 9600;
+
+	switch(ser->type) {
+	case SIO:
+		switch(baud) {
+		case 300:
+			divval = FTb300;
+			break;
+		case 600:
+			divval = FTb600;
+			break;
+		case 1200:
+			divval = FTb1200;
+			break;
+		case 2400:
+			divval = FTb2400;
+			break;
+		case 4800:
+			divval = FTb4800;
+			break;
+		case 9600:
+			divval = FTb9600;
+			break;
+		case 19200:
+			divval = FTb19200;
+			break;
+		case 38400:
+			divval = FTb38400;
+			break;
+		case 57600:
+			divval = FTb57600;
+			break;
+		case 115200:
+			divval = FTb115200;
+			break;
+		default:
+			divval = FTb9600;
+			break;
+		}
+		break;
+	case FT8U232AM:
+		if(baud <= 3000000)
+			divval = ft232ambaud2div(baud);
+		else
+			divval = ft232ambaud2div(9600);
+		break;
+	case FT232BM:
+	case FT2232C:
+	case FTKINDR:
+	case FT2232H:
+	case FT4232H:
+		if(baud <= 3000000)
+			divval = ft232bmbaud2div(baud);
+		else
+			divval = ft232bmbaud2div(9600);
+		break;
+	default:
+		divval = ft232bmbaud2div(9600);
+		break;
+	}
+	return divval;
+}
+
+static int
+ftsetparam(Serialport *p)
+{
+	int res;
+	uint16_t val;
+	uint32_t bauddiv;
+
+	val = 0;
+	if(p->stop == 1)
+		val |= FTSETDATASTOPBITS1;
+	else if(p->stop == 2)
+		val |= FTSETDATASTOPBITS2;
+	else if(p->stop == 15)
+		val |= FTSETDATASTOPBITS15;
+	switch(p->parity){
+	case 0:
+		val |= FTSETDATAParNONE;
+		break;
+	case 1:
+		val |= FTSETDATAParODD;
+		break;
+	case 2:
+		val |= FTSETDATAParEVEN;
+		break;
+	case 3:
+		val |= FTSETDATAParMARK;
+		break;
+	case 4:
+		val |= FTSETDATAParSPACE;
+		break;
+	};
+
+	dsprint(2, "serial: setparam\n");
+
+	res = ftdiwrite(p, val, 0, FTSETDATA);
+	if(res < 0)
+		return res;
+
+	res = ftmodemctl(p, p->mctl);
+	if(res < 0)
+		return res;
+
+	bauddiv = ftbaudcalcdiv(p->s, p->baud);
+	res = ftdiwrite(p, bauddiv, (bauddiv>>16) & 1, FTSETBAUDRATE);
+
+	dsprint(2, "serial: setparam res: %d\n", res);
+	return res;
+}
+
+static int
+hasjtag(Usbdev *udev)
+{
+	/* no string, for now, by default we detect no jtag */
+	if(udev->product != nil && cistrstr(udev->product, "jtag") != nil)
+		return 1;
+	return 0;
+}
+
+/* ser locked */
+static void
+ftgettype(Serial *ser)
+{
+	int i, outhdrsz, dno, pksz;
+	uint32_t baudbase;
+	Conf *cnf;
+
+	pksz = Packsz;
+	/* Assume it is not the original SIO device for now. */
+	baudbase = ClockNew / 2;
+	outhdrsz = 0;
+	dno = ser->dev->usb->dno;
+	cnf = ser->dev->usb->conf[0];
+	ser->nifcs = 0;
+	for(i = 0; i < Niface; i++)
+		if(cnf->iface[i] != nil)
+			ser->nifcs++;
+	if(ser->nifcs > 1) {
+		/*
+		 * Multiple interfaces.  default assume FT2232C,
+		 */
+		if(dno == 0x500)
+			ser->type = FT2232C;
+		else if(dno == 0x600)
+			ser->type = FTKINDR;
+		else if(dno == 0x700){
+			ser->type = FT2232H;
+			pksz = Maxpacksz;
+		} else if(dno == 0x800){
+			ser->type = FT4232H;
+			pksz = Maxpacksz;
+		} else
+			ser->type = FT2232C;
+
+		if(hasjtag(ser->dev->usb))
+			ser->jtag = 0;
+
+		/*
+		 * BM-type devices have a bug where dno gets set
+		 * to 0x200 when serial is 0.
+		 */
+		if(dno < 0x500)
+			fprint(2, "serial: warning: dno %d too low for "
+				"multi-interface device\n", dno);
+	} else if(dno < 0x200) {
+		/* Old device.  Assume it is the original SIO. */
+		ser->type = SIO;
+		baudbase = ClockOld/16;
+		outhdrsz = 1;
+	} else if(dno < 0x400)
+		/*
+		 * Assume its an FT8U232AM (or FT8U245AM)
+		 * (It might be a BM because of the iSerialNumber bug,
+		 * but it will still work as an AM device.)
+		 */
+		ser->type = FT8U232AM;
+	else			/* Assume it is an FT232BM (or FT245BM) */
+		ser->type = FT232BM;
+
+	ser->maxrtrans = ser->maxwtrans = pksz;
+	ser->baudbase = baudbase;
+	ser->outhdrsz = outhdrsz;
+	ser->inhdrsz = 2;
+
+	dsprint (2, "serial: detected type: %#x\n", ser->type);
+}
+
+int
+ftmatch(Serial *ser, char *info)
+{
+	Cinfo *ip;
+	char buf[50];
+
+	for(ip = ftinfo; ip->vid != 0; ip++){
+		snprint(buf, sizeof buf, "vid %#06x did %#06x", ip->vid, ip->did);
+		dsprint(2, "serial: %s %s\n", buf, info);
+		if(strstr(info, buf) != nil){
+			if(ser != nil){
+				qlock(&ser->QLock);
+				ftgettype(ser);
+				qunlock(&ser->QLock);
+			}
+			return 0;
+		}
+	}
+	return -1;
+}
+
+static int
+ftuseinhdr(Serialport *p, uint8_t *b)
+{
+	if(b[0] & FTICTS)
+		p->cts = 1;
+	else
+		p->cts = 0;
+	if(b[0] & FTIDSR)
+		p->dsr = 1;
+	else
+		p->dsr = 0;
+	if(b[0] & FTIRI)
+		p->ring = 1;
+	else
+		p->ring = 0;
+	if(b[0] & FTIRLSD)
+		p->rlsd = 1;
+	else
+		p->rlsd = 0;
+
+	if(b[1] & FTIOE)
+		p->novererr++;
+	if(b[1] & FTIPE)
+		p->nparityerr++;
+	if(b[1] & FTIFE)
+		p->nframeerr++;
+	if(b[1] & FTIBI)
+		p->nbreakerr++;
+	return 0;
+}
+
+static int
+ftsetouthdr(Serialport *p, uint8_t *b, int len)
+{
+	if(p->s->outhdrsz != 0)
+		b[0] = FTOPORT | (FTOLENMSK & len);
+	return p->s->outhdrsz;
+}
+
+static int
+wait4data(Serialport *p, uint8_t *data, int count)
+{
+	int d;
+	Serial *ser;
+
+	ser = p->s;
+
+	qunlock(&ser->QLock);
+	d = sendul(p->w4data, 1);
+	qlock(&ser->QLock);
+	if(d <= 0)
+		return -1;
+	if(p->ndata >= count)
+		p->ndata -= count;
+	else{
+		count = p->ndata;
+		p->ndata = 0;
+	}
+	assert(count >= 0);
+	assert(p->ndata >= 0);
+	memmove(data, p->data, count);
+	if(p->ndata != 0)
+		memmove(p->data, p->data+count, p->ndata);
+
+	recvul(p->gotdata);
+	return count;
+}
+
+static int
+wait4write(Serialport *p, uint8_t *data, int count)
+{
+	int off, fd;
+	uint8_t *b;
+	Serial *ser;
+
+	ser = p->s;
+
+	b = emallocz(count+ser->outhdrsz, 1);
+	off = ftsetouthdr(p, b, count);
+	memmove(b+off, data, count);
+
+	fd = p->epout->dfd;
+	qunlock(&ser->QLock);
+	count = write(fd, b, count+off);
+	qlock(&ser->QLock);
+	free(b);
+	return count;
+}
+
+typedef struct Packser Packser;
+struct Packser{
+	int	nb;
+	uint8_t	b[Bufsiz];
+};
+
+typedef struct Areader Areader;
+struct Areader{
+	Serialport	*p;
+	Channel	*c;
+};
+
+static void
+shutdownchan(Channel *c)
+{
+	Packser *bp;
+
+	while((bp=nbrecvp(c)) != nil)
+		free(bp);
+	chanfree(c);
+}
+
+int
+cpdata(Serial *ser, Serialport *port, uint8_t *out, uint8_t *in, int sz)
+{
+	int i, ncp, ntotcp, pksz;
+
+	pksz = ser->maxrtrans;
+	ntotcp = 0;
+
+	for(i = 0; i < sz; i+= pksz){
+		ftuseinhdr(port, in + i);
+		if(sz - i > pksz)
+			ncp = pksz - ser->inhdrsz;
+		else
+			ncp = sz - i - ser->inhdrsz;
+		memmove(out, in + i + ser->inhdrsz, ncp);
+		out += ncp;
+		ntotcp += ncp;
+	}
+	return ntotcp;
+}
+
+static void
+epreader(void *u)
+{
+	int dfd, rcount, cl, ntries, recov;
+	char err[40];
+	Areader *a;
+	Channel *c;
+	Packser *pk;
+	Serial *ser;
+	Serialport *p;
+
+	threadsetname("epreader proc");
+	a = u;
+	p = a->p;
+	ser = p->s;
+	c = a->c;
+	free(a);
+
+	qlock(&ser->QLock);	/* this makes the reader wait end of initialization too */
+	dfd = p->epin->dfd;
+	qunlock(&ser->QLock);
+
+	ntries = 0;
+	pk = nil;
+	do {
+		if (pk == nil)
+			pk = emallocz(sizeof(Packser), 1);
+Eagain:
+		rcount = read(dfd, pk->b, sizeof pk->b);
+		if(serialdebug > 5)
+			dsprint(2, "%d %#x%#x ", rcount, p->data[0],
+				p->data[1]);
+
+		if(rcount < 0){
+			if(ntries++ > 100)
+				break;
+			qlock(&ser->QLock);
+			recov = serialrecover(ser, p, nil, "epreader: bulkin error");
+			qunlock(&ser->QLock);
+			if(recov >= 0)
+				goto Eagain;
+		}
+		if(rcount == 0)
+			continue;
+		if(rcount >= ser->inhdrsz){
+			rcount = cpdata(ser, p, pk->b, pk->b, rcount);
+			if(rcount != 0){
+				pk->nb = rcount;
+				cl = sendp(c, pk);
+				if(cl < 0){
+					/*
+					 * if it was a time-out, I don't want
+					 * to give back an error.
+					 */
+					rcount = 0;
+					break;
+				}
+			}else
+				free(pk);
+			qlock(&ser->QLock);
+			ser->recover = 0;
+			qunlock(&ser->QLock);
+			ntries = 0;
+			pk = nil;
+		}
+	} while(rcount >= 0 || (rcount < 0 && strstr(err, "timed out") != nil));
+
+	if(rcount < 0)
+		fprint(2, "%s: error reading %s: %r\n", argv0, p->fs.name);
+	free(pk);
+	nbsendp(c, nil);
+	if(p->w4data != nil)
+		chanclose(p->w4data);
+	if(p->gotdata != nil)
+		chanclose(p->gotdata);
+	devctl(ser->dev, "detach");
+	closedev(ser->dev);
+	usbfsdel(&p->fs);
+}
+
+static void
+statusreader(void *u)
+{
+	Areader *a;
+	Channel *c;
+	Packser *pk;
+	Serialport *p;
+	Serial *ser;
+	int cl;
+
+	p = u;
+	ser = p->s;
+	threadsetname("statusreader thread");
+	/* big buffering, fewer bytes lost */
+	c = chancreate(sizeof(Packser *), 128);
+	a = emallocz(sizeof(Areader), 1);
+	a->p = p;
+	a->c = c;
+	incref(&ser->dev->Ref);
+	proccreate(epreader, a, 16*1024);
+
+	while((pk = recvp(c)) != nil){
+		memmove(p->data, pk->b, pk->nb);
+		p->ndata = pk->nb;
+		free(pk);
+		dsprint(2, "serial %p: status reader %d \n", p, p->ndata);
+		/* consume it all */
+		while(p->ndata != 0){
+			dsprint(2, "serial %p: status reader to consume: %d\n",
+				p, p->ndata);
+			cl = recvul(p->w4data);
+			if(cl  < 0)
+				break;
+			cl = sendul(p->gotdata, 1);
+			if(cl  < 0)
+				break;
+		}
+	}
+
+	shutdownchan(c);
+	devctl(ser->dev, "detach");
+	closedev(ser->dev);
+	usbfsdel(&p->fs);
+}
+
+static int
+ftreset(Serial *ser, Serialport *p)
+{
+	int i;
+
+	if(p != nil){
+		ftdiwrite(p, FTRESETCTLVAL, 0, FTRESET);
+		return 0;
+	}
+	p = ser->p;
+	for(i = 0; i < Maxifc; i++)
+		if(p[i].s != nil)
+			ftdiwrite(&p[i], FTRESETCTLVAL, 0, FTRESET);
+	return 0;
+}
+
+static int
+ftinit(Serialport *p)
+{
+	Serial *ser;
+	uint timerval;
+	int res;
+
+	ser = p->s;
+	if(p->isjtag){
+		res = ftdiwrite(p, FTSETFLOWCTRL, 0, FTDISABLEFLOWCTRL);
+		if(res < 0)
+			return -1;
+		res = ftdiread(p, FTSETLATENCYTIMER, 0, (uint8_t *)&timerval,
+			FTLATENCYTIMERSZ);
+		if(res < 0)
+			return -1;
+		dsprint(2, "serial: jtag latency timer is %d\n", timerval);
+		timerval = 2;
+		ftdiwrite(p, FTLATENCYDEFAULT, 0, FTSETLATENCYTIMER);
+		res = ftdiread(p, FTSETLATENCYTIMER, 0, (uint8_t *)&timerval,
+			FTLATENCYTIMERSZ);
+		if(res < 0)
+			return -1;
+
+		dsprint(2, "serial: jtag latency timer set to %d\n", timerval);
+		/* may be unnecessary */
+		devctl(p->epin,  "timeout 5000");
+		devctl(p->epout, "timeout 5000");
+		/* 0xb is the mask for lines. plug dependant? */
+		ftdiwrite(p, BMMPSSE|0x0b, 0, FTSETBITMODE);
+	}
+	incref(&ser->dev->Ref);
+	threadcreate(statusreader, p, 8*1024);
+	return 0;
+}
+
+static int
+ftsetbreak(Serialport *p, int val)
+{
+	return ftdiwrite(p, (val != 0? FTSETBREAK: 0), 0, FTSETDATA);
+}
+
+static int
+ftclearpipes(Serialport *p)
+{
+	/* maybe can be done in one... */
+	ftdiwrite(p, FTRESETCTLVALPURGETX, 0, FTRESET);
+	ftdiwrite(p, FTRESETCTLVALPURGERX, 0, FTRESET);
+	return 0;
+}
+
+static int
+setctlline(Serialport *p, uint8_t val)
+{
+	return ftdiwrite(p, val | (val << 8), 0, FTSETMODEMCTRL);
+}
+
+static void
+updatectlst(Serialport *p, int val)
+{
+	if(p->rts)
+		p->ctlstate |= val;
+	else
+		p->ctlstate &= ~val;
+}
+
+static int
+setctl(Serialport *p)
+{
+	int res;
+	Serial *ser;
+
+	ser = p->s;
+
+	if(ser->dev->usb->vid == FTVid && ser->dev->usb->did ==  FTHETIRA1Did){
+		fprint(2, "serial: cannot set lines for this device\n");
+		updatectlst(p, CtlRTS|CtlDTR);
+		p->rts = p->dtr = 1;
+		return -1;
+	}
+
+	/* NB: you can not set DTR and RTS with one control message */
+	updatectlst(p, CtlRTS);
+	res = setctlline(p, (CtlRTS<<8)|p->ctlstate);
+	if(res < 0)
+		return res;
+
+	updatectlst(p, CtlDTR);
+	res = setctlline(p, (CtlDTR<<8)|p->ctlstate);
+	if(res < 0)
+		return res;
+
+	return 0;
+}
+
+static int
+ftsendlines(Serialport *p)
+{
+	int res;
+
+	dsprint(2, "serial: sendlines: %#2.2x\n", p->ctlstate);
+	res = setctl(p);
+	dsprint(2, "serial: sendlines res: %d\n", res);
+	return 0;
+}
+
+static int
+ftseteps(Serialport *p)
+{
+	char *s;
+	Serial *ser;
+
+	ser = p->s;
+
+	s = smprint("maxpkt %d", ser->maxrtrans);
+	devctl(p->epin, s);
+	free(s);
+
+	s = smprint("maxpkt %d", ser->maxwtrans);
+	devctl(p->epout, s);
+	free(s);
+	return 0;
+}
+
+Serialops ftops = {
+	.init		= ftinit,
+	.seteps		= ftseteps,
+	.setparam	= ftsetparam,
+	.clearpipes	= ftclearpipes,
+	.reset		= ftreset,
+	.sendlines	= ftsendlines,
+	.modemctl	= ftmodemctl,
+	.setbreak	= ftsetbreak,
+	.wait4data	= wait4data,
+	.wait4write	= wait4write,
+};

--- a/sys/src/libusb/serial/prolific.c
+++ b/sys/src/libusb/serial/prolific.c
@@ -1,0 +1,448 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <usb/usb.h>
+#include <usb/usbfs.h>
+#include <usb/serial.h>
+#include <usb/prolific.h>
+
+Cinfo plinfo[] = {
+	{ PL2303Vid,	PL2303Did },
+	{ PL2303Vid,	PL2303DidRSAQ2 },
+	{ PL2303Vid,	PL2303DidDCU11 },
+	{ PL2303Vid,	PL2303DidRSAQ3 },
+	{ PL2303Vid,	PL2303DidPHAROS },
+	{ PL2303Vid,	PL2303DidALDIGA },
+	{ PL2303Vid,	PL2303DidMMX },
+	{ PL2303Vid,	PL2303DidGPRS },
+	{ IODATAVid,	IODATADid },
+	{ IODATAVid,	IODATADidRSAQ5 },
+	{ ATENVid,	ATENDid },
+	{ ATENVid2,	ATENDid },
+	{ ELCOMVid,	ELCOMDid },
+	{ ELCOMVid,	ELCOMDidUCSGT },
+	{ ITEGNOVid,	ITEGNODid },
+	{ ITEGNOVid,	ITEGNODid2080 },
+	{ MA620Vid,	MA620Did },
+	{ RATOCVid,	RATOCDid },
+	{ TRIPPVid,	TRIPPDid },
+	{ RADIOSHACKVid,RADIOSHACKDid },
+	{ DCU10Vid,	DCU10Did },
+	{ SITECOMVid,	SITECOMDid },
+	{ ALCATELVid,	ALCATELDid },
+	{ SAMSUNGVid,	SAMSUNGDid },
+	{ SIEMENSVid,	SIEMENSDidSX1 },
+	{ SIEMENSVid,	SIEMENSDidX65 },
+	{ SIEMENSVid,	SIEMENSDidX75 },
+	{ SIEMENSVid,	SIEMENSDidEF81 },
+	{ SYNTECHVid,	SYNTECHDid },
+	{ NOKIACA42Vid,	NOKIACA42Did },
+	{ CA42CA42Vid,	CA42CA42Did },
+	{ SAGEMVid,	SAGEMDid },
+	{ LEADTEKVid,	LEADTEK9531Did },
+	{ SPEEDDRAGONVid,SPEEDDRAGONDid },
+	{ DATAPILOTU2Vid,DATAPILOTU2Did },
+	{ BELKINVid,	BELKINDid },
+	{ ALCORVid,	ALCORDid },
+	{ WS002INVid,	WS002INDid },
+	{ COREGAVid,	COREGADid },
+	{ YCCABLEVid,	YCCABLEDid },
+	{ SUPERIALVid,	SUPERIALDid },
+	{ HPVid,	HPLD220Did },
+	{ 0,		0 },
+};
+
+int
+plmatch(char *info)
+{
+	Cinfo *ip;
+	char buf[50];
+
+	for(ip = plinfo; ip->vid != 0; ip++){
+		snprint(buf, sizeof buf, "vid %#06x did %#06x",
+			ip->vid, ip->did);
+		dsprint(2, "serial: %s %s\n", buf, info);
+		if(strstr(info, buf) != nil)
+			return 0;
+	}
+	return -1;
+}
+
+static void	statusreader(void *u);
+
+static void
+dumpbuf(uint8_t *buf, int bufsz)
+{
+	int i;
+
+	for(i=0; i<bufsz; i++)
+		print("buf[%d]=%#x ", i, buf[i]);
+	print("\n");
+}
+
+static int
+vendorread(Serialport *p, int val, int index, uint8_t *buf)
+{
+	int res;
+	Serial *ser;
+
+	ser = p->s;
+
+	dsprint(2, "serial: vendorread val: 0x%x idx:%d buf:%p\n",
+		val, index, buf);
+	res = usbcmd(ser->dev,  Rd2h | Rvendor | Rdev, VendorReadReq,
+		val, index, buf, 1);
+	dsprint(2, "serial: vendorread res:%d\n", res);
+	return res;
+}
+
+static int
+vendorwrite(Serialport *p, int val, int index)
+{
+	int res;
+	Serial *ser;
+
+	ser = p->s;
+
+	dsprint(2, "serial: vendorwrite val: 0x%x idx:%d\n", val, index);
+	res = usbcmd(ser->dev, Rh2d | Rvendor | Rdev, VendorWriteReq,
+		val, index, nil, 0);
+	dsprint(2, "serial: vendorwrite res:%d\n", res);
+	return res;
+}
+
+/* BUG: I could probably read Dcr0 and set only the bits */
+static int
+plmodemctl(Serialport *p, int set)
+{
+	Serial *ser;
+
+	ser = p->s;
+
+	if(set == 0){
+		p->mctl = 0;
+		vendorwrite(p, Dcr0Idx|DcrSet, Dcr0Init);
+		return 0;
+	}
+
+	p->mctl = 1;
+	if(ser->type == TypeHX)
+		vendorwrite(p, Dcr0Idx|DcrSet, Dcr0Init|Dcr0HwFcX);
+	else
+		vendorwrite(p, Dcr0Idx|DcrSet, Dcr0Init|Dcr0HwFcH);
+	return 0;
+}
+
+static int
+plgetparam(Serialport *p)
+{
+	uint8_t buf[ParamReqSz];
+	int res;
+	Serial *ser;
+
+	ser = p->s;
+
+
+	res = usbcmd(ser->dev, Rd2h | Rclass | Riface, GetLineReq,
+		0, 0, buf, sizeof buf);
+	p->baud = GET4(buf);
+
+	/*
+	 * with the Pl9 interface it is not possible to set `1.5' as stop bits
+	 * for the prologic:
+	 *	0 is 1 stop bit
+	 *	1 is 1.5 stop bits
+	 *	2 is 2 stop bits
+	 */
+	if(buf[4] == 1)
+		fprint(2, "warning, stop bit set to 1.5 unsupported");
+	else if(buf[4] == 0)
+		p->stop = 1;
+	else if(buf[4] == 2)
+		p->stop = 2;
+	p->parity = buf[5];
+	p->bits = buf[6];
+
+	dsprint(2, "serial: getparam: ");
+	if(serialdebug)
+		dumpbuf(buf, sizeof buf);
+	dsprint(2, "serial: getparam res: %d\n", res);
+	return res;
+}
+
+static int
+plsetparam(Serialport *p)
+{
+	uint8_t buf[ParamReqSz];
+	int res;
+	Serial *ser;
+
+	ser = p->s;
+
+	PUT4(buf, p->baud);
+
+	if(p->stop == 1)
+		buf[4] = 0;
+	else if(p->stop == 2)
+		buf[4] = 2; 			/* see comment in getparam */
+	buf[5] = p->parity;
+	buf[6] = p->bits;
+
+	dsprint(2, "serial: setparam: ");
+	if(serialdebug)
+		dumpbuf(buf, sizeof buf);
+	res = usbcmd(ser->dev, Rh2d | Rclass | Riface, SetLineReq,
+		0, 0, buf, sizeof buf);
+	plmodemctl(p, p->mctl);
+	plgetparam(p);		/* make sure our state corresponds */
+
+	dsprint(2, "serial: setparam res: %d\n", res);
+	return res;
+}
+
+static int
+revid(uint32_t devno)
+{
+	switch(devno){
+	case RevH:
+		return TypeH;
+	case RevX:
+	case RevHX:
+	case Rev1:
+		return TypeHX;
+	default:
+		return TypeUnk;
+	}
+}
+
+/* linux driver says the release id is not always right */
+static int
+heuristicid(uint32_t csp, uint32_t maxpkt)
+{
+	if(Class(csp) == 0x02)
+		return TypeH;
+	else if(maxpkt == 0x40)
+		return TypeHX;
+	else if(Class(csp) == 0x00 || Class(csp) == 0xFF)
+		return TypeH;
+	else{
+		fprint(2, "serial: chip unknown, setting to HX version\n");
+		return TypeHX;
+	}
+}
+
+static int
+plinit(Serialport *p)
+{
+	char *st;
+	uint8_t *buf;
+	uint32_t csp, maxpkt, dno;
+	Serial *ser;
+
+	ser = p->s;
+	buf = emallocz(VendorReqSz, 1);
+	dsprint(2, "plinit\n");
+
+	csp = ser->dev->usb->csp;
+	maxpkt = ser->dev->maxpkt;
+	dno = ser->dev->usb->dno;
+
+	if((ser->type = revid(dno)) == TypeUnk)
+		ser->type = heuristicid(csp, maxpkt);
+
+	dsprint(2, "serial: type %d\n", ser->type);
+
+	vendorread(p, 0x8484, 0, buf);
+	vendorwrite(p, 0x0404, 0);
+	vendorread(p, 0x8484, 0, buf);
+	vendorread(p, 0x8383, 0, buf);
+	vendorread(p, 0x8484, 0, buf);
+	vendorwrite(p, 0x0404, 1);
+	vendorread(p, 0x8484, 0, buf);
+	vendorread(p, 0x8383, 0, buf);
+
+	vendorwrite(p, Dcr0Idx|DcrSet, Dcr0Init);
+	vendorwrite(p, Dcr1Idx|DcrSet, Dcr1Init);
+
+	if(ser->type == TypeHX)
+		vendorwrite(p, Dcr2Idx|DcrSet, Dcr2InitX);
+	else
+		vendorwrite(p, Dcr2Idx|DcrSet, Dcr2InitH);
+
+	plgetparam(p);
+	qunlock(&ser->QLock);
+	free(buf);
+	st = emallocz(255, 1);
+	qlock(&ser->QLock);
+	if(serialdebug)
+		serdumpst(p, st, 255);
+	dsprint(2, st);
+	free(st);
+	/* p gets freed by closedev, the process has a reference */
+	incref(&ser->dev->Ref);
+	proccreate(statusreader, p, 8*1024);
+	return 0;
+}
+
+static int
+plsetbreak(Serialport *p, int val)
+{
+	Serial *ser;
+
+	ser = p->s;
+	return usbcmd(ser->dev, Rh2d | Rclass | Riface,
+		(val != 0? BreakOn: BreakOff), val, 0, nil, 0);
+}
+
+static int
+plclearpipes(Serialport *p)
+{
+	Serial *ser;
+
+	ser = p->s;
+
+	if(ser->type == TypeHX){
+		vendorwrite(p, PipeDSRst, 0);
+		vendorwrite(p, PipeUSRst, 0);
+	}else{
+		if(unstall(ser->dev, p->epout, Eout) < 0)
+			dprint(2, "disk: unstall epout: %r\n");
+		if(unstall(ser->dev, p->epin, Ein) < 0)
+			dprint(2, "disk: unstall epin: %r\n");
+		if(unstall(ser->dev, p->epintr, Ein) < 0)
+			dprint(2, "disk: unstall epintr: %r\n");
+	}
+	return 0;
+}
+
+static int
+setctlline(Serialport *p, uint8_t val)
+{
+	Serial *ser;
+
+	ser = p->s;
+	return usbcmd(ser->dev, Rh2d | Rclass | Riface, SetCtlReq,
+		val, 0, nil, 0);
+}
+
+static void
+composectl(Serialport *p)
+{
+	if(p->rts)
+		p->ctlstate |= CtlRTS;
+	else
+		p->ctlstate &= ~CtlRTS;
+	if(p->dtr)
+		p->ctlstate |= CtlDTR;
+	else
+		p->ctlstate &= ~CtlDTR;
+}
+
+static int
+plsendlines(Serialport *p)
+{
+	int res;
+
+	dsprint(2, "serial: sendlines: %#2.2x\n", p->ctlstate);
+	composectl(p);
+	res = setctlline(p, p->ctlstate);
+	dsprint(2, "serial: sendlines res: %d\n", res);
+	return 0;
+}
+
+static int
+plreadstatus(Serialport *p)
+{
+	int nr, dfd;
+	char err[40];
+	uint8_t buf[VendorReqSz];
+	Serial *ser;
+
+	ser = p->s;
+
+	qlock(&ser->QLock);
+	dsprint(2, "serial: reading from interrupt\n");
+	dfd = p->epintr->dfd;
+
+	qunlock(&ser->QLock);
+	nr = read(dfd, buf, sizeof buf);
+	qlock(&ser->QLock);
+	snprint(err, sizeof err, "%r");
+	dsprint(2, "serial: interrupt read %d %r\n", nr);
+
+	if(nr < 0 && strstr(err, "timed out") == nil){
+		dsprint(2, "serial: need to recover, status read %d %r\n", nr);
+		if(serialrecover(ser, nil, nil, err) < 0){
+			qunlock(&ser->QLock);
+			return -1;
+		}
+	}
+	if(nr < 0){
+		dsprint(2, "serial: reading status: %r");
+	} else if(nr >= sizeof buf - 1){
+		p->dcd = buf[8] & DcdStatus;
+		p->dsr = buf[8] & DsrStatus;
+		p->cts = buf[8] & BreakerrStatus;
+		p->ring = buf[8] & RingStatus;
+		p->cts = buf[8] & CtsStatus;
+		if(buf[8] & FrerrStatus)
+			p->nframeerr++;
+		if(buf[8] & ParerrStatus)
+			p->nparityerr++;
+		if(buf[8] & OvererrStatus)
+			p->novererr++;
+	} else {
+		dsprint(2, "serial: bad status read %d\n", nr);
+	}
+	dsprint(2, "serial: finished read from interrupt %d\n", nr);
+	qunlock(&ser->QLock);
+	return 0;
+}
+
+static void
+statusreader(void *u)
+{
+	Serialport *p;
+	Serial *ser;
+
+	p = u;
+	ser = p->s;
+	threadsetname("statusreaderproc");
+	while(plreadstatus(p) >= 0)
+		;
+	fprint(2, "serial: statusreader exiting\n");
+	closedev(ser->dev);
+}
+
+/*
+ * Maximum number of bytes transferred per frame
+ * The output buffer size cannot be increased due to the size encoding
+ */
+
+static int
+plseteps(Serialport *p)
+{
+	devctl(p->epin,  "maxpkt 256");
+	devctl(p->epout, "maxpkt 256");
+	return 0;
+}
+
+Serialops plops = {
+	.init		= plinit,
+	.getparam	= plgetparam,
+	.setparam	= plsetparam,
+	.clearpipes	= plclearpipes,
+	.sendlines	= plsendlines,
+	.modemctl	= plmodemctl,
+	.setbreak	= plsetbreak,
+	.seteps		= plseteps,
+};

--- a/sys/src/libusb/serial/serial.c
+++ b/sys/src/libusb/serial/serial.c
@@ -1,0 +1,910 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+/*
+ * This part takes care of locking except for initialization and
+ * other threads created by the hw dep. drivers.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <ctype.h>
+#include <thread.h>
+#include <usb/usb.h>
+#include <usb/usbfs.h>
+#include <usb/serial.h>
+#include <usb/prolific.h>
+#include <usb/ucons.h>
+#include <usb/ftdi.h>
+#include <usb/silabs.h>
+
+int serialdebug;
+
+enum {
+	/* Qids. Maintain order (relative to dirtabs structs) */
+	Qroot	= 0,
+	Qctl,
+	Qdata,
+	Qmax,
+};
+
+typedef struct Dirtab Dirtab;
+struct Dirtab {
+	char	*name;
+	int	mode;
+};
+
+static Dirtab dirtab[] = {
+	[Qroot] =	{"/",		DMDIR|0555},
+	[Qdata] =	{"%s",		0660},
+	[Qctl] =	{"%sctl",	0664},
+};
+
+/* someday? static int sdebug; */
+
+static void
+serialfatal(Serial *ser)
+{
+	Serialport *p;
+	int i;
+
+	dsprint(2, "serial: fatal error, detaching\n");
+	devctl(ser->dev, "detach");
+
+	for(i = 0; i < ser->nifcs; i++){
+		p = &ser->p[i];
+		usbfsdel(&p->fs);
+		if(p->w4data != nil)
+			chanclose(p->w4data);
+		if(p->gotdata != nil)
+			chanclose(p->gotdata);
+		if(p->readc)
+			chanclose(p->readc);
+	}
+}
+
+/* I sleep with the lock... only way to drain in general */
+static void
+serialdrain(Serialport *p)
+{
+	Serial *ser;
+	uint baud, pipesize;
+
+	ser = p->s;
+	baud = p->baud;
+
+	if(p->baud == ~0)
+		return;
+	if(ser->maxwtrans < 256)
+		pipesize = 256;
+	else
+		pipesize = ser->maxwtrans;
+	/* wait for the at least 256-byte pipe to clear */
+	sleep(10 + pipesize/((1 + baud)*1000));
+	if(ser->Serialops.clearpipes != nil)
+		ser->Serialops.clearpipes(p);
+}
+
+int
+serialreset(Serial *ser)
+{
+	Serialport *p;
+	int i, res;
+
+	res = 0;
+	/* cmd for reset */
+	for(i = 0; i < ser->nifcs; i++){
+		p = &ser->p[i];
+		serialdrain(p);
+	}
+	if(ser->Serialops.reset != nil)
+		res = ser->Serialops.reset(ser, nil);
+	return res;
+}
+
+/* call this if something goes wrong, must be qlocked */
+int
+serialrecover(Serial *ser, Serialport *p, Dev *ep, char *err)
+{
+	if(p != nil) {
+		dprint(2, "serial[%d], %s: %s, level %d\n", p->interfc,
+			p->name, err, ser->recover);
+	} else {
+		dprint(2, "serial[%s], global error, level %d\n",
+			ser->p[0].name, ser->recover);
+	}
+	ser->recover++;
+	if(strstr(err, "detached") != nil)
+		return -1;
+	if(ser->recover < 3){
+		if(p != nil){
+			if(ep != nil){
+				if(ep == p->epintr)
+					unstall(ser->dev, p->epintr, Ein);
+				if(ep == p->epin)
+					unstall(ser->dev, p->epin, Ein);
+				if(ep == p->epout)
+					unstall(ser->dev, p->epout, Eout);
+				return 0;
+			}
+
+			if(p->epintr != nil)
+				unstall(ser->dev, p->epintr, Ein);
+			if(p->epin != nil)
+				unstall(ser->dev, p->epin, Ein);
+			if(p->epout != nil)
+				unstall(ser->dev, p->epout, Eout);
+		}
+		return 0;
+	}
+	if(ser->recover > 4 && ser->recover < 8)
+		serialfatal(ser);
+	if(ser->recover > 8){
+		ser->Serialops.reset(ser, p);
+		return 0;
+	}
+	if(serialreset(ser) < 0)
+		return -1;
+	return 0;
+}
+
+static int
+serialctl(Serialport *p, char *cmd)
+{
+	Serial *ser;
+	int c, i, n, nf, nop, nw, par, drain, set, lines;
+	char *f[16];
+	uint8_t x;
+
+	ser = p->s;
+	drain = set = lines = 0;
+	nf = tokenize(cmd, f, nelem(f));
+	for(i = 0; i < nf; i++){
+		if(strncmp(f[i], "break", 5) == 0){
+			if(ser->Serialops.setbreak != nil)
+				ser->Serialops.setbreak(p, 1);
+			continue;
+		}
+
+		nop = 0;
+		n = atoi(f[i]+1);
+		c = *f[i];
+		if (isascii(c) && isupper(c))
+			c = tolower(c);
+		switch(c){
+		case 'b':
+			drain++;
+			p->baud = n;
+			set++;
+			break;
+		case 'c':
+			p->dcd = n;
+			// lines++;
+			++nop;
+			break;
+		case 'd':
+			p->dtr = n;
+			lines++;
+			break;
+		case 'e':
+			p->dsr = n;
+			// lines++;
+			++nop;
+			break;
+		case 'f':		/* flush the pipes */
+			drain++;
+			break;
+		case 'h':		/* hangup?? */
+			p->rts = p->dtr = 0;
+			lines++;
+			fprint(2, "serial: %c, unsure ctl\n", c);
+			break;
+		case 'i':
+			++nop;
+			break;
+		case 'k':
+			drain++;
+			ser->Serialops.setbreak(p, 1);
+			sleep(n);
+			ser->Serialops.setbreak(p, 0);
+			break;
+		case 'l':
+			drain++;
+			p->bits = n;
+			set++;
+			break;
+		case 'm':
+			drain++;
+			if(ser->Serialops.modemctl != nil)
+				ser->Serialops.modemctl(p, n);
+			if(n == 0)
+				p->cts = 0;
+			break;
+		case 'n':
+			p->blocked = n;
+			++nop;
+			break;
+		case 'p':		/* extended... */
+			if(strlen(f[i]) != 2)
+				return -1;
+			drain++;
+			par = f[i][1];
+			if(par == 'n')
+				p->parity = 0;
+			else if(par == 'o')
+				p->parity = 1;
+			else if(par == 'e')
+				p->parity = 2;
+			else if(par == 'm')	/* mark parity */
+				p->parity = 3;
+			else if(par == 's')	/* space parity */
+				p->parity = 4;
+			else
+				return -1;
+			set++;
+			break;
+		case 'q':
+			// drain++;
+			p->limit = n;
+			++nop;
+			break;
+		case 'r':
+			drain++;
+			p->rts = n;
+			lines++;
+			break;
+		case 's':
+			drain++;
+			p->stop = n;
+			set++;
+			break;
+		case 'w':
+			/* ?? how do I put this */
+			p->timer = n * 100000LL;
+			++nop;
+			break;
+		case 'x':
+			if(n == 0)
+				x = CTLS;
+			else
+				x = CTLQ;
+			if(ser->Serialops.wait4write != nil)
+				nw = ser->Serialops.wait4write(p, &x, 1);
+			else
+				nw = write(p->epout->dfd, &x, 1);
+			if(nw != 1){
+				serialrecover(ser, p, p->epout, "");
+				return -1;
+			}
+			break;
+		}
+		/*
+		 * don't print.  the condition is harmless and the print
+		 * splatters all over the display.
+		 */
+		USED(nop);
+		if (0 && nop)
+			fprint(2, "serial: %c, unsupported nop ctl\n", c);
+	}
+	if(drain)
+		serialdrain(p);
+	if(lines && !set){
+		if(ser->Serialops.sendlines != nil && ser->Serialops.sendlines(p) < 0)
+			return -1;
+	} else if(set){
+		if(ser->Serialops.setparam != nil && ser->Serialops.setparam(p) < 0)
+			return -1;
+	}
+	ser->recover = 0;
+	return 0;
+}
+
+char *pformat = "noems";
+
+char *
+serdumpst(Serialport *p, char *buf, int bufsz)
+{
+	char *e, *s;
+	Serial *ser;
+
+	ser = p->s;
+
+	e = buf + bufsz;
+	s = seprint(buf, e, "b%d ", p->baud);
+	s = seprint(s, e, "c%d ", p->dcd);	/* unimplemented */
+	s = seprint(s, e, "d%d ", p->dtr);
+	s = seprint(s, e, "e%d ", p->dsr);	/* unimplemented */
+	s = seprint(s, e, "l%d ", p->bits);
+	s = seprint(s, e, "m%d ", p->mctl);
+	if(p->parity >= 0 || p->parity < strlen(pformat))
+		s = seprint(s, e, "p%c ", pformat[p->parity]);
+	else
+		s = seprint(s, e, "p%c ", '?');
+	s = seprint(s, e, "r%d ", p->rts);
+	s = seprint(s, e, "s%d ", p->stop);
+	s = seprint(s, e, "i%d ", p->fifo);
+	s = seprint(s, e, "\ndev(%d) ", 0);
+	s = seprint(s, e, "type(%d)  ", ser->type);
+	s = seprint(s, e, "framing(%d) ", p->nframeerr);
+	s = seprint(s, e, "overruns(%d) ", p->novererr);
+	s = seprint(s, e, "berr(%d) ", p->nbreakerr);
+	s = seprint(s, e, " serr(%d)\n", p->nparityerr);
+	return s;
+}
+
+static int
+serinit(Serialport *p)
+{
+	int res;
+	res = 0;
+	Serial *ser;
+
+	ser = p->s;
+
+	if(ser->Serialops.init != nil)
+		res = ser->Serialops.init(p);
+	if(ser->Serialops.getparam != nil)
+		ser->Serialops.getparam(p);
+	p->nframeerr = p->nparityerr = p->nbreakerr = p->novererr = 0;
+
+	return res;
+}
+
+static int
+dwalk(Usbfs *fs, Fid *fid, char *name)
+{
+	int i;
+	char *dname;
+	Qid qid;
+	Serialport *p;
+
+	qid = fid->qid;
+	if((qid.type & QTDIR) == 0){
+		werrstr("walk in non-directory");
+		return -1;
+	}
+
+	if(strcmp(name, "..") == 0){
+		/* must be /eiaU%d; i.e. our root dir. */
+		fid->qid.path = Qroot | fs->qid;
+		fid->qid.vers = 0;
+		fid->qid.type = QTDIR;
+		return 0;
+	}
+
+	p = fs->aux;
+	for(i = 1; i < nelem(dirtab); i++){
+		dname = smprint(dirtab[i].name, p->name);
+		if(strcmp(name, dname) == 0){
+			qid.path = i | fs->qid;
+			qid.vers = 0;
+			qid.type = dirtab[i].mode >> 24;
+			fid->qid = qid;
+			free(dname);
+			return 0;
+		} else
+			free(dname);
+	}
+	werrstr(Enotfound);
+	return -1;
+}
+
+static void
+dostat(Usbfs *fs, int path, Dir *d)
+{
+	Dirtab *t;
+	Serialport *p;
+
+	t = &dirtab[path];
+	d->qid.path = path;
+	d->qid.type = t->mode >> 24;
+	d->mode = t->mode;
+	p = fs->aux;
+
+	if(strcmp(t->name, "/") == 0)
+		d->name = t->name;
+	else
+		snprint(d->name, Namesz, t->name, p->fs.name);
+	d->length = 0;
+}
+
+static int
+dstat(Usbfs *fs, Qid qid, Dir *d)
+{
+	int path;
+
+	path = qid.path & ~fs->qid;
+	dostat(fs, path, d);
+	d->qid.path |= fs->qid;
+	return 0;
+}
+
+static int
+dopen(Usbfs *fs, Fid *fid, int _1)
+{
+	uint32_t path;
+	Serialport *p;
+
+	path = fid->qid.path & ~fs->qid;
+	p = fs->aux;
+	switch(path){		/* BUG: unneeded? */
+	case Qdata:
+		dsprint(2, "serial, opened data\n");
+		break;
+	case Qctl:
+		dsprint(2, "serial, opened ctl\n");
+		if(p->isjtag)
+			return 0;
+		serialctl(p, "l8 i1");	/* default line parameters */
+		break;
+	}
+	return 0;
+}
+
+
+static void
+filldir(Usbfs *fs, Dir *d, Dirtab *tab, int i, void *v)
+{
+	Serialport *p;
+
+	p = v;
+	d->qid.path = i | fs->qid;
+	d->mode = tab->mode;
+	if((d->mode & DMDIR) != 0)
+		d->qid.type = QTDIR;
+	else
+		d->qid.type = QTFILE;
+	sprint(d->name, tab->name, p->name);	/* hope it fits */
+}
+
+static int
+dirgen(Usbfs *fs, Qid _1, int i, Dir *d, void *p)
+{
+	i++;				/* skip root */
+	if(i >= nelem(dirtab))
+		return -1;
+	filldir(fs, d, &dirtab[i], i, p);
+	return 0;
+}
+
+enum {
+	Serbufsize	= 256,
+};
+
+static int32_t
+dread(Usbfs *fs, Fid *fid, void *data, int32_t count, int64_t offset)
+{
+	int dfd;
+	int32_t rcount;
+	uint32_t path;
+	char *e, *buf, *err;	/* change */
+	Qid q;
+	Serialport *p;
+	Serial *ser;
+	static int errrun, good;
+
+	q = fid->qid;
+	path = fid->qid.path & ~fs->qid;
+	p = fs->aux;
+	ser = p->s;
+
+	buf = emallocz(Serbufsize, 1);
+	err = emallocz(Serbufsize, 1);
+	qlock(&ser->QLock);
+	switch(path){
+	case Qroot:
+		count = usbdirread(fs, q, data, count, offset, dirgen, p);
+		break;
+	case Qdata:
+		if(count > ser->maxread)
+			count = ser->maxread;
+
+		dsprint(2, "serial: reading from data\n");
+		do {
+			err[0] = 0;
+			dfd = p->epin->dfd;
+			if(usbdebug >= 3)
+				dsprint(2, "serial: reading: %ld\n", count);
+
+			assert(count > 0);
+			if(ser->Serialops.wait4data != nil)
+				rcount = ser->Serialops.wait4data(p, data, count);
+			else{
+				qunlock(&ser->QLock);
+				rcount = read(dfd, data, count);
+				qlock(&ser->QLock);
+			}
+			/*
+			 * if we encounter a long run of continuous read
+			 * errors, do something drastic so that our caller
+			 * doesn't just spin its wheels forever.
+			 */
+			if(rcount < 0) {
+				snprint(err, Serbufsize, "%r");
+				++errrun;
+				sleep(20);
+				if (good > 0 && errrun > 10000) {
+					/* the line has been dropped; give up */
+					qunlock(&ser->QLock);
+					fprint(2, "%s: line %s is gone: %r\n",
+						argv0, p->fs.name);
+					threadexitsall("serial line gone");
+				}
+			} else {
+				errrun = 0;
+				good++;
+			}
+			if(usbdebug >= 3)
+				dsprint(2, "serial: read: %s %ld\n", err, rcount);
+		} while(rcount < 0 && strstr(err, "timed out") != nil);
+
+		dsprint(2, "serial: read from bulk %ld, %10.10s\n", rcount, err);
+		if(rcount < 0){
+			dsprint(2, "serial: need to recover, data read %ld %r\n",
+				count);
+			serialrecover(ser, p, p->epin, err);
+		}
+		dsprint(2, "serial: read from bulk %ld\n", rcount);
+		count = rcount;
+		break;
+	case Qctl:
+		if(offset != 0 || p->isjtag)
+			count = 0;
+		else {
+			e = serdumpst(p, buf, Serbufsize);
+			count = usbreadbuf(data, count, 0, buf, e - buf);
+		}
+		break;
+	}
+	if(count >= 0)
+		ser->recover = 0;
+	qunlock(&ser->QLock);
+	free(err);
+	free(buf);
+	return count;
+}
+
+static int32_t
+altwrite(Serialport *p, uint8_t *buf, int32_t count)
+{
+	int nw, dfd;
+	char err[128];
+	Serial *ser;
+
+	ser = p->s;
+	do{
+		dsprint(2, "serial: write to bulk %ld\n", count);
+
+		if(ser->Serialops.wait4write != nil)
+			/* unlocked inside later */
+			nw = ser->Serialops.wait4write(p, buf, count);
+		else{
+			dfd = p->epout->dfd;
+			qunlock(&ser->QLock);
+			nw = write(dfd, buf, count);
+			qlock(&ser->QLock);
+		}
+		rerrstr(err, sizeof err);
+		dsprint(2, "serial: written %s %d\n", err, nw);
+	} while(nw < 0 && strstr(err, "timed out") != nil);
+
+	if(nw != count){
+		dsprint(2, "serial: need to recover, status in write %d %r\n",
+			nw);
+		snprint(err, sizeof err, "%r");
+		serialrecover(p->s, p, p->epout, err);
+	}
+	return nw;
+}
+
+static int32_t
+dwrite(Usbfs *fs, Fid *fid, void *buf, int32_t count, int64_t _1)
+{
+	uint32_t path;
+	char *cmd;
+	Serialport *p;
+	Serial *ser;
+
+	p = fs->aux;
+	ser = p->s;
+	path = fid->qid.path & ~fs->qid;
+
+	qlock(&ser->QLock);
+	switch(path){
+	case Qdata:
+		count = altwrite(p, (uint8_t *)buf, count);
+		break;
+	case Qctl:
+		if(p->isjtag)
+			break;
+		cmd = emallocz(count+1, 1);
+		memmove(cmd, buf, count);
+		cmd[count] = 0;
+		if(serialctl(p, cmd) < 0){
+			qunlock(&ser->QLock);
+			werrstr(Ebadctl);
+			free(cmd);
+			return -1;
+		}
+		free(cmd);
+		break;
+	default:
+		qunlock(&ser->QLock);
+		werrstr(Eperm);
+		return -1;
+	}
+	if(count >= 0)
+		ser->recover = 0;
+	else
+		serialrecover(ser, p, p->epout, "writing");
+	qunlock(&ser->QLock);
+	return count;
+}
+
+static int
+openeps(Serialport *p, int epin, int epout, int epintr)
+{
+	Serial *ser;
+
+	ser = p->s;
+	p->epin = openep(ser->dev, epin);
+	if(p->epin == nil){
+		fprint(2, "serial: openep %d: %r\n", epin);
+		return -1;
+	}
+	if(epout == epin){
+		incref(&p->epin->Ref);
+		p->epout = p->epin;
+	}else
+		p->epout = openep(ser->dev, epout);
+	if(p->epout == nil){
+		fprint(2, "serial: openep %d: %r\n", epout);
+		closedev(p->epin);
+		return -1;
+	}
+
+	if(!p->isjtag){
+		devctl(p->epin,  "timeout 1000");
+		devctl(p->epout, "timeout 1000");
+	}
+
+	if(ser->hasepintr){
+		p->epintr = openep(ser->dev, epintr);
+		if(p->epintr == nil){
+			fprint(2, "serial: openep %d: %r\n", epintr);
+			closedev(p->epin);
+			closedev(p->epout);
+			return -1;
+		}
+		opendevdata(p->epintr, OREAD);
+		devctl(p->epintr, "timeout 1000");
+	}
+
+	if(ser->Serialops.seteps!= nil)
+		ser->Serialops.seteps(p);
+	if(p->epin == p->epout)
+		opendevdata(p->epin, ORDWR);
+	else{
+		opendevdata(p->epin, OREAD);
+		opendevdata(p->epout, OWRITE);
+	}
+	if(p->epin->dfd < 0 ||p->epout->dfd < 0 ||
+	    (ser->hasepintr && p->epintr->dfd < 0)){
+		fprint(2, "serial: open i/o ep data: %r\n");
+		closedev(p->epin);
+		closedev(p->epout);
+		if(ser->hasepintr)
+			closedev(p->epintr);
+		return -1;
+	}
+	return 0;
+}
+
+static int
+findendpoints(Serial *ser, int ifc)
+{
+	int i, epin, epout, epintr;
+	Ep *ep, **eps;
+
+	epintr = epin = epout = -1;
+
+	/*
+	 * interfc 0 means start from the start which is equiv to
+	 * iterate through endpoints probably, could be done better
+	 */
+	eps = ser->dev->usb->conf[0]->iface[ifc]->ep;
+
+	for(i = 0; i < Niface; i++){
+		if((ep = eps[i]) == nil)
+			continue;
+		if(ser->hasepintr && ep->type == Eintr &&
+		    ep->dir == Ein && epintr == -1)
+			epintr = ep->id;
+		if(ep->type == Ebulk){
+			if((ep->dir == Ein || ep->dir == Eboth) && epin == -1)
+				epin = ep->id;
+			if((ep->dir == Eout || ep->dir == Eboth) && epout == -1)
+				epout = ep->id;
+		}
+	}
+	dprint(2, "serial[%d]: ep ids: in %d out %d intr %d\n", ifc, epin, epout, epintr);
+	if(epin == -1 || epout == -1 || (ser->hasepintr && epintr == -1))
+		return -1;
+
+	if(openeps(&ser->p[ifc], epin, epout, epintr) < 0)
+		return -1;
+
+	dprint(2, "serial: ep in %s out %s\n", ser->p[ifc].epin->dir, ser->p[ifc].epout->dir);
+	if(ser->hasepintr)
+		dprint(2, "serial: ep intr %s\n", ser->p[ifc].epintr->dir);
+
+	if(usbdebug > 1 || serialdebug > 2){
+		devctl(ser->p[ifc].epin,  "debug 1");
+		devctl(ser->p[ifc].epout, "debug 1");
+		if(ser->hasepintr)
+			devctl(ser->p[ifc].epintr, "debug 1");
+		devctl(ser->dev, "debug 1");
+	}
+	return 0;
+}
+
+/* keep in sync with main.c */
+static int
+usage(void)
+{
+	werrstr("usage: usb/serial [-dD] [-m mtpt] [-s srv]");
+	return -1;
+}
+
+static void
+serdevfree(void *a)
+{
+	Serial *ser = a;
+	Serialport *p;
+	int i;
+
+	if(ser == nil)
+		return;
+
+	for(i = 0; i < ser->nifcs; i++){
+		p = &ser->p[i];
+
+		if(ser->hasepintr)
+			closedev(p->epintr);
+		closedev(p->epin);
+		closedev(p->epout);
+		p->epintr = p->epin = p->epout = nil;
+		if(p->w4data != nil)
+			chanfree(p->w4data);
+		if(p->gotdata != nil)
+			chanfree(p->gotdata);
+		if(p->readc)
+			chanfree(p->readc);
+
+	}
+	free(ser);
+}
+
+static Usbfs serialfs = {
+	.walk =	dwalk,
+	.open =	dopen,
+	.read =	dread,
+	.write=	dwrite,
+	.stat =	dstat,
+};
+
+static void
+serialfsend(Usbfs *fs)
+{
+	Serialport *p;
+
+	p = fs->aux;
+
+	if(p->w4data != nil)
+		chanclose(p->w4data);
+	if(p->gotdata != nil)
+		chanclose(p->gotdata);
+	if(p->readc)
+		chanclose(p->readc);
+}
+
+int
+serialmain(Dev *dev, int argc, char* argv[])
+{
+	Serial *ser;
+	Serialport *p;
+	char buf[50];
+	int i, devid;
+
+	devid = dev->id;
+	ARGBEGIN{
+	case 'd':
+		serialdebug++;
+		break;
+	case 'N':
+		devid = atoi(EARGF(usage()));
+		break;
+	default:
+		return usage();
+	}ARGEND
+	if(argc != 0)
+		return usage();
+
+	ser = dev->aux = emallocz(sizeof(Serial), 1);
+	ser->maxrtrans = ser->maxwtrans = sizeof ser->p[0].data;
+	ser->maxread = ser->maxwrite = sizeof ser->p[0].data;
+	ser->dev = dev;
+	dev->free = serdevfree;
+	ser->jtag = -1;
+	ser->nifcs = 1;
+
+	snprint(buf, sizeof buf, "vid %#06x did %#06x",
+		dev->usb->vid, dev->usb->did);
+	if(plmatch(buf) == 0){
+		ser->hasepintr = 1;
+		ser->Serialops = plops;
+	} else if(uconsmatch(buf) == 0)
+		ser->Serialops = uconsops;
+	else if(ftmatch(ser, buf) == 0)
+		ser->Serialops = ftops;
+	else if(slmatch(buf) == 0)
+		ser->Serialops = slops;
+	else {
+		werrstr("serial: no serial devices found");
+		return -1;
+	}
+	for(i = 0; i < ser->nifcs; i++){
+		p = &ser->p[i];
+		p->interfc = i;
+		p->s = ser;
+		p->fs = serialfs;
+		if(i == ser->jtag){
+			p->isjtag++;
+		}
+		if(findendpoints(ser, i) < 0){
+			werrstr("serial: no endpoints found for ifc %d", i);
+			return -1;
+		}
+		p->w4data  = chancreate(sizeof(uint32_t), 0);
+		p->gotdata = chancreate(sizeof(uint32_t), 0);
+	}
+
+	qlock(&ser->QLock);
+	serialreset(ser);
+	for(i = 0; i < ser->nifcs; i++){
+		p = &ser->p[i];
+		dprint(2, "serial: valid interface, calling serinit\n");
+		if(serinit(p) < 0){
+			dprint(2, "serial: serinit: %r\n");
+			return -1;
+		}
+
+		dsprint(2, "serial: adding interface %d, %p\n", p->interfc, p);
+		if(p->isjtag){
+			snprint(p->name, sizeof p->name, "jtag");
+			dsprint(2, "serial: JTAG interface %d %p\n", i, p);
+			snprint(p->fs.name, sizeof p->fs.name, "jtag%d.%d", devid, i);
+		} else {
+			snprint(p->name, sizeof p->name, "eiaU");
+			if(i == 0)
+				snprint(p->fs.name, sizeof p->fs.name, "eiaU%d", devid);
+			else
+				snprint(p->fs.name, sizeof p->fs.name, "eiaU%d.%d", devid, i);
+		}
+		fprint(2, "%s...", p->fs.name);
+		p->fs.dev = dev;
+		incref(&dev->Ref);
+		p->fs.aux = p;
+		p->fs.end = serialfsend;
+		usbfsadd(&p->fs);
+	}
+
+	qunlock(&ser->QLock);
+	return 0;
+}

--- a/sys/src/libusb/serial/silabs.c
+++ b/sys/src/libusb/serial/silabs.c
@@ -1,0 +1,156 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <usb/usb.h>
+#include <usb/usbfs.h>
+#include <usb/serial.h>
+#include <usb/silabs.h>
+
+static Cinfo slinfo[] = {
+	{ 0x10c4, 0xea60, },		/* CP210x */
+	{ 0x10c4, 0xea61, },		/* CP210x */
+	{ 0,	0, },
+};
+
+enum {
+	Enable		= 0x00,
+
+	Getbaud		= 0x1D,
+	Setbaud		= 0x1E,
+	Setlcr		= 0x03,
+	Getlcr		= 0x04,
+		Bitsmask	= 0x0F00,
+		Bitsshift	= 8,
+		Parmask		= 0x00F0,
+		Parshift	= 4,
+		Stopmask	= 0x000F,
+		Stop1		= 0x0000,
+		Stop1_5		= 0x0001,
+		Stop2		= 0x0002,
+};
+
+int
+slmatch(char *info)
+{
+	Cinfo *ip;
+	char buf[50];
+
+	for(ip = slinfo; ip->vid != 0; ip++){
+		snprint(buf, sizeof buf, "vid %#06x did %#06x",
+			ip->vid, ip->did);
+		if(strstr(info, buf) != nil)
+			return 0;
+	}
+	return -1;
+}
+
+static int
+slwrite(Serialport *p, int req, void *buf, int len)
+{
+	Serial *ser;
+
+	ser = p->s;
+	return usbcmd(ser->dev, Rh2d | Rvendor | Riface, req, 0, p->interfc,
+		buf, len);
+}
+
+static int
+slput(Serialport *p, uint op, uint val)
+{
+	Serial *ser;
+
+	ser = p->s;
+	return usbcmd(ser->dev, Rh2d | Rvendor | Riface, op, val, p->interfc,
+		nil, 0);
+}
+
+static int
+slread(Serialport *p, int req, void *buf, int len)
+{
+	Serial *ser;
+
+	ser = p->s;
+	return usbcmd(ser->dev, Rd2h | Rvendor | Riface, req, 0, p->interfc,
+		buf, len);
+}
+
+static int
+slinit(Serialport *p)
+{
+	Serial *ser;
+
+	ser = p->s;
+	dsprint(2, "slinit\n");
+
+	slput(p, Enable, 1);
+
+	slops.getparam(p);
+
+	/* p gets freed by closedev, the process has a reference */
+	incref(&ser->dev->Ref);
+	return 0;
+}
+
+static int
+slgetparam(Serialport *p)
+{
+	uint16_t lcr;
+
+	slread(p, Getbaud, &p->baud, sizeof(p->baud));
+	slread(p, Getlcr, &lcr, sizeof(lcr));
+	p->bits = (lcr&Bitsmask)>>Bitsshift;
+	p->parity = (lcr&Parmask)>>Parshift;
+	p->stop = (lcr&Stopmask) == Stop1? 1 : 2;
+	return 0;
+}
+
+static int
+slsetparam(Serialport *p)
+{
+	uint16_t lcr;
+
+	lcr = p->stop == 1? Stop1 : Stop2;
+	lcr |= (p->bits<<Bitsshift) | (p->parity<<Parshift);
+	slput(p, Setlcr, lcr);
+	slwrite(p, Setbaud, &p->baud, sizeof(p->baud));
+	return 0;
+}
+
+static int
+seteps(Serialport *p)
+{
+	if(devctl(p->epin, "timeout 0") < 0){
+		fprint(2, "can't set timeout on %s: %r\n", p->epin->dir);
+		return -1;
+	}
+	return 0;
+}
+
+static int
+wait4data(Serialport *p, uint8_t *data, int count)
+{
+	int n;
+
+	qunlock(&p->s->QLock);
+	while ((n = read(p->epin->dfd, data, count)) == 0)
+		;
+	qlock(&p->s->QLock);
+	return n;
+}
+
+Serialops slops = {
+	.init		= slinit,
+	.getparam	= slgetparam,
+	.setparam	= slsetparam,
+	.seteps		= seteps,
+	.wait4data	= wait4data,
+};

--- a/sys/src/libusb/serial/ucons.c
+++ b/sys/src/libusb/serial/ucons.c
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <usb/usb.h>
+#include <usb/usbfs.h>
+#include <usb/serial.h>
+#include <usb/ucons.h>
+
+Cinfo uconsinfo[] = {
+	{ Net20DCVid,	Net20DCDid },
+	{ 0,		0 },
+};
+
+int
+uconsmatch(char *info)
+{
+	Cinfo *ip;
+	char buf[50];
+
+	for(ip = uconsinfo; ip->vid != 0; ip++){
+		snprint(buf, sizeof buf, "vid %#06x did %#06x",
+			ip->vid, ip->did);
+		dsprint(2, "serial: %s %s\n", buf, info);
+		if(strstr(info, buf) != nil)
+			return 0;
+	}
+	return -1;
+}
+
+static int
+ucseteps(Serialport *p)
+{
+	Serial *ser;
+
+	ser = p->s;
+
+	p->baud = ~0;	/* not real port */
+	ser->maxrtrans = ser->maxwtrans = 8;
+	devctl(p->epin,  "maxpkt 8");
+	devctl(p->epout, "maxpkt 8");
+	return 0;
+}
+
+/* all nops */
+Serialops uconsops = {
+	.seteps = ucseteps,
+};


### PR DESCRIPTION
commit 275f0b42411259f8078477cf24f2b338d47c6ab2
Author: Dan Cross <cross@gajendra.net>
Date:   Thu Apr 20 16:19:04 2017 +0000

    Really expose warnings

    But also make it so that we can continue building.
    By exposing them, we see them so we can fix them.

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit 313973c85082becd8a5ffe1974b3d967138958f4
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Sun Apr 30 17:18:20 2017 -0700

    JSON: run preen on json files

    Long overdue:
    ./util/preen -d=false `find . -name "*.json" -print`

    Preen needs some cleanup. I never changed it since for a while util/build
    was going away. But it still works.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit 331ffebb5394eb0768cea498e43a2d2c98829e9d
Author: Sevki Hasirci <s@sevki.org>
Date:   Mon Feb 22 00:55:22 2016 +0100

    just the files

commit 400364d361586e548bd7c08d8cdcb64a4bc69e90
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Wed Jul 6 13:53:16 2016 -0700

    fixfmt: with this last round of changes I can boot.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit 48090c023db7a9d0f4f36f3b270dc30080c24ce5
Author: ron minnich <rminnich@gmail.com>
Date:   Sun Feb 14 05:49:03 2016 +0100

    Revert "build: added new build files"
    Does not work at all. Can't build a working system with it yet.

    Let's take this slower, ok? Not break it all next time.

    This reverts commit 4fd75744926150212a0c0cd3c5a2ea51d0637d12.

    Change-Id: I91fce92249dd9d7bf3ca731a124c61a499382dd2

commit 4ca6762f63dbd6c2cd027cfff46ee5a60c7590b4
Author: Elbing Miss <elbingmiss@gmail.com>
Date:   Mon Jul 18 02:48:45 2016 +0200

    fixfmt: Last cleaning of %u modifier in libs

    Restoring -Werror for kernel build

    (secondary: replacing memcpy in port/devramfs for memmmove
     to avoid warning in kernel build)

commit 4fd75744926150212a0c0cd3c5a2ea51d0637d12
Author: Sevki <sevki@spotify.com>
Date:   Wed Jan 27 12:46:31 2016 +0100

    build: added new build files

    kernel compiles and crashes

    closes #37

    to test use

            go get -u sevki.org/build/cmd/build
            build //sys/src/9/amd64:harvey
    or

            build -v //sys/src/9/amd64:harvey

    inside a editor like emacs or acme.

    If you are building on OS X you should also have something like .build
    file at the root of the project and add something like

            CC: gcc
            TOOLPREFIX: x86_64-elf-

    Change-Id: Ib6f6156eee1936ceb5f8b0bfa64ed45589195c31
    Signed-off-by: Sevki <sevki@spotify.com>

commit 509545d74c842f94fd908060a879aeaf960c9870
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Thu May 5 08:14:37 2016 -0700

    clang: we can now build all of userland and boot

    usbd dies with a suicide, as it seems to try to use floating point
    in a note handler, oops. I bet there is a memcpy and clang generates
    code to use xmm.

    I remove the call to build libz/regression.json because clang got upset
    with it.

    There are many warnings, still, but at least we can build. I am going to get the warnings
    fixed tonight/tomorrow and then add clang to the travis test matrix.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit 6533db6114e97d5687bdb6a0f94136c98d009408
Author: Dan Cross <cross@gajendra.net>
Date:   Mon May 1 00:00:16 2017 +0000

    Remove trailing whitespace from source files.

    This is a trivial cleanup (done with a script, Ron!).

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit 70fc07aea69802ae5a301dd4df4ff7ef286ad0f7
Author: Dan Cross <cross@gajendra.net>
Date:   Thu Apr 20 19:52:40 2017 +0000

    Squash more warnings.

    We're down in less than 500 now.

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit 7856b81d60a5a8eed0e06f49db21677932bead55
Author: Keith Poole <keith.poole@gmail.com>
Date:   Sun May 1 17:33:39 2016 +0100

    Removed plan9 extensions from libusb

    Signed-off-by: Keith Poole <keith.poole@gmail.com>

commit 7955c22c6ac664b6482dcfc8f8aeca45dbb8a49c
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Sun Jul 31 21:15:21 2016 -0700

    fmt: another round of format fixes for %#ul*x to remove the u

    Remove the u.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit 9b90a3f6fdb22222c46db89eb7a8edb67400a180
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Wed Dec 9 15:44:54 2015 -0800

    USB: add disk to the library

    Change-Id: I7fa945977e07c29219f73454fbddc634f3a82148
    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit 9fba51d999489cf1bf2adf3a35c2260caebf0c32
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Wed Jul 6 13:09:10 2016 -0700

    fixfmt: fix all usages of %u so that u is a type, not a modifier

    The rest of the world uses %u to mean unsigned decimal. Plan 9
    uses it as a modifier, which is arguably better, but what can we do?
    You don't always get to pick the standard.

    This change modifies libc/fmt so that %u is unsigned decimal, and
    modifies most uses of it so the kernel almost boots. Almost. Obviously
    we didn't get them all yet.

    It hangs in ipconfig.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit a9af88676d84c6df472f07bb27691959bded8db9
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Sun Jul 31 21:18:18 2016 -0700

    fixfmt: change %#l*ux so the ux is now just u

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit a9d13806e2923195accce1ddbd0caa6e18ce386b
Author: fuchicar <rafita.fernandez@gmail.com>
Date:   Fri Mar 10 12:33:27 2017 +0100

    Removed ifndef _MPINT from libsec.h

    This is not Harvey style. Removing it implies add #include <mp.h> before each #include <libsec.h>

    Signed-off-by: fuchicar <rafita.fernandez@gmail.com>

commit b8ff46bc9ea9f3fa6eb7459c9cc2bb9b43f53d33
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Wed Dec 9 14:52:27 2015 -0800

    USB: add serial functions to libusb

    Change-Id: Ib5378ed47ecade7884f39510f1055b739de3ffcf
    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit bad35858c734e58c2594d8095fcca8a247f0b543
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Fri Mar 3 22:06:54 2017 -0800

    build: fix problems uncoverd by new build

    Why did this build? Why did it stop? Who knows.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit bdb2567f42b853a6b6f6881339726d6e21ccf90f
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Thu Dec 10 16:40:27 2015 -0800

    usb: move all common include files to /sys/include/usb

    This is part of the effort to make it easy to write out of tree usb programs.

    All common .h files are now in /sys/include/usb/.
    And all library code is in /$ARCH/lib/libusb.a

    Builds and boots and usbd still works. Unless I screwed up *again*.

    Change-Id: Iec9e502ee686398b513193a90e0aa6646afbd6f0
    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit c58c6c510d5875253d66b4d26d9ae9025f9191f3
Author: Dan Cross <cross@gajendra.net>
Date:   Mon May 1 00:39:33 2017 +0000

    Remove blank lines at end of file.

    Remove a bunch of blank lines at the end of files.

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit c9bec0b2ba4272968072bbb58237fda58725088d
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Fri Apr 22 16:02:25 2016 -0700

    Move plan9-extensions option into only those places that need it

    Now you can start to fix the individual things. It's not in
    core.json any more.

    You can start with bufio, which is a mess.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit cac72d4555626b4e1693a68113baf37f3e30c790
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Wed Jul 6 14:15:44 2016 -0700

    fixfmt: The final final set of changes.

    I missed %lud and %llud somehow. Still boots and
    output from du -s makes more sense.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit cf95a25b42823536fe44eb460866460d35ca6b68
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Wed Dec 9 14:10:16 2015 -0800

    USB: move usb library code to libusb.

    Old code is not removed in this CL. It is no longer used.

    Change-Id: I2b13e715823c33cb2f63c53f51d70540b1a5e21e
    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit f6e68a90f971b8dc021fe4f4c97fa9234de37f17
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Thu Jul 7 19:52:40 2016 -0700

    fixfmt: Still MORE problems.

    %x.yu[doX] -> %x.y[uoX]

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit f9697c642ffc26c23d03835e2dafac9ad19f22d8
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Wed Dec 9 19:16:30 2015 -0800

    USB: get the rest of the files to compile.

    The big goal here is that we'll have .h files in /sys/include and
    library functions in /lib/libusb.a  so it's easy to build usb programs.

    It all builds and as in all these conversion efforts I found errors
    in the code.

    The next step is probably to create /sys/include/usb/ and put
    all .h files there, and make sure it all builds. Then we can
    have /sys/src/cmds/usb/whatever and in there have example
    usb programs.

    The USB stuff was pretty incomplete so it's going to take a while
    to get this rework right (assuming you all like it OK).

    Change-Id: I2698cca6a369193cb7386c34146b45f964938793
    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>