### PR TITLE
Mitigate bug 615

### DIFF
--- a/sys/src/cmd/acme/acme.c
+++ b/sys/src/cmd/acme/acme.c
@@ -237,6 +237,9 @@ threadmain(int argc, char *argv[])
 
 	threadnotify(shutdown, 1);
 	recvul(cexit);
+	closekeyboard(keyboardctl);
+	closemouse(mousectl);
+	closedisplay(display);
 	killprocs();
 	threadexitsall(nil);
 }


### PR DESCRIPTION
This patch should mitigate the bug 615 for Acme, but the error is still present in Harvey, this is only a way to recover the shell after exit from Acme

Signed-off-by: fuchicar <rafita.fernandez@gmail.com>