### PR TITLE
Various fixes:

### DIFF
--- a/sys/include/libc.h
+++ b/sys/include/libc.h
@@ -296,7 +296,7 @@ enum
 	PNGROUP		= 2,
 };
 
-extern	void	_assert(const char*);
+extern	void	_assert(char*);
 extern	int	abs(int);
 extern	int	atexit(void(*)(void));
 extern	void	atexitdont(void(*)(void));

--- a/sys/src/9/port/portclock.c
+++ b/sys/src/9/port/portclock.c
@@ -187,7 +187,7 @@ hzclock(Ureg *ur)
 
 	if(machp()->machno == 0) {
 		/* since sys->ticks is only updated if machp()->machno == 0 */
-	checkalarms();
+		checkalarms();
 	}
 
 	if(up && up->state == Running)

--- a/sys/src/cmd/vnc/compat.c
+++ b/sys/src/cmd/vnc/compat.c
@@ -20,7 +20,7 @@ char	*eve;
 extern void *mainmem;
 
 void
-_assert(const char *fmt)
+_assert(char *fmt)
 {
 	panic("assert failed: %s", fmt);
 }

--- a/sys/src/libc/9sys/abort.c
+++ b/sys/src/libc/9sys/abort.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the UCB release of Plan 9. It is subject to the license
- * terms in the LICENSE file found in the toplevel directory of this	
+ * terms in the LICENSE file found in the toplevel directory of this
  * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
  * part of the UCB release of Plan 9, including this file, may be copied,
  * modified, propagated, or distributed except according to the terms contained
@@ -13,5 +13,6 @@
 void
 abort(void)
 {
-	__builtin_trap();
+	while(*(volatile int*)0)
+		;
 }

--- a/sys/src/libc/port/_assert.c
+++ b/sys/src/libc/port/_assert.c
@@ -13,10 +13,10 @@
 void (*__assert)(char*);
 
 void
-_assert(const char *s)
+_assert(char *s)
 {
 	if(__assert)
-		(*__assert)((char*)s);
+		(*__assert)(s);
 	fprint(2, "assert failed: %s\n", s);
 	abort();
 }

--- a/util/src/harvey/cmd/mksys/mksys.go
+++ b/util/src/harvey/cmd/mksys/mksys.go
@@ -137,7 +137,7 @@ func main() {
 		case "amd64":
 		case "riscv":
 			usage("riscv support is incomplete")
-		default: 
+		default:
 			usage(a + " is not supported.")
 		}
 		syscallargs := []string{"DI", "SI", "DX", "R10", "R8", "R9"}
@@ -230,7 +230,7 @@ TEXT runtime·{{ .Libname }}(SB),NOSPLIT,$0
 		if err != nil {
 			log.Fatal(err)
 		}
-		default: 
+		default:
 			usage(a + " is not supported for system call generation.")
 		}
 
@@ -354,8 +354,7 @@ int nsyscall = nelem(systab);
 
 Method method[] = {
 {{ range . }}{ "{{.Name}}", {{.Config}}, {{.Connect}}, "{{.Arg}}", },
-{{ end }}
-	{ nil },
+{{ end }}{ nil },
 };
 
 int cpuflag = 1;


### PR DESCRIPTION
- assert doesn't need to be restrict to const.
- builtin_trap is an alternative for abort under certain circumstances,
  our need is the original loop.
- aesthetic fix in mksys.go for boot methods

Signed-off-by: Álvaro Jurado <elbingmiss@gmail.com>