### PR TITLE
Reintroduce libndb

### DIFF
--- a/sys/src/libndb/csgetval.c
+++ b/sys/src/libndb/csgetval.c
@@ -88,7 +88,7 @@ csgetvalue(char *netroot, char *attr, char *val, char *rattr,
 	}
 
 	if(pp){
-		setmalloctag(first, getcallerpc(&netroot));
+		setmalloctag(first, getcallerpc());
 		*pp = first;
 	} else
 		ndbfree(first);
@@ -114,6 +114,6 @@ csgetval(char *netroot, char *attr, char *val, char *rattr,
 		}
 		free(p);
 	}
-	ndbsetmalloctag(t, getcallerpc(&netroot));
+	ndbsetmalloctag(t, getcallerpc());
 	return t;
 }

--- a/sys/src/libndb/csipinfo.c
+++ b/sys/src/libndb/csipinfo.c
@@ -43,7 +43,7 @@ csipinfo(char *netroot, char *attr, char *val, char **list, int n)
 			break;
 		p = seprint(p, e, " %s", *list++);
 	}
-	
+
 	if(write(fd, line, strlen(line)) < 0){
 		close(fd);
 		return 0;
@@ -72,6 +72,6 @@ csipinfo(char *netroot, char *attr, char *val, char **list, int n)
 	}
 	close(fd);
 
-	ndbsetmalloctag(first, getcallerpc(&netroot));
+	ndbsetmalloctag(first, getcallerpc());
 	return first;
 }

--- a/sys/src/libndb/dnsquery.c
+++ b/sys/src/libndb/dnsquery.c
@@ -76,7 +76,7 @@ dnsquery(char *net, char *val, char *type)
 	 * walking to /net*^/dns.  Must be prepared to re-open it on error.
 	 */
 	close(fd);
-	ndbsetmalloctag(t, getcallerpc(&net));
+	ndbsetmalloctag(t, getcallerpc());
 	return t;
 }
 
@@ -133,11 +133,11 @@ doquery(int fd, char *dn, char *type)
 	snprint(buf, sizeof(buf), "!%s %s", dn, type);
 	if(write(fd, buf, strlen(buf)) < 0)
 		return nil;
-		
+
 	seek(fd, 0, 0);
 
 	first = last = nil;
-	
+
 	for(;;){
 		n = read(fd, buf, sizeof(buf)-2);
 		if(n <= 0)
@@ -165,6 +165,6 @@ doquery(int fd, char *dn, char *type)
 		}
 	}
 
-	ndbsetmalloctag(first, getcallerpc(&fd));
+	ndbsetmalloctag(first, getcallerpc());
 	return first;
 }

--- a/sys/src/libndb/libndb.json
+++ b/sys/src/libndb/libndb.json
@@ -1,29 +1,30 @@
 {
-	"Include": [
-		"../lib.json"
-	],
-	"Install": "/$ARCH/lib/",
-	"Library": "libndb.a",
-	"Name": "libndb",
-	"SourceFiles": [
-		"csgetval.c",
-		"csipinfo.c",
-		"dnsquery.c",
-		"ipattr.c",
-		"ndbaux.c",
-		"ndbcache.c",
-		"ndbcat.c",
-		"ndbconcatenate.c",
-		"ndbdiscard.c",
-		"ndbfree.c",
-		"ndbgetipaddr.c",
-		"ndbgetval.c",
-		"ndbhash.c",
-		"ndbipinfo.c",
-		"ndblookval.c",
-		"ndbopen.c",
-		"ndbparse.c",
-		"ndbreorder.c",
-		"ndbsubstitute.c"
-	]
+	"libndb": {
+		"Include": [
+			"../lib.json"
+		],
+		"Install": "/$ARCH/lib/",
+		"Library": "libndb.a",
+		"SourceFiles": [
+			"csgetval.c",
+			"csipinfo.c",
+			"dnsquery.c",
+			"ipattr.c",
+			"ndbaux.c",
+			"ndbcache.c",
+			"ndbcat.c",
+			"ndbconcatenate.c",
+			"ndbdiscard.c",
+			"ndbfree.c",
+			"ndbgetipaddr.c",
+			"ndbgetval.c",
+			"ndbhash.c",
+			"ndbipinfo.c",
+			"ndblookval.c",
+			"ndbopen.c",
+			"ndbparse.c",
+			"ndbreorder.c",
+			"ndbsubstitute.c"
+		]
+	}
 }

