### PR TITLE
Reintroduce libthread

### DIFF
--- a/sys/src/libthread/386.c
+++ b/sys/src/libthread/386.c
@@ -30,4 +30,3 @@ _threadinitstack(Thread *t, void (*f)(void*), void *arg)
 	t->sched[JMPBUFPC] = (uint32_t)launcher386+JMPBUFDPC;
 	t->sched[JMPBUFSP] = (uint32_t)tos - 8;		/* old PC and new PC */
 }
-

--- a/sys/src/libthread/BUILD
+++ b/sys/src/libthread/BUILD
@@ -8,7 +8,7 @@ cc_library(
             "//amd64/include",
         ],
 	srcs = [
-		"amd64.c",
+		"$ARCH.c",
 		"channel.c",
 		"chanprint.c",
 		"create.c",

--- a/sys/src/libthread/amd64.c
+++ b/sys/src/libthread/amd64.c
@@ -34,4 +34,3 @@ _threadinitstack(Thread *t, void (*f)(void*), void *arg)
 	t->sched[JMPBUFARG1] = (uint64_t)f;		/* old PC and new PC */
 	t->sched[JMPBUFARG2] = (uint64_t)arg;		/* old PC and new PC */
 }
-

--- a/sys/src/libthread/arm.c
+++ b/sys/src/libthread/arm.c
@@ -34,4 +34,3 @@ _threadinitstack(Thread *t, void (*f)(void*), void *arg)
 	t->sched[JMPBUFPC] = (uint32_t)launcherarm+JMPBUFDPC;
 	t->sched[JMPBUFSP] = (uint32_t)tos;
 }
-

--- a/sys/src/libthread/create.c
+++ b/sys/src/libthread/create.c
@@ -26,7 +26,7 @@ nextID(void)
 	unlock(&l);
 	return i;
 }
-	
+
 /*
  * Create and initialize a new Thread structure attached to a given proc.
  */
@@ -66,7 +66,7 @@ newthread(Proc *p, void (*f)(void *arg), void *arg, uint stacksize,
 	return id;
 }
 
-/* 
+/*
  * Create a new thread and schedule it to run.
  * The thread grp is inherited from the currently running thread.
  */
@@ -160,4 +160,3 @@ _freethread(Thread *t)
 	free(t->stk);
 	free(t);
 }
-

--- a/sys/src/libthread/dial.c
+++ b/sys/src/libthread/dial.c
@@ -17,7 +17,7 @@ typedef struct DS DS;
 
 static int	call(char*, char*, DS*);
 static int	csdial(DS*);
