### PR TITLE
Reintroduce libregexp

### DIFF
--- a/sys/src/libregexp/libregexp.json
+++ b/sys/src/libregexp/libregexp.json
@@ -1,17 +1,18 @@
 {
-	"Include": [
-		"../lib.json"
-	],
-	"Install": "/$ARCH/lib/",
-	"Library": "libregexp.a",
-	"Name": "libregexp",
-	"SourceFiles": [
-		"regcomp.c",
-		"regerror.c",
-		"regexec.c",
-		"regsub.c",
-		"regaux.c",
-		"rregexec.c",
-		"rregsub.c"
-	]
+	"libregexp": {
+		"Include": [
+			"../lib.json"
+		],
+		"Install": "/$ARCH/lib/",
+		"Library": "libregexp.a",
+		"SourceFiles": [
+			"regcomp.c",
+			"regerror.c",
+			"regexec.c",
+			"regsub.c",
+			"regaux.c",
+			"rregexec.c",
+			"rregsub.c"
+		]
+	}
 }

--- a/sys/src/libregexp/regcomp.c
+++ b/sys/src/libregexp/regcomp.c
@@ -26,7 +26,8 @@ struct Node
 }Node;
 
 /* max character classes per program is nelem(reprog->class) */
-static Reprog	*reprog;
+/* TODO: why does clang think this is never used if we declare it static? */
+/*static */Reprog	*reprog;
 
 /* max rune ranges per character class is nelem(classp->spans)/2 */
 #define NCCRUNE	nelem(classp->spans)
@@ -122,7 +123,7 @@ regerr2(char *s, int c)
 	while(*s)
 		*cp++ = *s++;
 	*cp++ = c;
-	*cp = '\0'; 
+	*cp = '\0';
 	rcerror(buf);
 }
 

--- a/sys/src/libregexp/regexec.c
+++ b/sys/src/libregexp/regexec.c
@@ -90,7 +90,7 @@ regexec1(Reprog *progp,	/* program to run */
 			_renewemptythread(tl, progp->startinst, ms, s);
 
 		/* Execute machine until current list is empty */
-		for(tlp=tl; tlp->inst; tlp++){	/* assignment = */
+		for(tlp=tl; tlp->inst; tlp++){
 			for(inst = tlp->inst; ; inst = inst->next){
 				switch(inst->type){
 				case RUNE:	/* regular character */

--- a/sys/src/libregexp/rregsub.c
+++ b/sys/src/libregexp/rregsub.c
@@ -56,7 +56,7 @@ rregsub(Rune *sp,	/* source string */
 					*dp++ = *sp;
 				break;
 			}
-		}else if(*sp == '&'){				
+		}else if(*sp == '&'){
 			if(mp[0].rsp != 0 && mp!=0 && ms>0)
 			if(mp[0].rsp != 0)
 				for(ssp = mp[0].rsp;


### PR DESCRIPTION
commit 275f0b42411259f8078477cf24f2b338d47c6ab2
Author: Dan Cross <cross@gajendra.net>
Date:   Thu Apr 20 16:19:04 2017 +0000

    Really expose warnings

    But also make it so that we can continue building.
    By exposing them, we see them so we can fix them.

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit 331ffebb5394eb0768cea498e43a2d2c98829e9d
Author: Sevki Hasirci <s@sevki.org>
Date:   Mon Feb 22 00:55:22 2016 +0100

    just the files

commit 48090c023db7a9d0f4f36f3b270dc30080c24ce5
Author: ron minnich <rminnich@gmail.com>
Date:   Sun Feb 14 05:49:03 2016 +0100

    Revert "build: added new build files"
    Does not work at all. Can't build a working system with it yet.

    Let's take this slower, ok? Not break it all next time.

    This reverts commit 4fd75744926150212a0c0cd3c5a2ea51d0637d12.

    Change-Id: I91fce92249dd9d7bf3ca731a124c61a499382dd2

commit 4fd75744926150212a0c0cd3c5a2ea51d0637d12
Author: Sevki <sevki@spotify.com>
Date:   Wed Jan 27 12:46:31 2016 +0100

    build: added new build files

    kernel compiles and crashes

    closes #37

    to test use

            go get -u sevki.org/build/cmd/build
            build //sys/src/9/amd64:harvey
    or

            build -v //sys/src/9/amd64:harvey

    inside a editor like emacs or acme.

    If you are building on OS X you should also have something like .build
    file at the root of the project and add something like

            CC: gcc
            TOOLPREFIX: x86_64-elf-

    Change-Id: Ib6f6156eee1936ceb5f8b0bfa64ed45589195c31
    Signed-off-by: Sevki <sevki@spotify.com>

commit 509545d74c842f94fd908060a879aeaf960c9870
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Thu May 5 08:14:37 2016 -0700

    clang: we can now build all of userland and boot

    usbd dies with a suicide, as it seems to try to use floating point
    in a note handler, oops. I bet there is a memcpy and clang generates
    code to use xmm.

    I remove the call to build libz/regression.json because clang got upset
    with it.

    There are many warnings, still, but at least we can build. I am going to get the warnings
    fixed tonight/tomorrow and then add clang to the travis test matrix.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit 52a059d54222c030241de2359803d1d6d7a40ecb
Author: Dan Cross <cross@gajendra.net>
Date:   Mon May 1 02:31:53 2017 +0000

    More broken windows: now-redundant 'assign' comments.

    Remove a bunch of no-longer-relevant comments about
    assignments in loops and conditionals.

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit 6533db6114e97d5687bdb6a0f94136c98d009408
Author: Dan Cross <cross@gajendra.net>
Date:   Mon May 1 00:00:16 2017 +0000

    Remove trailing whitespace from source files.

    This is a trivial cleanup (done with a script, Ron!).

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit ba14fa27776ef2371a42607ec04bf50287fbd0be
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Fri Nov 13 08:20:41 2015 -0800

    New json format per Giacomo's ideas.

    Instead of this:
    {
            "Name": "a",
            ...
    }

    Do this:
    {
            "Name": {
                    ...
            }
    }

    This is way better. Now the name is visible at the top level of any json viewer, we can
    have multiple stanzas per file, the name is way more easy to find, ... the advantages are legion.

    This includes a change to build.go but not to preen.

    This now works fine, BUILD all produces a working kernel and userland. But someone else needs to verify it.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

    Change-Id: I9b1cf2597e582895b8f3ab127bc9c1d77de96cbd