### PR TITLE
TSS: set IO map base address correctly.

### DIFF
--- a/sys/src/9/amd64/vsvm.c
+++ b/sys/src/9/amd64/vsvm.c
@@ -151,7 +151,7 @@ tssinit(Mach *mach, uintptr_t sp)
 		tss->ist[ist] = sp;
 		tss->ist[ist+1] = sp>>32;
 	}
-	tss->iomap = 0xdfff;
+	tss->iomap = sizeof(*tss);
 }
 
 void acsyscallentry(void)


### PR DESCRIPTION
This was set to an absurdly high value, meaning that
random bits of the kernel were being consulted to check
permissions for unprivileged code to perform programmed
IO.  Set it to sizeof(Tss) to mark it as not used.

See the SDM for more information.