--- a/sys/src/libndb/ndbaux.c
+++ b/sys/src/libndb/ndbaux.c
@@ -31,7 +31,7 @@ _ndbparsetuple(char *cp, Ndbtuple **tp)
 		return 0;
 
 	t = ndbnew(nil, nil);
-	setmalloctag(t, getcallerpc(&cp));
+	setmalloctag(t, getcallerpc());
 	*tp = t;
 
 	/* parse attribute */
@@ -69,7 +69,7 @@ _ndbparsetuple(char *cp, Ndbtuple **tp)
 }
 
 /*
- *  parse all tuples in a line.  we assume that the 
+ *  parse all tuples in a line.  we assume that the
  *  line ends in a '\n'.
  *
  *  the tuples are linked as a list using ->entry and
@@ -95,10 +95,10 @@ _ndbparseline(char *cp)
 		last = t;
 		t->line = 0;
 		t->entry = 0;
-		setmalloctag(t, getcallerpc(&cp));
+		setmalloctag(t, getcallerpc());
 	}
 	if(first)
 		last->line = first;
-	ndbsetmalloctag(first, getcallerpc(&cp));
+	ndbsetmalloctag(first, getcallerpc());
 	return first;
 }

--- a/sys/src/libndb/ndbcache.c
+++ b/sys/src/libndb/ndbcache.c
@@ -18,7 +18,7 @@ struct Ndbcache
 	char		*attr;
 	char		*val;
 	Ndbs		s;
-	Ndbtuple	*t;	
+	Ndbtuple	*t;
 };
 
 enum
@@ -73,7 +73,7 @@ ndbcopy(Ndb *db, Ndbtuple *from_t, Ndbs *from_s, Ndbs *to_s)
 		last = to_t;
 		newline = from_t->line != from_t->entry;
 	}
-	ndbsetmalloctag(first, getcallerpc(&db));
+	ndbsetmalloctag(first, getcallerpc());
 	return first;
 }
 
@@ -137,7 +137,7 @@ _ndbcacheadd(Ndb *db, Ndbs *s, char *attr, char *val, Ndbtuple *t)
 	*l = nil;
 err:
 	ndbcachefree(c);
-	ndbsetmalloctag(t, getcallerpc(&db));
+	ndbsetmalloctag(t, getcallerpc());
 	return t;
 }
 

--- a/sys/src/libndb/ndbconcatenate.c
+++ b/sys/src/libndb/ndbconcatenate.c
@@ -23,6 +23,6 @@ ndbconcatenate(Ndbtuple *a, Ndbtuple *b)
 	for(t = a; t->entry; t = t->entry)
 		;
 	t->entry = b;
-	ndbsetmalloctag(a, getcallerpc(&a));
+	ndbsetmalloctag(a, getcallerpc());
 	return a;
 }

--- a/sys/src/libndb/ndbdiscard.c
+++ b/sys/src/libndb/ndbdiscard.c
@@ -34,6 +34,6 @@ ndbdiscard(Ndbtuple *t, Ndbtuple *a)
 	a->entry = nil;
 	ndbfree(a);
 
-	ndbsetmalloctag(t, getcallerpc(&t));
+	ndbsetmalloctag(t, getcallerpc());
 	return t;
 }

--- a/sys/src/libndb/ndbfree.c
+++ b/sys/src/libndb/ndbfree.c
@@ -70,8 +70,8 @@ ndbnew(char *attr, char *val)
 	t->val = t->valbuf;
 	if(val != nil)
 		ndbsetval(t, val, strlen(val));
-	ndbsetmalloctag(t, getcallerpc(&attr));
-	return t;	
+	ndbsetmalloctag(t, getcallerpc());
+	return t;
 }
 
 /*

--- a/sys/src/libndb/ndbgetipaddr.c
+++ b/sys/src/libndb/ndbgetipaddr.c
@@ -25,7 +25,7 @@ ndbgetipaddr(Ndb *db, char *val)
 	attr = ipattr(val);
 	if(strcmp(attr, "ip") == 0){
 		it = ndbnew("ip", val);
-		ndbsetmalloctag(it, getcallerpc(&db));
+		ndbsetmalloctag(it, getcallerpc());
 		return it;
 	}
 
@@ -53,6 +53,6 @@ ndbgetipaddr(Ndb *db, char *val)
 		}
 	}
 
-	ndbsetmalloctag(first, getcallerpc(&db));
+	ndbsetmalloctag(first, getcallerpc());
 	return first;
 }

--- a/sys/src/libndb/ndbgetval.c
+++ b/sys/src/libndb/ndbgetval.c
@@ -82,6 +82,6 @@ ndbgetval(Ndb *db, Ndbs *s, char *attr, char *val, char *rattr,
 		}
 		free(p);
 	}
-	ndbsetmalloctag(t, getcallerpc(&db));
+	ndbsetmalloctag(t, getcallerpc());
 	return t;
 }

--- a/sys/src/libndb/ndbhash.c
+++ b/sys/src/libndb/ndbhash.c
@@ -133,13 +133,13 @@ ndbsearch(Ndb *db, Ndbs *s, char *attr, char *val)
 	if(_ndbcachesearch(db, s, attr, val, &t) == 0){
 		/* found in cache */
 		if(t != nil){
-			ndbsetmalloctag(t, getcallerpc(&db));
+			ndbsetmalloctag(t, getcallerpc());
 			return t;	/* answer from this file */
 		}
 		if(db->next == nil)
 			return nil;
 		t = ndbsearch(db->next, s, attr, val);
