### PR TITLE
Reintroduce liboventi

### DIFF
--- a/sys/src/liboventi/client.c
+++ b/sys/src/liboventi/client.c
@@ -21,7 +21,7 @@ static Packet *vtRPC(VtSession *z, int op, Packet *p);
 VtSession *
 vtClientAlloc(void)
 {
-	VtSession *z = vtAlloc();	
+	VtSession *z = vtAlloc();
 	return z;
 }
 
@@ -33,7 +33,7 @@ vtDial(char *host, int canfail)
 	char *na;
 	char e[ERRMAX];
 
-	if(host == nil) 
+	if(host == nil)
 		host = getenv("venti");
 	if(host == nil)
 		host = "$venti";
@@ -67,7 +67,7 @@ vtRedial(VtSession *z, char *host)
 	int fd;
 	char *na;
 
-	if(host == nil) 
+	if(host == nil)
 		host = getenv("venti");
 	if(host == nil)
 		host = "$venti";
@@ -228,7 +228,7 @@ vtWritePacket(VtSession *z, uint8_t score[VtScoreSize], int type, Packet *p)
 		vtSetError(ELumpSize);
 		goto Err;
 	}
-	
+
 	if(n == 0) {
 		memmove(score, vtZeroScore, VtScoreSize);
 		return 1;

--- a/sys/src/liboventi/liboventi.json
+++ b/sys/src/liboventi/liboventi.json
@@ -1,26 +1,27 @@
 {
-	"Include": [
-		"../lib.json"
-	],
-	"Install": "/$ARCH/lib/",
-	"Library": "liboventi.a",
-	"Name": "liboventi",
-	"SourceFiles": [
-		"client.c",
-		"debug.c",
-		"errfmt.c",
-		"fatal.c",
-		"pack.c",
-		"packet.c",
-		"parsescore.c",
-		"readfully.c",
-		"rpc.c",
-		"scorefmt.c",
-		"server.c",
-		"strdup.c",
-		"zero.c",
-		"plan9-io.c",
-		"plan9-sha1.c",
-		"plan9-thread.c"
-	]
+	"liboventi": {
+		"Include": [
+			"../lib.json"
+		],
+		"Install": "/$ARCH/lib/",
+		"Library": "liboventi.a",
+		"SourceFiles": [
+			"client.c",
+			"debug.c",
+			"errfmt.c",
+			"fatal.c",
+			"pack.c",
+			"packet.c",
+			"parsescore.c",
+			"readfully.c",
+			"rpc.c",
+			"scorefmt.c",
+			"server.c",
+			"strdup.c",
+			"zero.c",
+			"plan9-io.c",
+			"plan9-sha1.c",
+			"plan9-thread.c"
+		]
+	}
 }

--- a/sys/src/liboventi/pack.c
+++ b/sys/src/liboventi/pack.c
@@ -35,7 +35,7 @@ checkSize(int n)
 	}
 	return 1;
 }
-		
+
 
 void
 vtRootPack(VtRoot *r, uint8_t *p)
@@ -144,7 +144,7 @@ vtEntryUnpack(VtEntry *e, uint8_t *p, int index)
 	p += VtScoreSize;
 
 	assert(p-op == VtEntrySize);
-	
+
 	if(!(e->flags & VtEntryActive))
 		return 1;
 
@@ -153,4 +153,3 @@ vtEntryUnpack(VtEntry *e, uint8_t *p, int index)
 
 	return 1;
 }
-

