### PR TITLE
Fix clang 7 build of usb audio

### DIFF
--- a/sys/include/usb/audio.h
+++ b/sys/include/usb/audio.h
@@ -25,7 +25,7 @@ enum {
 	Channel_control		= 0x0b,
 	Resolution_control	= 0x0c,
 	Ncontrol,
-	Selector_control	= 0x0d,
+	//Selector_control	= 0x0d,		// Currently disabled
 
 	sampling_freq_control	= 0x01,
 

--- a/sys/src/libusb/audio/audioctl.c
+++ b/sys/src/libusb/audio/audioctl.c
@@ -415,11 +415,12 @@ setcontrol(int rec, char *name, int32_t *value)
 		control = ctl<<8;
 		index = featureid[rec]<<8;
 		break;
-	case Selector_control:
+	// Selector_control currently disabled
+	/*case Selector_control:
 		type = Rh2d|Rclass|Riface;
 		control = 0;
 		index = selectorid[rec]<<8;
-		break;
+		break;*/
 	case Channel_control:
 		control = findalt(rec, value[0], controls[rec][Resolution_control].value[0], defaultspeed[rec]);
 		if(control < 0 || setaudioalt(rec, c, control) < 0){
@@ -502,11 +503,12 @@ getspecialcontrol(int rec, int ctl, int req, int32_t *value)
 		control = ctl<<8;
 		index = featureid[rec]<<8;
 		break;
-	case Selector_control:
+	// Currently disabled
+	/*case Selector_control:
 		type = Rd2h|Rclass|Riface;
 		control = 0;
 		index = selectorid[rec]<<8;
-		break;
+		break;*/
 	case Mute_control:
 	case Agc_control:
 	case Bassboost_control:

--- a/sys/src/libusb/audio/audiosub.c
+++ b/sys/src/libusb/audio/audiosub.c
@@ -185,9 +185,10 @@ audio_interface(Dev *_1, Desc *dd)
 					if(selectorid[u] >= 0)
 						fprint(2, "Second selector (%d, %d) on %s\n", selectorid[u], b[3], u?"record":"playback");
 					selectorid[u] = b[3];
-					controls[u][Selector_control].readable = 1;
-					controls[u][Selector_control].settable = 1;
-					controls[u][Selector_control].chans = 0;
+					// Currently disabled
+					//controls[u][Selector_control].readable = 1;
+					//controls[u][Selector_control].settable = 1;
+					//controls[u][Selector_control].chans = 0;
 				}
 			}
 			break;


### PR DESCRIPTION
Selector_control seems to have been partially disabled a long time ago, but some code still assumed it existed.

Clang caught the code trying to access an array entry out of bounds.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>