### PR TITLE
Updating GO9P* scripts to Qemu 2.10

### DIFF
--- a/util/GO9PCPU
+++ b/util/GO9PCPU
@@ -28,7 +28,7 @@ hostfwd=tcp::17010-:17010,\
 hostfwd=tcp::1666-:1666,\
 hostfwd=tcp::5356-:5356,\
 hostfwd=tcp::17013-:17013 \
--net dump,file=/tmp/vm0.pcap \
+-object filter-dump,id=f1,netdev=user.0,file=/tmp/vm0.pcap \
 -append "service=cpu nobootprompt=tcp maxcores=1024 fs=10.0.2.2 auth=10.0.2.2 nvram=/boot/nvram nvrlen=512 nvroff=0 acpiirq=1" \
 -kernel $HARVEY/sys/src/9/amd64/harvey.32bit $*
 EOF
@@ -48,12 +48,12 @@ wait
 #-kernel mnt/hdd/kernel $*
 
 # if you need the dump.
-#-net dump,file=/tmp/vm0.pcap \
+#-object filter-dump,id=f1,netdev=user.0,file=/tmp/vm0.pcap \
 
 #sudo qemu-system-x86_64 -s -cpu phenom -smp 8 -m 4096 -nographic  \
 #-net nic,model=rtl8139 mnt/hdd268mb.img \
 #-net user,hostfwd=tcp::5555-:23 \
-#-net dump,file=/tmp/vm0.pcap \
+#-object filter-dump,id=f1,netdev=user.0,file=/tmp/vm0.pcap \
 #-kernel mnt/hdd/kernel $*
 #
 #sudo qemu-system-x86_64 -s -cpu phenom -smp 8 -m 6024 -nographic  -net nic,model=rtl8139 mnt/hdd268mb.img -netdev user,id=mynet0 -kernel mnt/hdd/kernel $*

--- a/util/GO9PCPUDOCKER
+++ b/util/GO9PCPUDOCKER
@@ -28,7 +28,7 @@ hostfwd=tcp::17010-:17010,\
 hostfwd=tcp::1666-:1666,\
 hostfwd=tcp::5356-:5356,\
 hostfwd=tcp::17013-:17013 \
--net dump,file=/tmp/vm0.pcap \
+-object filter-dump,id=f1,netdev=user.0,file=/tmp/vm0.pcap \
 -append "service=cpu nobootprompt=tcp maxcores=1024 fs=10.0.2.2 auth=10.0.2.2 nvram=/boot/nvram nvrlen=512 nvroff=0 acpiirq=1" \
 -kernel $HARVEY/sys/src/9/amd64/harvey.32bit $*
 EOF

--- a/util/GO9PTERM
+++ b/util/GO9PTERM
@@ -36,7 +36,7 @@ hostfwd=tcp::17010-:17010,\
 hostfwd=tcp::1666-:1666,\
 hostfwd=tcp::5356-:5356,\
 hostfwd=tcp::17013-:17013 \
--net dump,file=/tmp/vm0.pcap \
+-object filter-dump,id=f1,netdev=user.0,file=/tmp/vm0.pcap \
 -append "service=terminal nobootprompt=tcp maxcores=1024 fs=10.0.2.2 auth=10.0.2.2 nvram=/boot/nvram nvrlen=512 nvroff=0 acpiirq=1  mouseport=ps2 vgasize=1024x768x24 monitor=vesa" \
 -kernel $HARVEY/sys/src/9/amd64/harvey.32bit $*
 EOF
@@ -56,12 +56,12 @@ wait
 #-kernel mnt/hdd/kernel $*
 
 # if you need the dump.
-#-net dump,file=/tmp/vm0.pcap \
+#-object filter-dump,id=f1,netdev=user.0,file=/tmp/vm0.pcap \
 
 #sudo qemu-system-x86_64 -s -cpu phenom -smp 8 -m 4096 -nographic  \
 #-net nic,model=rtl8139 mnt/hdd268mb.img \
 #-net user,hostfwd=tcp::5555-:23 \
-#-net dump,file=/tmp/vm0.pcap \
+#-object filter-dump,id=f1,netdev=user.0,file=/tmp/vm0.pcap \
 #-kernel mnt/hdd/kernel $*
 #
 #sudo qemu-system-x86_64 -s -cpu phenom -smp 8 -m 6024 -nographic  -net nic,model=rtl8139 mnt/hdd268mb.img -netdev user,id=mynet0 -kernel mnt/hdd/kernel $*


### PR DESCRIPTION
- net dump is deprecated.
- GO9PTERM had -smp 2 unlike rest which is 4

Signed-off-by: Álvaro Jurado <elbingmiss@gmail.com>