### PR TITLE
Avoid unnecessary retries in sdiahci

### DIFF
--- a/sys/src/9/amd64/sdiahci.c
+++ b/sys/src/9/amd64/sdiahci.c
@@ -202,6 +202,7 @@ struct Ctlr {
 struct Asleep {
 	Aport	*p;
 	int	i;
+	int	slept;
 };
 
 extern SDifc sdiahciifc;
@@ -279,9 +280,13 @@ esleep(int ms)
 static int
 ahciclear(void *v)
 {
-	Asleep *s;
+	Asleep *s = v;
 
-	s = v;
+	if (!s->slept) {
+		s->slept = 1;
+		return 0;
+	}
+
 	return (s->p->ci & s->i) == 0;
 }
 
@@ -1897,6 +1902,7 @@ retry:
 
 		as.p = p;
 		as.i = 1;
+		as.slept = 0;
 		d->intick = sys->ticks;
 		d->active++;
 

--- a/util/img/prepfs
+++ b/util/img/prepfs
@@ -1,0 +1,20 @@
+#!/bin/rc
+venti=127.0.0.1
+
+disk/prep -w -a^(nvram fossil arenas bloom isect) /dev/sdE0/plan9
+
+venti/fmtarenas arenas0 /dev/sdE0/arenas
+venti/fmtisect isect0 /dev/sdE0/isect
+venti/fmtindex /util/img/venti.conf
+venti/conf -w /dev/sdE0/arenas < /util/img/venti.conf
+venti/venti -c /dev/sdE0/arenas
+fossil/flfmt /dev/sdE0/fossil
+fossil/conf -w /dev/sdE0/fossil < /util/img/fossil.conf
+fossil/fossil -f /dev/sdE0/fossil
+
+mount -c /srv/fossil /n/fossil
+
+cd /n/fossil
+mkdir x
+cd x
+dircp /root/amd64 .


### PR DESCRIPTION
We get the retry blk message in iario because ci is cleared between the time it's set and we test it before sleeping.  We don't clear ci manually, but it can be cleared if the ST flag on p->cmd is cleared (and probably for other reasons too).  We clear the st flag at various points throughout the sdiahci code

This fix is a little hacky, but ensures we always sleep at least once, which would always happen in the usual case anyway.

This change also includes a script to build a fossil file system and do a large dircp.  This currently functions as a test, but will become a script to build the plan 9 file system for an image.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>