--- a/sys/src/liboventi/packet.c
+++ b/sys/src/liboventi/packet.c
@@ -46,7 +46,7 @@ Packet *
 packetAlloc(void)
 {
 	Packet *p;
-	
+
 	lock(&freeList.lk);
 	p = freeList.packet;
 	if(p != nil)
@@ -93,7 +93,7 @@ if(0)fprint(2, "packetFree %p\n", p);
 
 Packet *
 packetDup(Packet *p, int offset, int n)
-{	
+{
 	Frag *f, *ff;
 	Packet *pp;
 
@@ -112,7 +112,7 @@ packetDup(Packet *p, int offset, int n)
 	/* skip offset */
 	for(f=p->first; offset >= FRAGSIZE(f); f=f->next)
 		offset -= FRAGSIZE(f);
-	
+
 	/* first frag */
 	ff = fragDup(pp, f);
 	ff->rp += offset;
@@ -128,7 +128,7 @@ packetDup(Packet *p, int offset, int n)
 		n -= FRAGSIZE(ff);
 		pp->asize += FRAGASIZE(ff);
 	}
-	
+
 	/* fix up last frag: note n <= 0 */
 	ff->wp += n;
 	ff->next = nil;
@@ -216,7 +216,7 @@ packetTrim(Packet *p, int offset, int n)
 		p->asize = 0;
 		return 1;
 	}
-	
+
 	/* free before offset */
 	for(f=p->first; offset >= FRAGSIZE(f); f=ff) {
 		p->asize -= FRAGASIZE(f);
@@ -261,7 +261,7 @@ packetHeader(Packet *p, int n)
 	}
 
 	p->size += n;
-	
+
 	/* try and fix in current frag */
 	f = p->first;
 	if(f != nil) {
@@ -295,7 +295,7 @@ packetTrailer(Packet *p, int n)
 	}
 
 	p->size += n;
-	
+
 	/* try and fix in current frag */
 	if(p->first != nil) {
 		f = p->last;
@@ -349,7 +349,7 @@ packetPrefix(Packet *p, uint8_t *buf, int n)
 		nn = n;
 		if(nn > MaxFragSize)
 			nn = MaxFragSize;
-		f = fragAlloc(p, nn, PEnd, p->first);	
+		f = fragAlloc(p, nn, PEnd, p->first);
 		p->asize += FRAGASIZE(f);
 		if(p->first == nil)
 			p->last = f;
@@ -386,7 +386,7 @@ packetAppend(Packet *p, uint8_t *buf, int n)
 			n -= nn;
 		}
 	}
-	
+
 	while(n > 0) {
 		nn = n;
 		if(nn > MaxFragSize)
@@ -447,7 +447,7 @@ packetPeek(Packet *p, uint8_t *buf, int offset, int n)
 		vtSetError(EPacketSize);
 		return 0;
 	}
-	
+
 	/* skip up to offset */
 	for(f=p->first; offset >= FRAGSIZE(f); f=f->next)
 		offset -= FRAGSIZE(f);
@@ -493,7 +493,7 @@ packetFragments(Packet *p, IOchunk *io, int nio, int offset)
 	NOTFREE(p);
 	if(p->size == 0 || nio <= 0)
 		return 0;
-	
+
 	if(offset < 0 || offset > p->size) {
 		vtSetError(EPacketOffset);
 		return -1;
@@ -506,7 +506,7 @@ packetFragments(Packet *p, IOchunk *io, int nio, int offset)
 	eio = io + nio;
 	for(; f != nil && io < eio; f=f->next) {
 		io->addr = f->rp + offset;
-		io->len = f->wp - (f->rp + offset);	
+		io->len = f->wp - (f->rp + offset);
 		offset = 0;
 		size += io->len;
 		io++;
@@ -537,7 +537,7 @@ packetStats(void)
 	nbm = 0;
 	for(m=freeList.bigMem; m; m=m->next)
 		nbm++;
-	
+
 	fprint(2, "packet: %d/%d frag: %d/%d small mem: %d/%d big mem: %d/%d\n",
 		np, freeList.npacket,
 		nf, freeList.nfrag,
@@ -555,7 +555,7 @@ packetSize(Packet *p)
 	if(0) {
 		Frag *f;
 		int size = 0;
-	
+
 		for(f=p->first; f; f=f->next)
 			size += FRAGSIZE(f);
 		if(size != p->size)
@@ -572,7 +572,7 @@ packetAllocatedSize(Packet *p)
 	if(0) {
 		Frag *f;
 		int asize = 0;
-	
+
 		for(f=p->first; f; f=f->next)
 			asize += FRAGASIZE(f);
 		if(asize != p->asize)
@@ -653,7 +653,7 @@ packetCmp(Packet *pkt0, Packet *pkt1)
 		}
 	}
 }
-	
+
 
 static Frag *
 fragAlloc(Packet *p, int n, int pos, Frag *next)
@@ -670,7 +670,7 @@ fragAlloc(Packet *p, int n, int pos, Frag *next)
 			goto Found;
 		}
 	}
