### PR TITLE
Rename #XF exception to #XM to match Intel docs

### DIFF
--- a/sys/src/9/amd64/amd64.h
+++ b/sys/src/9/amd64/amd64.h
@@ -115,7 +115,7 @@
 #define IdtMF		16			/* x87 FPE-Pending */
 #define IdtAC		17			/* Alignment-Check */
 #define IdtMC		18			/* Machine-Check */
-#define IdtXF		19			/* SIMD Floating-Point */
+#define IdtXM		19			/* SIMD Floating-Point */
 
 /* Vestigial Segmented Virtual Memory */
 #define SdISTM		0x0000000700000000	/* Interrupt Stack Table Mask */

--- a/sys/src/9/amd64/fpu.c
+++ b/sys/src/9/amd64/fpu.c
@@ -307,16 +307,14 @@ fpunote(void)
 }
 
 static char*
-xfpuxf(Ureg* ureg, void* v)
+xfpuxm(Ureg* ureg, void* v)
 {
 	Proc *up = externup();
 	uint32_t mxcsr;
 	Fxsave *fxsave;
 	char *cm;
 
-	/*
-	 * #XF - SIMD Floating Point Exception (Vector 18).
-	 */
+	// #XM - SIMD Floating Point Exception (Vector 19).
 
 	/*
 	 * Save FPU state to check out the error.
@@ -327,7 +325,7 @@ xfpuxf(Ureg* ureg, void* v)
 	up->FPU.fpustate = Idle;
 
 	if(ureg->ip & KZERO)
-		panic("#MF: ip=%#p", ureg->ip);
+		panic("#XM: ip=%#p", ureg->ip);
 
 	/*
 	 * Notify the user process.
@@ -357,20 +355,20 @@ xfpuxf(Ureg* ureg, void* v)
 }
 
 static void
-fpuxf(Ureg *ureg, void *p)
+fpuxm(Ureg *ureg, void *p)
 {
 	Proc *up = externup();
 	char *n;
 
-	n = xfpuxf(ureg, p);
+	n = xfpuxm(ureg, p);
 	if(n != nil)
 		postnote(up, 1, n, NDebug);
 }
 
 static char*
-acfpuxf(Ureg *ureg, void *p)
+acfpuxm(Ureg *ureg, void *p)
 {
-	return xfpuxf(ureg, p);
+	return xfpuxm(ureg, p);
 }
 
 static char*
@@ -549,10 +547,10 @@ fpuinit(void)
 	 */
 	trapenable(IdtNM, fpunm, 0, "#NM");
 	trapenable(IdtMF, fpumf, 0, "#MF");
-	trapenable(IdtXF, fpuxf, 0, "#XF");
+	trapenable(IdtXM, fpuxm, 0, "#XM");
 
 	/* Same thing, for the AC */
 	actrapenable(IdtNM, acfpunm, 0, "#NM");
 	actrapenable(IdtMF, acfpumf, 0, "#MF");
-	actrapenable(IdtXF, acfpuxf, 0, "#XF");
+	actrapenable(IdtXM, acfpuxm, 0, "#XM");
 }

--- a/sys/src/9/amd64/l64acidt.S
+++ b/sys/src/9/amd64/l64acidt.S
@@ -103,7 +103,7 @@ acidthandlers:
 	CALL _acintrp; .byte IdtMF		/* #MF x87 FPE-Pending */
 	CALL _acintre; .byte IdtAC		/* #AC Alignment-Check */
 	CALL _acintrp; .byte IdtMC		/* #MC Machine-Check */
-	CALL _acintrp; .byte IdtXF		/* #XF SIMD Floating-Point */
+	CALL _acintrp; .byte IdtXM		/* #XM SIMD Floating-Point */
 	CALL _acintrp; .byte 0x14		/* reserved */
 	CALL _acintrp; .byte 0x15		/* reserved */
 	CALL _acintrp; .byte 0x16		/* reserved */

--- a/sys/src/9/amd64/l64idt.S
+++ b/sys/src/9/amd64/l64idt.S
@@ -165,7 +165,7 @@ idthandlers:
 	call _intrp; .byte IdtMF		/* #MF x87 FPE-Pending */
 	call _intre; .byte IdtAC		/* #AC Alignment-Check */
 	call _intrp; .byte IdtMC		/* #MC Machine-Check */
-	call _intrp; .byte IdtXF		/* #XF SIMD Floating-Point */
+	call _intrp; .byte IdtXM		/* #XM SIMD Floating-Point */
 	call _intrp; .byte 0x14		/* reserved */
 	call _intrp; .byte 0x15		/* reserved */
 	call _intrp; .byte 0x16		/* reserved */

--- a/sys/src/9/amd64/tcore.c
+++ b/sys/src/9/amd64/tcore.c
@@ -272,7 +272,7 @@ runacore(void)
 				break;
 			case IdtNM:
 			case IdtMF:
-			case IdtXF:
+			case IdtXM:
 				/* these are handled in the AC;
 				 * If we get here, they left in m->NIX.icc->data
 				 * a note to be posted to the process.

--- a/sys/src/9/amd64/trap.c
+++ b/sys/src/9/amd64/trap.c
@@ -309,7 +309,7 @@ static char* excname[32] = {
 	"#MF",					/* x87 FPE-Pending */
 	"#AC",					/* Alignment-Check */
 	"#MC",					/* Machine-Check */
-	"#XF",					/* SIMD Floating-Point */
+	"#XM",					/* SIMD Floating-Point */
 	"#20 (reserved)",
 	"#21 (reserved)",
 	"#22 (reserved)",

--- a/sys/src/9/riscv/tcore.c
+++ b/sys/src/9/riscv/tcore.c
@@ -275,7 +275,7 @@ runacore(void)
 				break;
 			case IdtNM:
 			case IdtMF:
-			case IdtXF:
+			case IdtXM:
 				/* these are handled in the AC;
 				 * If we get here, they left in m->NIX.icc->data
 				 * a note to be posted to the process.


### PR DESCRIPTION
Not sure why it's called #XF here - maybe that was an old name for it?  It seems to be named #XM everywhere in the Intel guide, other than 3 references to #XF, and is vector 19 (not 18 as stated in a comment).

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>