### PR TITLE
Reintroduce libmemlayer

### DIFF
--- a/sys/src/libmemlayer/BUILD
+++ b/sys/src/libmemlayer/BUILD
@@ -1,7 +1,7 @@
 load('//sys/src/FLAGS', "KLIB_COMPILER_FLAGS", "LIB_COMPILER_FLAGS")
 
 cc_library(
-    name="libkmemlayer",
+    name="klibmemlayer",
     copts=KLIB_COMPILER_FLAGS,
     includes=[
         "//sys/include",

--- a/sys/src/libmemlayer/draw.c
+++ b/sys/src/libmemlayer/draw.c
@@ -73,8 +73,8 @@ memdraw(Memimage *dst, Rectangle r, Memimage *src, Point p0, Memimage *mask, Poi
 		mask = memopaque;
 
 	if(mask->layer){
-if(drawdebug)	iprint("mask->layer != nil\n");
-		return;	/* too hard, at least for now */
+		if(drawdebug)	iprint("mask->layer != nil\n");
+			return;	/* too hard, at least for now */
 	}
 
     Top:
@@ -84,7 +84,7 @@ if(drawdebug)	iprint("mask->layer != nil\n");
 	}
 
 	if(drawclip(dst, &r, src, &p0, mask, &p1, &srcr, &mr) == 0){
-if(drawdebug)	iprint("drawclip dstcr %R srccr %R maskcr %R\n", dst->clipr, src->clipr, mask->clipr);
+		if(drawdebug)	iprint("drawclip dstcr %R srccr %R maskcr %R\n", dst->clipr, src->clipr, mask->clipr);
 		return;
 	}
 

--- a/sys/src/libmemlayer/klibmemlayer.json
+++ b/sys/src/libmemlayer/klibmemlayer.json
@@ -1,10 +1,10 @@
 {
-	"libmemlayer": {
+	"KernelLibmemlayer": {
 		"Include": [
-			"../lib.json"
+			"/$ARCH/include/klib.json"
 		],
 		"Install": "/$ARCH/lib/",
-		"Library": "libmemlayer.a",
+		"Library": "klibmemlayer.a",
 		"SourceFiles": [
 			"draw.c",
 			"lalloc.c",


### PR DESCRIPTION
commit 275f0b42411259f8078477cf24f2b338d47c6ab2
Author: Dan Cross <cross@gajendra.net>
Date:   Thu Apr 20 16:19:04 2017 +0000

    Really expose warnings

    But also make it so that we can continue building.
    By exposing them, we see them so we can fix them.

    Signed-off-by: Dan Cross <cross@gajendra.net>

commit 432c7a6bc6b62468540867571d18b1aaedf1e297
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Sun Jun 26 16:45:58 2016 -0700

    ACPI: fix up BUILD files so kernel almost builds.

    There were missing flags, the library names were still wrong, lots of little things.

    Still not quite there but close.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit 48090c023db7a9d0f4f36f3b270dc30080c24ce5
Author: ron minnich <rminnich@gmail.com>
Date:   Sun Feb 14 05:49:03 2016 +0100

    Revert "build: added new build files"
    Does not work at all. Can't build a working system with it yet.

    Let's take this slower, ok? Not break it all next time.

    This reverts commit 4fd75744926150212a0c0cd3c5a2ea51d0637d12.

    Change-Id: I91fce92249dd9d7bf3ca731a124c61a499382dd2

commit 4fd75744926150212a0c0cd3c5a2ea51d0637d12
Author: Sevki <sevki@spotify.com>
Date:   Wed Jan 27 12:46:31 2016 +0100

    build: added new build files

    kernel compiles and crashes

    closes #37

    to test use

            go get -u sevki.org/build/cmd/build
            build //sys/src/9/amd64:harvey
    or

            build -v //sys/src/9/amd64:harvey

    inside a editor like emacs or acme.

    If you are building on OS X you should also have something like .build
    file at the root of the project and add something like

            CC: gcc
            TOOLPREFIX: x86_64-elf-

    Change-Id: Ib6f6156eee1936ceb5f8b0bfa64ed45589195c31
    Signed-off-by: Sevki <sevki@spotify.com>

commit ada265febbdf82eeced35e932912560f5ed3ef8e
Merge: 16eb9742b 8e7d21798
Author: Sevki <s@sevki.org>
Date:   Tue Mar 1 14:55:23 2016 +0100

    Merge branch 'master' into master

commit ba14fa27776ef2371a42607ec04bf50287fbd0be
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Fri Nov 13 08:20:41 2015 -0800

    New json format per Giacomo's ideas.

    Instead of this:
    {
            "Name": "a",
            ...
    }

    Do this:
    {
            "Name": {
                    ...
            }
    }

    This is way better. Now the name is visible at the top level of any json viewer, we can
    have multiple stanzas per file, the name is way more easy to find, ... the advantages are legion.

    This includes a change to build.go but not to preen.

    This now works fine, BUILD all produces a working kernel and userland. But someone else needs to verify it.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

    Change-Id: I9b1cf2597e582895b8f3ab127bc9c1d77de96cbd

commit cbe9d09d92aa7041fa5e2d640d3bec2ba92f81ad
Author: Ronald G. Minnich <rminnich@gmail.com>
Date:   Sat Feb 27 08:34:32 2016 -0800

    riscv: relocate some files that are architecture-dependent; fix mksys.go for riscv syscalls

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

commit da1fc778d8ec321fb85a6c044bfbc0ac0bc81ef7
Author: Elbing <elbingmiss@gmail.com>
Date:   Wed Sep 2 16:06:23 2015 +0200

    Bringing rio: Stage 1.

    Serial mouse goes to Heaven :-)

    Added devvga and various drivers. VESA is not working, it wants
    dev/realmode and others ancient relics.

    Testing kvm with vmware driver. For now, adding missing files
    in dis patch. I'll add some other vga drivers, suggestions
    are welcome, because I don't know all of the vendors and some are out
    of date (s3, 3dfx, etc..).

    Added Cirrus driver for qemu/KVM testing.

    Removing old alloc.c and merging its functions in qmalloc.c

    Added another driver to test.

    REMOVING DRIVERS DUE TO A NEW MODEL.
    Changes in json files are needed, devdraw, devmouse, and related
    are needed, though they will be refactored.

    Remaining file removed.

    Last change to get rid off old drivers.

    Last cleaning. No drivers for now.

    Change-Id: Ifeb53b62ff846a2ead217fc51136724e5310a443

commit fb6397b65de181cedb2c0a782d3d92f4c6dfd537
Author: Elbing Miss <elbingmiss@gmail.com>
Date:   Thu Aug 11 03:28:57 2016 +0200

    Updating code to be able being built by gcc 6

    Added -Wno-frame-address to avoid errors about
    __builtin_frame_address in:
    - libc/port/getcallerpc.c
    - libc/port/malloc.c

    And related in kernel and cmd.

    NOTE: if/else statements indentation is now a warning in case
    {} would be missing.