-	lock(&freeList.lk);	
+	lock(&freeList.lk);
 	f = freeList.frag;
 	if(f != nil)
 		freeList.frag = f->next;
@@ -704,7 +704,7 @@ fragDup(Packet *p, Frag *f)
 	Frag *ff;
 	Mem *m;
 
-	m = f->mem;	
+	m = f->mem;
 
 	/*
 	 * m->rp && m->wp can be out of date when ref == 1
@@ -737,7 +737,7 @@ fragFree(Frag *f)
 	lock(&freeList.lk);
 	f->next = freeList.frag;
 	freeList.frag = f;
-	unlock(&freeList.lk);	
+	unlock(&freeList.lk);
 }
 
 static Mem *
@@ -775,7 +775,7 @@ memAlloc(int n, int pos)
 		m->bp = vtMemBrk(nn);
 		m->ep = m->bp + nn;
 	}
-	assert(m->ref == 0);	
+	assert(m->ref == 0);
 	m->ref = 1;
 
 	switch(pos) {
@@ -790,7 +790,7 @@ memAlloc(int n, int pos)
 		break;
 	case PEnd:
 		m->rp = m->ep - n;
-		break; 
+		break;
 	}
 	/* check we did not blow it */
 	if(m->rp < m->bp)

--- a/sys/src/liboventi/packet.h
+++ b/sys/src/liboventi/packet.h
@@ -40,7 +40,7 @@ enum {
 	FragLocalAlloc,
 	FragGlobal,
 };
-	
+
 struct Frag
 {
 	int state;
@@ -54,12 +54,11 @@ struct Packet
 {
 	int size;
 	int asize;  /* allocated memmory - always greater than size */
-	
+
 	Packet *next;
-	
+
 	Frag *first;
 	Frag *last;
-	
+
 	Frag local[NLocalFrag];
 };
-

--- a/sys/src/liboventi/parsescore.c
+++ b/sys/src/liboventi/parsescore.c
@@ -32,9 +32,8 @@ vtParseScore(char *buf, uint n, uint8_t score[VtScoreSize])
 
 		if((i & 1) == 0)
 			c <<= 4;
-	
+
 		score[i>>1] |= c;
 	}
 	return 1;
 }
-

--- a/sys/src/liboventi/plan9-io.c
+++ b/sys/src/liboventi/plan9-io.c
@@ -34,7 +34,7 @@ vtMemAlloc(int size)
 	p = malloc(size);
 	if(p == 0)
 		vtFatal("vtMemAlloc: out of memory");
-	setmalloctag(p, getcallerpc(&size));
+	setmalloctag(p, getcallerpc());
 	return p;
 }
 
@@ -43,7 +43,7 @@ vtMemAllocZ(int size)
 {
 	void *p = vtMemAlloc(size);
 	memset(p, 0, size);
-	setmalloctag(p, getcallerpc(&size));
+	setmalloctag(p, getcallerpc());
 	return p;
 }
 
@@ -55,7 +55,7 @@ vtMemRealloc(void *p, int size)
 	p = realloc(p, size);
 	if(p == 0)
 		vtFatal("vtRealloc: out of memory");
-	setrealloctag(p, getcallerpc(&size));
+	setrealloctag(p, getcallerpc());
 	return p;
 }
 
@@ -74,21 +74,21 @@ vtMemBrk(int n)
 		align = IdealAlignment;
 	else if(n > 8)
 		align = 8;
-	else	
+	else
 		align = 4;
 
 	lock(&lk);
 	pad = (align - (uintptr)buf) & (align-1);
 	if(n + pad > nbuf) {
 		buf = vtMemAllocZ(ChunkSize);
-		setmalloctag(buf, getcallerpc(&n));
+		setmalloctag(buf, getcallerpc());
 		nbuf = ChunkSize;
 		pad = (align - (uintptr)buf) & (align-1);
 		nchunk++;
 	}
 
-	assert(n + pad <= nbuf);	
-	
+	assert(n + pad <= nbuf);
+
 	p = buf + pad;
 	buf += pad + n;
 	nbuf -= pad + n;