-		ndbsetmalloctag(t, getcallerpc(&db));
+		ndbsetmalloctag(t, getcallerpc());
 		return t;
 	}
 
@@ -150,7 +150,7 @@ ndbsearch(Ndb *db, Ndbs *s, char *attr, char *val)
 		p = hfread(s->hf, s->ptr+NDBHLEN, NDBPLEN);
 		if(p == 0){
 			t = _ndbcacheadd(db, s, attr, val, nil);
-			ndbsetmalloctag(t, getcallerpc(&db));
+			ndbsetmalloctag(t, getcallerpc());
 			return t;
 		}
 		s->ptr = NDBGETP(p);
@@ -165,7 +165,7 @@ ndbsearch(Ndb *db, Ndbs *s, char *attr, char *val)
 		if(db->next == 0)
 			return nil;
 		t = ndbsearch(db->next, s, attr, val);
-		ndbsetmalloctag(t, getcallerpc(&db));
+		ndbsetmalloctag(t, getcallerpc());
 		return t;
 	} else {
 		s->ptr = 0;
@@ -173,7 +173,7 @@ ndbsearch(Ndb *db, Ndbs *s, char *attr, char *val)
 	}
 	t = ndbsnext(s, attr, val);
 	_ndbcacheadd(db, s, attr, val, (t != nil && s->db == db)?t:nil);
-	ndbsetmalloctag(t, getcallerpc(&db));
+	ndbsetmalloctag(t, getcallerpc());
 	return t;
 }
 
@@ -211,21 +211,21 @@ ndbsnext(Ndbs *s, char *attr, char *val)
 			s->ptr = Boffset(&db->b);
 			if(t == 0)
 				break;
