### PR TITLE
Cleaning some messages from boot

### DIFF
--- a/sys/src/9/386/vgavesa.c
+++ b/sys/src/9/386/vgavesa.c
@@ -76,7 +76,7 @@ vbecall(Ureg *u)
 	pa = PADDR(RMBUF);
 	cmem->dev->write(cmem, modebuf, sizeof modebuf, pa);
 	u->trap = 0x10;
-	print("vbecall: sizeof u is %d\n", sizeof *u);
+	if(DBGFLG) print("vbecall: sizeof u is %d\n", sizeof *u);
 	creg->dev->write(creg, u, sizeof *u, 0);
 
 	creg->dev->read(creg, u, sizeof *u, 0);

--- a/sys/src/9/amd64/mmu.c
+++ b/sys/src/9/amd64/mmu.c
@@ -646,9 +646,9 @@ vmap(uintptr_t pa, usize size)
 	uintptr_t va;
 	usize o, sz;
 
-	DBG("vmap(%#p, %lu) pc=%#p\n", pa, size, getcallerpc());
+	if(DBGFLG) print("vmap(%#p, %lu) pc=%#p\n", pa, size, getcallerpc());
 
-	if(machp()->machno != 0)
+	if(machp()->machno != 0 && DBGFLG)
 		print("vmap: machp()->machno != 0\n");
 
 	/*
@@ -700,7 +700,7 @@ vunmap(void* v, usize size)
 	DBG("vunmap(%#p, %lu)\n", v, size);
 
 	if(machp()->machno != 0)
-		print("vmap: machp()->machno != 0\n");
+		DBG("vmap: machp()->machno != 0\n");
 
 	/*
 	 * See the comments above in vmap.

--- a/sys/src/9/boot/boot.c
+++ b/sys/src/9/boot/boot.c
@@ -95,7 +95,7 @@ boot(int argc, char *argv[])
 	bind("#e", "/env", MBEFORE|MCREATE);
 	bind("#s", "/srv", MREPL|MCREATE);
 	bind("#p", "/proc", MREPL|MCREATE);
-	print("Hello, I am Harvey :-)\n");
+	print("\nHello, I am Harvey :-)\n\n");
 #ifdef DEBUG
 	print("argc=%d\n", argc);
 	for(fd = 0; fd < argc; fd++)

--- a/sys/src/libacpi/harvey.c
+++ b/sys/src/libacpi/harvey.c
@@ -9,6 +9,9 @@
 
 #include <acpi.h>
 
+#undef DBG
+#define DBG print
+
 #define MiB (1<<20)
 
 BOOLEAN                        AcpiGbl_DebugTimeout = FALSE;
@@ -113,7 +116,7 @@ ins(uint16_t addr)
 	uint64_t off = addr;
 	uint16_t w;
 	if (pread(acpiio, &w, 2, off) < 2)
-		print("ins(0x%x): %r\n", addr);
+		if(debug) DBG("ins(0x%x): %r\n", addr);
 	return w;
 }
 
@@ -123,7 +126,7 @@ inb(uint16_t addr)
 	uint64_t off = addr;
 	uint16_t b;
 	if (pread(acpiio, &b, 1, off) < 1)
-		print("inb(0x%x): %r\n", addr);
+		if(debug) DBG("inb(0x%x): %r\n", addr);
 	return b;
 }
 
@@ -132,7 +135,7 @@ outl(uint16_t addr, uint32_t val)
 {
 	uint64_t off = addr;
 	if (pwrite(acpiio, &val, 4, off) < 4)
-		print("outl(0x%x): %r\n", addr);
+		if(debug) DBG("outl(0x%x): %r\n", addr);
 }
 
 void
@@ -140,7 +143,7 @@ outs(uint16_t addr, uint16_t val)
 {
 	uint64_t off = addr;
 	if (pwrite(acpiio, &val, 2, off) < 2)
-		print("outs(0x%x): %r\n", addr);
+		if(debug) DBG("outs(0x%x): %r\n", addr);
 }
 
 void
@@ -148,7 +151,7 @@ outb(uint16_t addr, uint8_t val)
 {
 	uint64_t off = addr;
 	if (pwrite(acpiio, &val, 1, off) < 1)
-		print("outb(0x%x): %r\n", addr);
+		if(debug) DBG("outb(0x%x): %r\n", addr);
 }
 
 #define MKBUS(t,b,d,f)	(((t)<<24)|(((b)&0xFF)<<16)|(((d)&0x1F)<<11)|(((f)&0x07)<<8))


### PR DESCRIPTION
Those messages now under DBG are useful for implementing
  ACPI or debugging and error. In Qemu there's only a line,
  In real hardware around 2 hundred.
  Same for mmu and vgavesa, not hundreds, but see useless messages
  if it's not debugging time.

Signed-off-by: Álvaro Jurado <elbingmiss@gmail.com>