@@ -129,7 +129,7 @@ int
 vtFdWrite(int fd, uint8_t *buf, int n)
 {
 	int nn;
-	
+
 	nn = write(fd, buf, n);
 	if(nn < 0) {
 		vtOSError();

--- a/sys/src/liboventi/plan9-sha1.c
+++ b/sys/src/liboventi/plan9-sha1.c
@@ -10,6 +10,7 @@
 #include <u.h>
 #include <libc.h>
 #include <oventi.h>
+#include <mp.h>
 #include <libsec.h>
 
 extern void vtSha1Block(uint32_t *s, uint8_t *p, uint32_t len);

--- a/sys/src/liboventi/plan9-thread.c
+++ b/sys/src/liboventi/plan9-thread.c
@@ -212,7 +212,7 @@ vtRendezAlloc(VtLock *p)
 
 	q = vtMemAllocZ(sizeof(VtRendez));
 	q->lk = p;
-	setmalloctag(q, getcallerpc(&p));
+	setmalloctag(q, getcallerpc());
 	return q;
 }
 
@@ -248,7 +248,7 @@ vtLock(VtLock *p)
 	Thread *t;
 
 	lock(&p->lk);
-	p->pc = getcallerpc(&p);
+	p->pc = getcallerpc();
 	t = *vtRock;
 	if(p->writer == nil && p->readers == 0) {
 		p->writer = t;

--- a/sys/src/liboventi/rpc.c
+++ b/sys/src/liboventi/rpc.c
@@ -16,8 +16,8 @@ struct {
 	int version;
 	char *s;
 } vtVersions[] = {
-	VtVersion02, "02",
-	0, 0,
+	{VtVersion02, "02"},
+	{0, 0},
 };
 
 static char EBigString[] = "string too long";
@@ -212,7 +212,7 @@ char *
 vtGetVersion(VtSession *z)
 {
 	int v, i;
-	
+
 	v = z->version;
 	if(v == 0)
 		return "unknown";
@@ -247,7 +247,7 @@ vtVersionRead(VtSession *z, char *prefix, int *ret)
 			*p = 0;
 			break;
 		}
-		if(c < ' ' || *q && c != *q) {
+		if(c < ' ' || (*q && c != *q)) {
 			vtSetError(EBadVersion);
 			return 0;
 		}
@@ -255,7 +255,7 @@ vtVersionRead(VtSession *z, char *prefix, int *ret)
 		if(*q)
 			q++;
 	}
-		
+
 	vtDebug(z, "version string in: %s\n", buf);
 
 	p = buf + strlen(prefix);
@@ -274,7 +274,7 @@ vtVersionRead(VtSession *z, char *prefix, int *ret)
 		if(*p != ':')
 			return 0;
 		p++;
-	}	
+	}
 }
 
 Packet*
@@ -321,9 +321,9 @@ vtRecvPacket(VtSession *z)
 	p = packetSplit(p, len);
 	vtUnlock(z->inLock);
 	return p;
-Err:	
+Err:
 	vtUnlock(z->inLock);
-	return nil;	
+	return nil;
 }
 
 int
@@ -332,7 +332,7 @@ vtSendPacket(VtSession *z, Packet *p)
 	IOchunk ioc;
 	int n;
 	uint8_t buf[2];
-	
+
 	/* add framing */
 	n = packetSize(p);
 	if(n >= (1<<16)) {
@@ -374,7 +374,7 @@ vtGetString(Packet *p, char **ret)
 		return 0;
 	}
 	s = vtMemAlloc(n+1);