-			if(s->t = match(t, attr, val)){
-				ndbsetmalloctag(t, getcallerpc(&s));
+			if((s->t = match(t, attr, val)) != 0){
+				ndbsetmalloctag(t, getcallerpc());
 				return t;
 			}
 			ndbfree(t);
 		} else if(s->type == Cptr){
 			if(Bseek(&db->b, s->ptr, 0) < 0)
-				break; 
+				break;
 			s->ptr = s->ptr1;
 			s->type = Cptr1;
 			t = ndbparse(db);
 			if(t == 0)
 				break;
-			if(s->t = match(t, attr, val)){
-				ndbsetmalloctag(t, getcallerpc(&s));
+			if((s->t = match(t, attr, val)) != 0){
+				ndbsetmalloctag(t, getcallerpc());
 				return t;
 			}
 			ndbfree(t);
@@ -240,13 +240,13 @@ ndbsnext(Ndbs *s, char *attr, char *val)
 				s->type = Cptr;
 			} else {		/* end of hash chain */
 				if(Bseek(&db->b, s->ptr, 0) < 0)
-					break; 
+					break;
 				s->ptr = NDBNAP;
 				t = ndbparse(db);
 				if(t == 0)
 					break;
-				if(s->t = match(t, attr, val)){
-					ndbsetmalloctag(t, getcallerpc(&s));
+				if((s->t = match(t, attr, val)) != 0){
+					ndbsetmalloctag(t, getcallerpc());
 					return t;
 				}
 				ndbfree(t);
@@ -264,6 +264,6 @@ nextfile:
 
 	/* advance search to next db file */
 	t = ndbsearch(db->next, s, attr, val);
-	ndbsetmalloctag(t, getcallerpc(&s));
+	ndbsetmalloctag(t, getcallerpc());
 	return t;
 }

--- a/sys/src/libndb/ndbipinfo.c
+++ b/sys/src/libndb/ndbipinfo.c
@@ -23,7 +23,6 @@ enum
 static Ndbtuple*	filter(Ndb *db, Ndbtuple *t, Ndbtuple *f);
 static Ndbtuple*	mkfilter(int argc, char **argv);
 static int		filtercomplete(Ndbtuple *f);
-static Ndbtuple*	toipaddr(Ndb *db, Ndbtuple *t);
 static int		prefixlen(uint8_t *ip);
 static Ndbtuple*	subnet(Ndb *db, uint8_t *net, Ndbtuple *f,
 			       int prefix);
@@ -50,7 +49,7 @@ mkfilter(int argc, char **argv)
 		}
 		strncpy(t->attr, p, sizeof(t->attr)-1);
 	}
-	ndbsetmalloctag(first, getcallerpc(&argc));
+	ndbsetmalloctag(first, getcallerpc());
 	return first;
 }
 
@@ -108,7 +107,7 @@ filter(Ndb *db, Ndbtuple *t, Ndbtuple *f)
 		if(nf->ptr & Ffound)
 			nf->ptr = (nf->ptr & ~Ffound) | Fignore;
 
-	ndbsetmalloctag(t, getcallerpc(&db));
+	ndbsetmalloctag(t, getcallerpc());
 	return t;
 }
 
@@ -156,7 +155,7 @@ subnet(Ndb *db, uint8_t *net, Ndbtuple *f, int prefix)
 		ndbfree(nt);
 		nt = ndbsnext(&s, "ip", netstr);
 	}
-	ndbsetmalloctag(t, getcallerpc(&db));
+	ndbsetmalloctag(t, getcallerpc());
 	return t;
 }
 
@@ -192,7 +191,7 @@ ndbipinfo(Ndb *db, char *attr, char *val, char **alist, int n)
 		/* none found, make one up */
 		if(strcmp(attr, "ip") != 0) {
 			ndbfree(f);
-			return nil;	
+			return nil;
 		}
 		t = ndbnew("ip", val);
 		t->line = t;
@@ -260,6 +259,6 @@ ndbipinfo(Ndb *db, char *attr, char *val, char **alist, int n)
 	}
 
 	ndbfree(f);
-	ndbsetmalloctag(t, getcallerpc(&db));
+	ndbsetmalloctag(t, getcallerpc());
 	return t;
 }

--- a/sys/src/libndb/ndbparse.c
+++ b/sys/src/libndb/ndbparse.c
@@ -53,7 +53,7 @@ ndbparse(Ndb *db)
 		t = _ndbparseline(line);
 		if(t == 0)
 			continue;
-		setmalloctag(t, getcallerpc(&db));
+		setmalloctag(t, getcallerpc());
 		if(first)
 			last->entry = t;
 		else
@@ -62,6 +62,6 @@ ndbparse(Ndb *db)
 		while(last->entry)
 			last = last->entry;
 	}
-	ndbsetmalloctag(first, getcallerpc(&db));
+	ndbsetmalloctag(first, getcallerpc());
 	return first;
 }

--- a/sys/src/libndb/ndbreorder.c
+++ b/sys/src/libndb/ndbreorder.c
@@ -36,7 +36,7 @@ ndbreorder(Ndbtuple *t, Ndbtuple *x)
 		for(nt = t; nt->entry != last->line; nt = nt->entry)
 			;
 		nt->entry = nil;
-	
+
 		/* switch */
 		for(nt = last; nt->entry != nil; nt = nt->entry)
 			;
