### PR TITLE
Reintroducing lib9p

### DIFF
--- a/sys/src/lib9p/srv.c
+++ b/sys/src/lib9p/srv.c
@@ -16,7 +16,6 @@
 
 void (*_forker)(void(*)(void*), void*, int);
 
-static char Ebadattach[] = "unknown specifier in attach";
 static char Ebadoffset[] = "bad offset";
 static char Ebotch[] = "9P protocol botch";
 static char Ecreatenondir[] = "create in non-directory";


### PR DESCRIPTION
- Removed Ebadattach due to it's not used

Signed-off-by: Álvaro Jurado <elbingmiss@gmail.com>