-	setmalloctag(s, getcallerpc(&p));
+	setmalloctag(s, getcallerpc());
 	if(!packetConsume(p, (uint8_t*)s, n)) {
 		vtMemFree(s);
 		return 0;
@@ -445,12 +445,12 @@ vtConnect(VtSession *z, char *password)
 		vtSha1Update(z->outHash, (uint8_t*)buf, p-buf);
 	if(!vtFdWrite(z->fd, (uint8_t*)buf, p-buf))
 		goto Err;
-	
+
 	vtDebug(z, "version string out: %s", buf);
 
 	if(!vtVersionRead(z, prefix, &z->version))
 		goto Err;
-		
+
 	vtDebug(z, "version = %d: %s\n", z->version, vtGetVersion(z));
 
 	vtUnlock(z->inLock);
@@ -463,7 +463,7 @@ vtConnect(VtSession *z, char *password)
 
 	if(!vtHello(z))
 		goto Err;
-	return 1;	
+	return 1;
 Err:
 	if(z->fd >= 0)
 		vtFdClose(z->fd);
@@ -472,6 +472,5 @@ Err:
 	vtUnlock(z->outLock);
 	z->cstate = VtStateClosed;
 	vtUnlock(z->lk);
-	return 0;	
+	return 0;
 }
-

--- a/sys/src/liboventi/scorefmt.c
+++ b/sys/src/liboventi/scorefmt.c
@@ -22,7 +22,7 @@ vtScoreFmt(Fmt *f)
 		fmtprint(f, "*");
 	}else{
 		for(i = 0; i < VtScoreSize; i++)
-			fmtprint(f, "%2.2ux", v[i]);
+			fmtprint(f, "%2.2x", v[i]);
 	}
 
 	return 0;

--- a/sys/src/liboventi/server.c
+++ b/sys/src/liboventi/server.c
@@ -22,7 +22,7 @@ vtServerAlloc(VtServerVtbl *vtbl)
 {
 	VtSession *z = vtAlloc();
 	z->vtbl = vtMemAlloc(sizeof(VtServerVtbl));
-	setmalloctag(z->vtbl, getcallerpc(&vtbl));
+	setmalloctag(z->vtbl, getcallerpc());
 	*z->vtbl = *vtbl;
 	return z;
 }
@@ -65,7 +65,7 @@ dispatchHello(VtSession *z, Packet **pkt)
 
 	p = *pkt;
 
-	version = nil;	
+	version = nil;
 	uid = nil;
 	crypto = nil;
 	codec = nil;
@@ -190,7 +190,6 @@ vtExport(VtSession *z)
 		return 1;
 	}
 
-	
 	p = nil;
 	clean = 0;
 	vtAttach();
@@ -198,7 +197,7 @@ vtExport(VtSession *z)
 		goto Exit;
 
 	vtDebug(z, "server connected!\n");
-if(0)	vtSetDebug(z, 1);
+	//vtSetDebug(z, 1);
 
 	for(;;) {
 		p = vtRecvPacket(z);
@@ -273,4 +272,3 @@ Exit:
 	exits(0);
 	return 0;	/* never gets here */
 }
-

--- a/sys/src/liboventi/session.h
+++ b/sys/src/liboventi/session.h
@@ -80,4 +80,3 @@ struct VtSession {
 	int crypto;
 	int codec;
 };
-

--- a/sys/src/liboventi/strdup.c
+++ b/sys/src/liboventi/strdup.c
@@ -22,7 +22,6 @@ vtStrDup(char *s)
 	n = strlen(s) + 1;
 	ss = vtMemAlloc(n);
 	memmove(ss, s, n);
-	setmalloctag(ss, getcallerpc(&s));
+	setmalloctag(ss, getcallerpc());
 	return ss;
 }
-

--- a/sys/src/liboventi/zero.c
+++ b/sys/src/liboventi/zero.c
@@ -49,7 +49,7 @@ vtZeroExtend(int type, uint8_t *buf, int n, int nn)
 	return 1;
 }
 