-static void	_dial_string_parse(char*, DS*);
+static void	_dial_string_parse(const char*, DS*);
 
 enum
 {
@@ -43,13 +43,13 @@ struct DS {
  *  the dialstring is of the form '[/net/]proto!dest'
  */
 int
-_threaddial(char *dest, char *local, char *dir, int *cfdp)
+_threaddial(const char *dest, const char *local, char *dir, int *cfdp)
 {
 	DS ds;
 	int rv;
 	char err[ERRMAX], alterr[ERRMAX];
 
-	ds.local = local;
+	ds.local = (char*)local;
 	ds.dir = dir;
 	ds.cfdp = cfdp;
 
@@ -148,7 +148,7 @@ call(char *clone, char *dest, DS *ds)
 		p = strchr(clone+1, '/');
 		if(p == nil)
 			p = clone;
-		else 
+		else
 			p++;
 	} else
 		p = clone;
@@ -201,7 +201,7 @@ call(char *clone, char *dest, DS *ds)
  *  parse a dial string
  */
 static void
-_dial_string_parse(char *str, DS *ds)
+_dial_string_parse(const char *str, DS *ds)
 {
 	char *p, *p2;
 

--- a/sys/src/libthread/exec.c
+++ b/sys/src/libthread/exec.c
@@ -38,7 +38,7 @@ procexec(Channel *pidc, char *prog, char *args[])
 	 * never return, and if it fails, return with errstr set.
 	 * Unfortunately, the exec happens in another proc since
 	 * we have to wait for the exec'ed process to finish.
-	 * To provide the semantics, we open a pipe with the 
+	 * To provide the semantics, we open a pipe with the
 	 * write end close-on-exec and hand it to the proc that
 	 * is doing the exec.  If the exec succeeds, the pipe will
 	 * close so that our read below fails.  If the exec fails,
@@ -84,6 +84,28 @@ procexec(Channel *pidc, char *prog, char *args[])
 void
 procexecl(Channel *pidc, char *f, ...)
 {
-	procexec(pidc, f, &f+1);
-}
+	/*
+	 * The cost of realloc is trivial compared the cost of an exec,
+	 * and realloc doesn't necessarily allocate more space anyway;
+	 * often realloc just returns its argument doing no further work.
+	 * Finally, the number of args is usually small.
+	 *
+	 * There is always at least one element in the argument vector
+	 * passed to procexec(), and argv[argc] == nil.
+	 */
+	va_list a;
+	char **args = nil;
+	char *arg;
+	int argc = 0;
 
+	va_start(a, f);
+	do {
+		arg = va_arg(a, char *);
+		argc++;
+		args = realloc(args, argc * sizeof(char *));
+		args[argc-1] = arg;
+	} while(arg != nil);
+	va_end(a);
+
+	procexec(pidc, f, args);
+}

--- a/sys/src/libthread/id.c
+++ b/sys/src/libthread/id.c
@@ -81,7 +81,7 @@ threadsetname(char *fmt, ...)
 	t->cmdname = vsmprint(fmt, arg);
 	va_end(arg);
 	if(t->cmdname && p->nthreads == 1){
-		snprint(buf, sizeof buf, "#p/%lud/args", _tos->pid); //getpid());
+		snprint(buf, sizeof buf, "#p/%lu/args", _tos->pid); //getpid());
 		if((fd = open(buf, OWRITE)) >= 0){
 			write(fd, t->cmdname, strlen(t->cmdname)+1);
 			close(fd);

--- a/sys/src/libthread/lib.c
+++ b/sys/src/libthread/lib.c
@@ -22,7 +22,7 @@ _threadmalloc(int32_t size, int z)
 	m = malloc(size);
 	if (m == nil)
 		sysfatal("Malloc of size %ld failed: %r", size);
-	setmalloctag(m, getcallerpc(&size));
+	setmalloctag(m, getcallerpc());
 	totalmalloc += size;
 	if (size > 100000000) {
 		fprint(2, "Malloc of size %ld, total %ld\n", size, totalmalloc);

--- a/sys/src/libthread/libthread.json
+++ b/sys/src/libthread/libthread.json
@@ -1,36 +1,37 @@
 {
-	"Include": [
-		"../lib.json"
-	],
-	"Cflags": [ "-Werror" ],
-	"Install": "/$ARCH/lib/",
-	"Library": "libthread.a",
-	"Name": "libthread",
-	"SourceFiles": [
-		"amd64.c",
-		"channel.c",
-		"chanprint.c",
-		"create.c",
-		"debug.c",
-		"dial.c",
-		"exec.c",
-		"exit.c",
-		"id.c",
-		"iocall.c",
-		"ioclose.c",
-		"iodial.c",
-		"ioopen.c",
-		"ioproc.c",
-		"ioread.c",
-		"ioreadn.c",
-		"iosleep.c",
-		"iowrite.c",
-		"kill.c",
-		"lib.c",
-		"main.c",
-		"note.c",
-		"ref.c",
-		"rendez.c",
-		"sched.c"
-	]
+	"libthread": {
+		"Include": [
+			"/$ARCH/include/cflags.json",
+			"../lib.json"
+		],
+		"Install": "/$ARCH/lib/",
+		"Library": "libthread.a",
+		"SourceFiles": [
+			"$ARCH.c",
+			"channel.c",
+			"chanprint.c",
+			"create.c",
+			"debug.c",
+			"dial.c",
+			"exec.c",
+			"exit.c",
+			"id.c",
+			"iocall.c",
+			"ioclose.c",
+			"iodial.c",
+			"ioopen.c",
+			"ioproc.c",
+			"ioread.c",
+			"ioreadn.c",
+			"iosleep.c",
+			"iowrite.c",
+			"kill.c",
+			"lib.c",
+			"main.c",
+			"note.c",
+			"ref.c",
+			"rendez.c",
+			"sched.c"
+		]
+	}
 }

--- a/sys/src/libthread/note.c
+++ b/sys/src/libthread/note.c
@@ -148,4 +148,3 @@ _procsplx(int s)
 	if(p->pending)
 		delayednotes(p, nil);
 }
-

--- a/sys/src/libthread/power.c
+++ b/sys/src/libthread/power.c
@@ -33,4 +33,3 @@ _threadinitstack(Thread *t, void (*f)(void*), void *arg)
 	t->sched[JMPBUFPC] = (uint32_t)launcherpower+JMPBUFDPC;
 	t->sched[JMPBUFSP] = (uint32_t)tos;
 }
-

--- a/sys/src/libthread/rendez.c
+++ b/sys/src/libthread/rendez.c
@@ -70,7 +70,7 @@ _threadrendezvous(void *tag, void *val)
 
 /*
  * This is called while holding _threadpq.lock and p->lock,
- * so we can't lock _threadrgrp.lock.  Instead our caller has 
+ * so we can't lock _threadrgrp.lock.  Instead our caller has
  * to call _threadbreakrendez after dropping those locks.
  */
 void

--- a/sys/src/libthread/sched.c
+++ b/sys/src/libthread/sched.c
@@ -93,14 +93,14 @@ needstack(int n)
 	int x;
 	Proc *p;
 	Thread *t;
-	
+
 	p = _threadgetproc();
 	t = p->thread;
-	
+
 	if((uint8_t*)&x - n < (uint8_t*)t->stk){
-		fprint(2, "%s %lud: &x=%p n=%d t->stk=%p\n",
+		fprint(2, "%s %lu: &x=%p n=%d t->stk=%p\n",
 			argv0, _tos->pid, &x, n, t->stk);
-		fprint(2, "%s %lud: stack overflow\n", argv0, _tos->pid);
+		fprint(2, "%s %lu: stack overflow\n", argv0, _tos->pid);
 		abort();
 	}
 }
@@ -195,4 +195,3 @@ yield(void)
 {
 	_sched();
 }
-

--- a/sys/src/libthread/threadimpl.h
+++ b/sys/src/libthread/threadimpl.h
@@ -7,7 +7,7 @@
  * in the LICENSE file.
  */
 
-/* 
+/*
  * Some notes on locking:
  *
  *	All the locking woes come from implementing
@@ -43,7 +43,7 @@ typedef enum
 	Ready,
 	Rendezvous,
 } State;
-	
+
 typedef enum
 {
 	Channone,


### PR DESCRIPTION
commit 275f0b42411259f8078477cf24f2b338d47c6ab2
Author: Dan Cross <cross@gajendra.net>
Date:   Thu Apr 20 16:19:04 2017 +0000

    Really expose warnings

    But also make it so that we can continue building.
    By exposing them, we see them so we can fix them.

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit 3272435e1b2cccd4cd4def9e6237f1c586662d70
Author: Dan Cross <crossd@gmail.com>
Date:   Wed Jul 27 19:47:02 2016 -0400

    Skeleton aarch64 files: minimum needed to build most libraries. (#230)

    Add the very minimum files needed to build most Harvey libraries:
    these are just placeholders.

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit 331ffebb5394eb0768cea498e43a2d2c98829e9d
Author: Sevki Hasirci <s@sevki.org>
Date:   Mon Feb 22 00:55:22 2016 +0100

    just the files

commit 48090c023db7a9d0f4f36f3b270dc30080c24ce5
Author: ron minnich <rminnich@gmail.com>
Date:   Sun Feb 14 05:49:03 2016 +0100

    Revert "build: added new build files"
    Does not work at all. Can't build a working system with it yet.

    Let's take this slower, ok? Not break it all next time.

    This reverts commit 4fd75744926150212a0c0cd3c5a2ea51d0637d12.

    Change-Id: I91fce92249dd9d7bf3ca731a124c61a499382dd2

commit 4fd75744926150212a0c0cd3c5a2ea51d0637d12
Author: Sevki <sevki@spotify.com>
Date:   Wed Jan 27 12:46:31 2016 +0100

    build: added new build files

    kernel compiles and crashes

    closes #37

    to test use

            go get -u sevki.org/build/cmd/build
            build //sys/src/9/amd64:harvey
    or

            build -v //sys/src/9/amd64:harvey

    inside a editor like emacs or acme.

    If you are building on OS X you should also have something like .build
    file at the root of the project and add something like

            CC: gcc
            TOOLPREFIX: x86_64-elf-

    Change-Id: Ib6f6156eee1936ceb5f8b0bfa64ed45589195c31
    Signed-off-by: Sevki <sevki@spotify.com>

commit 511ab31d18b3526ce77f541ae746a2ac2f6085d7
Author: Dan Cross <crossd@gmail.com>
Date:   Thu Mar 24 16:11:32 2016 -0400

    libthread: fix stdargs problem. Update to rminnich fix.

    Another vestige of the great migration to standard
    calling conventions.

    Change-Id: I2c0b075ac46edbcc3d15501708851373d542002f
    Signed-off-by: Dan Cross <crossd@gmail.com>

commit 51ca141e1fae9da49358ea5c7b895e636159d194
Author: Hank Donnay <hdonnay@gmail.com>
Date:   Wed Aug 12 11:30:46 2015 -0500

    Fix compiler warnings in libthread

    main.c: sub '...' for 'va_list' to match declaration.
    Remove some unused static functions.

    kill.c: handle other enum cases by doing nothing.

    channel.c: cast from volatile Channel when approriate.

    threadimpl.h: specify int32_t instead of long.

    thread.h: remove pragmas

    libthread.json: turn on -Werror now that warnings are gone.

    Change-Id: I98f76bbc91d3ca0a813c1a43d2c28fa90fc7322b
    Signed-off-by: Hank Donnay <hdonnay@gmail.com>

commit 5519f3acf0c56ded3025e20697c1b4bff21a5dc0
Author: Dan Cross <cross@gajendra.net>
Date:   Wed Oct 26 20:26:53 2016 +0000

    Various bits of aarch64 code to support ARM64.

    Implement (or copy from another architecture) most of the
    bits required for building libraries and applications for
    aarch64.  The system more or less builds now.

    I'm sure there are some bugs in this code: see, for example,
    libc/aarch64/main9.S: this is the "get to build" stage.  The
    next stage is "make work."

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit 6533db6114e97d5687bdb6a0f94136c98d009408
Author: Dan Cross <cross@gajendra.net>
Date:   Mon May 1 00:00:16 2017 +0000

    Remove trailing whitespace from source files.

    This is a trivial cleanup (done with a script, Ron!).

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit 70fc07aea69802ae5a301dd4df4ff7ef286ad0f7
Author: Dan Cross <cross@gajendra.net>
Date:   Thu Apr 20 19:52:40 2017 +0000

    Squash more warnings.

    We're down in less than 500 now.

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit 7d48be899922dd892ba5d266397a615964b5d43a
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Tue Dec 20 10:59:48 2016 -0800

    riscv: fix thread library launching

    because riscv puts call and return in a0/a1,
    we need to put args to the launcher in a3/a4.

    Add constants to u.h and change threadinitstack
    and launcher correspondingly.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit 9fba51d999489cf1bf2adf3a35c2260caebf0c32
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Wed Jul 6 13:09:10 2016 -0700

    fixfmt: fix all usages of %u so that u is a type, not a modifier

    The rest of the world uses %u to mean unsigned decimal. Plan 9
    uses it as a modifier, which is arguably better, but what can we do?
    You don't always get to pick the standard.

    This change modifies libc/fmt so that %u is unsigned decimal, and
    modifies most uses of it so the kernel almost boots. Almost. Obviously
    we didn't get them all yet.

    It hangs in ipconfig.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit ada265febbdf82eeced35e932912560f5ed3ef8e
Merge: 16eb9742b 8e7d21798
Author: Sevki <s@sevki.org>
Date:   Tue Mar 1 14:55:23 2016 +0100

    Merge branch 'master' into master

commit b6622f5db2fe243a21f744e200f85de00e253fbe
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Tue Dec 15 08:23:14 2015 -0800

    Sleep: partially undo the change of sleep to use awake (Fixes go runtime test hangs)

    This CL restores the original sleep system call, and now the go runtime
    test at least completes. It still has some bugs, but not the hang.

    I am doing this because the awake-based sleep has a race condition that can cause
    it to hang. The hang was seen in the go runtime tests, which would never complete.
    Still worse, the runtime hang was really hard to diagnose, as it occured almost
    randomly -- a classic sign of a race condition somewhere.

    The race was in our sleep function in libc.

    The proposed sleep replacement, using awake, looked like this:

    void
    sleep(int32_t millisecs)
    {
            int64_t wakeup;
            char c;

            wakeup = awake(millisecs);

            while(!awakened(wakeup) && /*read(0, &c, 1) && */rendezvous(&wakeup, (void*)1) == (void*)~0)
                    ;
    }

    I've added the part in /* */

    The code as written has a race that's not fixable in user mode.The test for exiting the
    loop is two parts: awakened and rendezvous. It's possible for the awakened test to fail,
    meaning there is time left; but is is further possible for
    the awake to finish, and now the rendezvous will block. Note the commented-out-read: if you
    uncomment it, and hit return at various times, the rendezvous will hang *depending on the value of the timeout
    variable*. This is a classic race.

    This broke the to Go runtime test, in various parts, in nonrepeatable ways.

    I'm leaving most of the awake-based sleep there until we decide what to do with it. It's also a
    warning to all of us to review global system call patches much more carefully. The libc sleep was
    broken, and the breakage should have been caught in code review. It was not.

    Finally, before we continue further global changes to system calls, we need a solid workload test.
    I renew my call for a moratorium on system call changes until we can verify them with a workload.

    Change-Id: If4eec8125048b03517cc759a1ddffbc48cf016a2
    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit b6caaf906f62a53b3a70f40ffa4357769d2f2743
Author: Sevki <s@sevki.org>
Date:   Tue Nov 29 23:06:37 2016 +0300

    bldy: envinroment variables can now be used in paths

    Signed-off-by: Sevki <s@sevki.org>

commit b8cfdeab918edba099e71faf034553ba7429de1d
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Wed Aug 19 18:36:19 2015 -0700

    Clean up the json files

    We had Cflags all over the place. Now they are mostly in one place. This is from
    running preen.

    Change-Id: I94f1074e3cdbe7f49e003a39b40a565bbef1e5e6
    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit ba14fa27776ef2371a42607ec04bf50287fbd0be
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Fri Nov 13 08:20:41 2015 -0800

    New json format per Giacomo's ideas.

    Instead of this:
    {
            "Name": "a",
            ...
    }

    Do this:
    {
            "Name": {
                    ...
            }
    }

    This is way better. Now the name is visible at the top level of any json viewer, we can
    have multiple stanzas per file, the name is way more easy to find, ... the advantages are legion.

    This includes a change to build.go but not to preen.

    This now works fine, BUILD all produces a working kernel and userland. But someone else needs to verify it.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

    Change-Id: I9b1cf2597e582895b8f3ab127bc9c1d77de96cbd

commit c58c6c510d5875253d66b4d26d9ae9025f9191f3
Author: Dan Cross <cross@gajendra.net>
Date:   Mon May 1 00:39:33 2017 +0000

    Remove blank lines at end of file.

    Remove a bunch of blank lines at the end of files.

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit e03575e5c12944776d956078d24d68c2c43d4868
Author: Dan Cross <crossd@gmail.com>
Date:   Thu Mar 24 15:50:37 2016 -0400

    Update generated text in bootstrap.sh.

    Change-Id: I6d649cd20dce132eee32441ae6409882104a0b98
    Signed-off-by: Dan Cross <crossd@gmail.com>

commit f8115b3fb9ca5722f247106a53796a0bd3a76a39
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Sat Feb 27 21:25:35 2016 -0800

    riscv: ainc and adec in assembly; sqrt in C; _tas; libthread suppor

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>