### PR TITLE
fix mistaken compare

### DIFF
--- a/sys/src/9/amd64/usbuhci.c
+++ b/sys/src/9/amd64/usbuhci.c
@@ -2212,7 +2212,7 @@ init(Hci *hp)
 	/* guess other ports */
 	for(i = 2; i < 6; i++){
 		sts = INS(PORT(i));
-		if(sts != 0xFFFF && (sts & PSreserved1) == 1){
+		if(sts != 0xFFFF && ((sts & PSreserved1) == PSreserved1)){
 			dprint(" psc%d %#x", i, sts);
 			hp->nports++;
 		}else


### PR DESCRIPTION
not sure how this happened but ...
-               if(sts != 0xFFFF && (sts & PSreserved1) == 1){
+               if(sts != 0xFFFF && ((sts & PSreserved1) == PSreserved1)){

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>