### PR TITLE
Use clang/gcc compatible builtin for abort to avoid clang error

### DIFF
--- a/sys/include/libc.h
+++ b/sys/include/libc.h
@@ -680,7 +680,7 @@ extern char *argv0;
 #define	ARGF()		(_argt=_args, _args="",\
 				(*_argt? _argt: argv[1]? (argc--, *++argv): 0))
 #define	EARGF(x)	(_argt=_args, _args="",\
-				(*_argt? _argt: argv[1]? (argc--, *++argv): ((x), argc = abort(), (char*)0)))
+				(*_argt? _argt: argv[1]? (argc--, *++argv): ((x), abort(), (char*)0)))
 
 #define	ARGC()		_argc
 

--- a/sys/src/libc/9sys/abort.c
+++ b/sys/src/libc/9sys/abort.c
@@ -9,9 +9,9 @@
 
 #include <u.h>
 #include <libc.h>
+
 void
 abort(void)
 {
-	while(*(int*)0)
-		;
+	__builtin_trap();
 }


### PR DESCRIPTION
Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>