@@ -47,7 +47,7 @@ ndbreorder(Ndbtuple *t, Ndbtuple *x)
 	if(x != last->line){
 
 		/* find entry before x */
-		for(prev = last; prev->line != x; prev = prev->line);
+		for(prev = last; prev->line != x; prev = prev->line)
 			;
 
 		/* detach line */

--- a/sys/src/libndb/ndbsubstitute.c
+++ b/sys/src/libndb/ndbsubstitute.c
@@ -19,12 +19,12 @@ ndbsubstitute(Ndbtuple *t, Ndbtuple *a, Ndbtuple *b)
 	Ndbtuple *nt;
 
 	if(a == b){
-		ndbsetmalloctag(t, getcallerpc(&t));
+		ndbsetmalloctag(t, getcallerpc());
 		return t;
 	}
 	if(b == nil){
 		t = ndbdiscard(t, a);
-		ndbsetmalloctag(t, getcallerpc(&t));
+		ndbsetmalloctag(t, getcallerpc());
 		return t;
 	}
 
@@ -46,10 +46,10 @@ ndbsubstitute(Ndbtuple *t, Ndbtuple *a, Ndbtuple *b)
 	ndbfree(a);
 
 	if(a == t){
-		ndbsetmalloctag(b, getcallerpc(&t));
+		ndbsetmalloctag(b, getcallerpc());
 		return b;
 	}else{
-		ndbsetmalloctag(t, getcallerpc(&t));
+		ndbsetmalloctag(t, getcallerpc());
 		return t;
 	}
 }


### PR DESCRIPTION
commit 331ffebb5394eb0768cea498e43a2d2c98829e9d
Author: Sevki Hasirci <s@sevki.org>
Date:   Mon Feb 22 00:55:22 2016 +0100

    just the files

commit 48090c023db7a9d0f4f36f3b270dc30080c24ce5
Author: ron minnich <rminnich@gmail.com>
Date:   Sun Feb 14 05:49:03 2016 +0100

    Revert "build: added new build files"
    Does not work at all. Can't build a working system with it yet.

    Let's take this slower, ok? Not break it all next time.

    This reverts commit 4fd75744926150212a0c0cd3c5a2ea51d0637d12.

    Change-Id: I91fce92249dd9d7bf3ca731a124c61a499382dd2

commit 4fd75744926150212a0c0cd3c5a2ea51d0637d12
Author: Sevki <sevki@spotify.com>
Date:   Wed Jan 27 12:46:31 2016 +0100

    build: added new build files

    kernel compiles and crashes

    closes #37

    to test use

            go get -u sevki.org/build/cmd/build
            build //sys/src/9/amd64:harvey
    or

            build -v //sys/src/9/amd64:harvey

    inside a editor like emacs or acme.

    If you are building on OS X you should also have something like .build
    file at the root of the project and add something like

            CC: gcc
            TOOLPREFIX: x86_64-elf-

    Change-Id: Ib6f6156eee1936ceb5f8b0bfa64ed45589195c31
    Signed-off-by: Sevki <sevki@spotify.com>

commit 72777a1fab7b33c26bb4d9dccff934d4f213303e
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Thu Aug 20 09:49:28 2015 -0700

    Expose the 'dc' parameter to user programs by extending the mount call.

    The mount call has another parameter, an int, which is the device character
    used to pick a mount device. This works for mount and ramfs,
    but it would be nice if someone else could verify it.

    Now, go forth, and write new devmnt devices!

    Change-Id: I765dd6830f5a26d8a96d5e568fe61871cf7e402c
    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit ba14fa27776ef2371a42607ec04bf50287fbd0be
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Fri Nov 13 08:20:41 2015 -0800

    New json format per Giacomo's ideas.

    Instead of this:
    {
            "Name": "a",
            ...
    }

    Do this:
    {
            "Name": {
                    ...
            }
    }

    This is way better. Now the name is visible at the top level of any json viewer, we can
    have multiple stanzas per file, the name is way more easy to find, ... the advantages are legion.

    This includes a change to build.go but not to preen.

    This now works fine, BUILD all produces a working kernel and userland. But someone else needs to verify it.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

    Change-Id: I9b1cf2597e582895b8f3ab127bc9c1d77de96cbd