-int 
+int
 vtZeroTruncate(int type, uint8_t *buf, int n)
 {
 	uint8_t *p;


### PR DESCRIPTION
commit 275f0b42411259f8078477cf24f2b338d47c6ab2
Author: Dan Cross <cross@gajendra.net>
Date:   Thu Apr 20 16:19:04 2017 +0000

    Really expose warnings

    But also make it so that we can continue building.
    By exposing them, we see them so we can fix them.

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit 400364d361586e548bd7c08d8cdcb64a4bc69e90
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Wed Jul 6 13:53:16 2016 -0700

    fixfmt: with this last round of changes I can boot.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit 48090c023db7a9d0f4f36f3b270dc30080c24ce5
Author: ron minnich <rminnich@gmail.com>
Date:   Sun Feb 14 05:49:03 2016 +0100

    Revert "build: added new build files"
    Does not work at all. Can't build a working system with it yet.

    Let's take this slower, ok? Not break it all next time.

    This reverts commit 4fd75744926150212a0c0cd3c5a2ea51d0637d12.

    Change-Id: I91fce92249dd9d7bf3ca731a124c61a499382dd2

commit 4fd75744926150212a0c0cd3c5a2ea51d0637d12
Author: Sevki <sevki@spotify.com>
Date:   Wed Jan 27 12:46:31 2016 +0100

    build: added new build files

    kernel compiles and crashes

    closes #37

    to test use

            go get -u sevki.org/build/cmd/build
            build //sys/src/9/amd64:harvey
    or

            build -v //sys/src/9/amd64:harvey

    inside a editor like emacs or acme.

    If you are building on OS X you should also have something like .build
    file at the root of the project and add something like

            CC: gcc
            TOOLPREFIX: x86_64-elf-

    Change-Id: Ib6f6156eee1936ceb5f8b0bfa64ed45589195c31
    Signed-off-by: Sevki <sevki@spotify.com>

commit 6533db6114e97d5687bdb6a0f94136c98d009408
Author: Dan Cross <cross@gajendra.net>
Date:   Mon May 1 00:00:16 2017 +0000

    Remove trailing whitespace from source files.

    This is a trivial cleanup (done with a script, Ron!).

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit 789474da8c5122316f7ee093a02e84a4aed24ad2
Author: Dan Cross <cross@gajendra.net>
Date:   Thu Apr 20 17:59:21 2017 +0000

    Kill a couple of thousand warnings.

    These are the easy ones. I've got a few hundred left.

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit a9d13806e2923195accce1ddbd0caa6e18ce386b
Author: fuchicar <rafita.fernandez@gmail.com>
Date:   Fri Mar 10 12:33:27 2017 +0100

    Removed ifndef _MPINT from libsec.h

    This is not Harvey style. Removing it implies add #include <mp.h> before each #include <libsec.h>

    Signed-off-by: fuchicar <rafita.fernandez@gmail.com>

commit ba14fa27776ef2371a42607ec04bf50287fbd0be
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Fri Nov 13 08:20:41 2015 -0800

    New json format per Giacomo's ideas.

    Instead of this:
    {
            "Name": "a",
            ...
    }

    Do this:
    {
            "Name": {
                    ...
            }
    }

    This is way better. Now the name is visible at the top level of any json viewer, we can
    have multiple stanzas per file, the name is way more easy to find, ... the advantages are legion.

    This includes a change to build.go but not to preen.

    This now works fine, BUILD all produces a working kernel and userland. But someone else needs to verify it.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

    Change-Id: I9b1cf2597e582895b8f3ab127bc9c1d77de96cbd

commit c58c6c510d5875253d66b4d26d9ae9025f9191f3
Author: Dan Cross <cross@gajendra.net>
Date:   Mon May 1 00:39:33 2017 +0000

    Remove blank lines at end of file.

    Remove a bunch of blank lines at the end of files.

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit fb6397b65de181cedb2c0a782d3d92f4c6dfd537
Author: Elbing Miss <elbingmiss@gmail.com>
Date:   Thu Aug 11 03:28:57 2016 +0200

    Updating code to be able being built by gcc 6

    Added -Wno-frame-address to avoid errors about
    __builtin_frame_address in:
    - libc/port/getcallerpc.c
    - libc/port/malloc.c

    And related in kernel and cmd.

    NOTE: if/else statements indentation is now a warning in case
    {} would be missing.

commit fb8adc5a7b7785b2dc2780b0e0afdc38bc6d62a8
Author: Hank Donnay <hdonnay@gmail.com>
Date:   Sun Aug 2 13:26:55 2015 -0500

    Fix compiler warnings in liboventi

    plan9-sha1.c: remove funciton declaration that was never defined.

    rpc.c: remove funciton declaration that was never defined.

    plan9-thread.c: cast void** from privalloc() to Thread**

    Change-Id: I00e345a1ecef26f81b0f1f226f2e9bb6508dc889
    Signed-off-by: Hank Donnay <hdonnay@gmail.com>