### PR TITLE
exec(usbd) args weren't nil terminated, so broke on init

### DIFF
--- a/sys/src/9/boot/boot.c
+++ b/sys/src/9/boot/boot.c
@@ -328,7 +328,7 @@ static void
 usbinit(void)
 {
 	static char usbd[] = "/boot/usbd";
-	static char *argv[] = {"usbd"};
+	static char *argv[] = {"usbd", nil};
 
 	if (access(usbd, AEXIST) < 0) {
 		print("usbinit: no %s\n", usbd);


### PR DESCRIPTION
This fixes the the first part of the long-standing USB init bug we've had.
Can now use usb keyboard by adding '-device usb-kbd' to the qemu options, but it seems hyper-sensitive - press a button and get 10 chars.  There also seems to be some warnings about a descriptor on usb init.  That's the next step.  Also usb mouse doesn't seem to work from startup.  It /seems/ to work if you add the mouse (in qemu) mid-session though.  Maybe?

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>