### PR TITLE
Importing read and write from APEX

### DIFF
--- a/amd64/include/u.h
+++ b/amd64/include/u.h
@@ -15,6 +15,7 @@ typedef	signed short	int16_t;
 typedef unsigned int	uint32_t;
 typedef unsigned int	uint;
 typedef signed int	int32_t;
+typedef long		ssize_t;
 typedef	unsigned long long uint64_t;
 typedef	long long	int64_t;
 typedef uint64_t uintptr;

--- a/sys/include/libc.h
+++ b/sys/include/libc.h
@@ -618,10 +618,10 @@ extern	int	fd2path(int, char*, int);
 // extern	int	fdflush(int);
 extern	int	pipe(int*);
 extern	int32_t	pread(int, void*, int32_t, int64_t);
-#define read(a, b, c) pread(a, b, c, ~0LL)
+extern	ssize_t read(int, void*, int32_t);
 extern	int32_t	preadv(int, IOchunk*, int, int64_t);
 extern	int32_t	pwrite(int, const void*, int32_t, int64_t);
-#define write(a, b, c) pwrite(a, b, c, ~0LL)
+extern	ssize_t write(int, const void*, int32_t);
 extern	int32_t	pwritev(int, IOchunk*, int, int64_t);
 extern	int32_t	r0(void);
 extern	int32_t	readn(int, void*, int32_t);

--- a/sys/src/libc/9sys/read.c
+++ b/sys/src/libc/9sys/read.c
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+
+ssize_t
+read(int d, void *buf, size_t nbytes)
+{
+	int n;
+
+	if(nbytes <= 0)
+		return 0;
+	if(buf == 0){
+		sysfatal("read failed: %r");
+	}
+
+	n = pread(d, buf, nbytes, ~0LL);
+	if(n < 0)
+		sysfatal("read failed: %r");;
+
+	return n;
+}

--- a/sys/src/libc/9sys/write.c
+++ b/sys/src/libc/9sys/write.c
@@ -1,0 +1,22 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+
+ssize_t
+write(int d, const void *buf, size_t nbytes)
+{
+	int n;
+
+	n = pwrite(d, buf, nbytes, ~0LL);
+	if(n < 0)
+		sysfatal("write failed: %r");
+	return n;
+}


### PR DESCRIPTION
Bringing up wirte and read from ap/lib/_write.c and ap/lib/_read.c
  in APEX.

Signed-off-by: Álvaro Jurado <elbingmiss@gmail.com>