### PR TITLE
Upgrading cputype

### DIFF
--- a/sys/src/9/amd64/archamd64.c
+++ b/sys/src/9/amd64/archamd64.c
@@ -47,7 +47,7 @@ cpuidinit(void)
 	return 1;
 }
 
-static int
+int
 cpuidinfo(uint32_t eax, uint32_t ecx, uint32_t info[4])
 {
 	if(machp()->CPU.ncpuinfos == 0 && cpuidinit() == 0)
@@ -65,7 +65,7 @@ cpuidinfo(uint32_t eax, uint32_t ecx, uint32_t info[4])
 	return 1;
 }
 
-static char *
+char *
 cpuidname(uint32_t *info0)
 {
 	char *vendorid;

--- a/sys/src/9/amd64/fns.h
+++ b/sys/src/9/amd64/fns.h
@@ -47,6 +47,8 @@ void	checkpa(char*, uintmem);
 void	(*coherence)(void);
 int	corecolor(int);
 uint32_t	cpuid(uint32_t, uint32_t, uint32_t[4]);
+int cpuidinfo(uint32_t, uint32_t, uint32_t[4]);
+char *cpuidname(uint32_t *);
 int	dbgprint(char*, ...);
 int	decref(Ref*);
 void	delay(int);

--- a/sys/src/9/riscv/devarch.c
+++ b/sys/src/9/riscv/devarch.c
@@ -513,11 +513,11 @@ cputyperead(Chan* c, void *a, int32_t n, int64_t off)
 }
 
 static int32_t
-numcoresread(Chan* c, void *a, int32_t n, int64_t off)
+cpucoresread(Chan* c, void *a, int32_t n, int64_t off)
 {
-        char buf[8];
-        snprint(buf, 8, "%d\n", sys->nmach);
-        return readstr(off, a, n, buf);
+	char buf[8];
+	snprint(buf, 8, "%d\n", sys->nmach);
+	return readstr(off, a, n, buf);
 }
 
 Queue *keybq;
@@ -564,7 +564,7 @@ void
 archinit(void)
 {
 	addarchfile("cputype", 0444, cputyperead, nil);
-	addarchfile("numcores", 0444, numcoresread, nil);
+	addarchfile("cpucores", 0444, cpucoresread, nil);
 	addarchfile("cons", 0666, consoleread, consolewrite);
 }
 


### PR DESCRIPTION
There's no need for a function and dev telling about number
of cores in the cpu, it should be part of the dev/cputype.
Now cputype can handle all the supported cpus in amd64/archamd64.c
For now seems nobody tried harvey in a machine without an AMD or Intel
processor, but who knows.
With this change, every supported cpu added to archamd64 will be showed
in dev/cputype.

TODO: some specific family and model info.

Signed-off-by: Álvaro Jurado <elbingmiss@gmail.com>