### PR TITLE
Change kbin dev to #j, fix ref in boot.c, fix usb print

### DIFF
--- a/sys/man/3/kbin
+++ b/sys/man/3/kbin
@@ -3,7 +3,7 @@
 kbin \- external keyboard input
 .SH SYNOPSIS
 .nf
-.B bind -a #Ι /dev
+.B bind -a #j /dev
 .sp 0.3v
 .B /dev/kbin
 .fi

--- a/sys/src/9/boot/boot.c
+++ b/sys/src/9/boot/boot.c
@@ -340,8 +340,8 @@ usbinit(void)
 		return;
 	}
 
-	if (bind("#I", "/dev", MAFTER) < 0) {
-		print("usbinit: can't bind #I to /dev: %r\n");
+	if (bind("#j", "/dev", MAFTER) < 0) {
+		print("usbinit: can't bind #j to /dev: %r\n");
 		return;
 	}
 

--- a/sys/src/9/port/devkbin.c
+++ b/sys/src/9/port/devkbin.c
@@ -28,7 +28,7 @@ int	kbinbusy;
 static Chan *
 kbinattach(char *spec)
 {
-	return devattach(L'Ι', spec);
+	return devattach(L'j', spec);
 }
 
 static Walkqid*

--- a/sys/src/9/port/devkbin.c
+++ b/sys/src/9/port/devkbin.c
@@ -99,7 +99,7 @@ kbinwrite(Chan *c, void *a, int32_t n, int64_t _)
 }
 
 Dev kbindevtab = {
-	.dc = L'Ι',
+	.dc = L'j',
 	.name = "kbin",
 
 	.reset = devreset,

--- a/sys/src/cmd/usb/usbd/usbd.c
+++ b/sys/src/cmd/usb/usbd/usbd.c
@@ -182,11 +182,11 @@ newhub(char *fn, Dev *d)
 	}
 	devctl(h->dev, "hub");
 	ud = h->dev->usb;
-	if(h->isroot)
-		devctl(h->dev, "info roothub csp %#08ux ports %d",
+	if (h->isroot) {
+		devctl(h->dev, "info roothub csp %#08x ports %d",
 			0x000009, h->nport);
-	else{
-		devctl(h->dev, "info hub csp %#08ulx ports %d %q %q",
+	} else {
+		devctl(h->dev, "info hub csp %#08x ports %d %q %q",
 			ud->csp, h->nport, ud->vendor, ud->product);
 		for(i = 1; i <= h->nport; i++)
 			if(hubfeature(h, i, Fportpower, 1) < 0)

--- a/sys/src/libusb/kb/kb.c
+++ b/sys/src/libusb/kb/kb.c
@@ -118,7 +118,7 @@ static QLock inlck;
 static Kin kbdin =
 {
 	.ref = 0,
-	.name = "#Ι/kbin",
+	.name = "#j/kbin",
 	.fd = -1,
 };
 static Kin ptrin =


### PR DESCRIPTION
kbin used iota for the dev identifier, this looks near-identical to I, so changed to #j.  Also fix an intended reference in boot.c to this device.
While I'm at it, fixed some print formatting in usbd.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>