### PR TITLE
Specify alignment of Fxsave struct by using aligned attribute

### DIFF
--- a/sys/src/9/amd64/dat.h
+++ b/sys/src/9/amd64/dat.h
@@ -117,15 +117,14 @@ struct Fxsave {
 	unsigned char	st[128];		/* shared 64-bit media and x87 regs */
 	unsigned char	xmm[256];		/* 128-bit media regs */
 	unsigned char	ign[96];		/* reserved, ignored */
-};
+} __attribute__ ((aligned(16)));
 
 /*
  *  FPU stuff in Proc
  */
 struct PFPU {
 	int	fpustate;
-	unsigned char	fxsave[sizeof(Fxsave)+15];
-	void*	fpusave;
+	Fxsave	fxsave;
 };
 
 /*


### PR DESCRIPTION
Simplifies the management of the saved FPU state a little.

Fxsave needs to be aligned to 16 bytes.  Using the aligned attribute seems like a nicer way of doing it.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>