### PR TITLE
Fix scanf - some va_end calls needed to be bracketed

### DIFF
--- a/sys/src/cmd/acpi/irq.c
+++ b/sys/src/cmd/acpi/irq.c
@@ -7,6 +7,8 @@
  * in the LICENSE file.
  */
 
+// irq is a program to configure PCI interrupts, based on the parsed ACPI AML.
+
 #include <acpi.h>
 
 #define CHECK_STATUS(fmt, ...) do { if (ACPI_FAILURE(status)) { \
@@ -63,6 +65,7 @@ main(int argc, char *argv[])
 	ACPI_STATUS status;
 	int verbose = 0;
 	AcpiDbgLevel = 0;
+
 	ARGBEGIN{
 	case 'v':
 		AcpiDbgLevel = ACPI_LV_VERBOSITY1;
@@ -87,7 +90,7 @@ main(int argc, char *argv[])
 		sysfatal("can't set up acpi tables: %d", status);
 
 	if (verbose)
-		print("init dables\n");
+		print("init tables\n");
         status = AcpiLoadTables();
         if (ACPI_FAILURE(status))
 		sysfatal("Can't load ACPI tables: %d", status);

--- a/sys/src/libstdio/vfscanf.c
+++ b/sys/src/libstdio/vfscanf.c
@@ -76,18 +76,24 @@ int vfscanf(FILE *f, const char *s, va_list args){
 	fmtp=s;
 	for(;*fmtp;fmtp++) switch(*fmtp){
 	default:
-		if(isspace(*fmtp)){
-			do
+		if (isspace(*fmtp)) {
+			do {
 				c=ngetc(f);
-			while(isspace(c));
-			if(c==EOF) va_end(arg); return ncvt?ncvt:EOF;
+			} while (isspace(c));
+			if (c==EOF) {
+				va_end(arg);
+				return ncvt?ncvt:EOF;
+			}
 			nungetc(c, f);
 			break;
 		}
 	NonSpecial:
 		c=ngetc(f);
-		if(c==EOF) va_end(arg); return ncvt?ncvt:EOF;
-		if(c!=*fmtp){
+		if (c==EOF) {
+			va_end(arg);
+			return ncvt?ncvt:EOF;
+		}
+		if (c!=*fmtp) {
 			nungetc(c, f);
 			va_end(arg);
 			return ncvt;
@@ -95,25 +101,35 @@ int vfscanf(FILE *f, const char *s, va_list args){
 		break;
 	case '%':
 		fmtp++;
-		if(*fmtp!='*') store=1;
-		else{
+		if (*fmtp!='*') {
+			store=1;
+		} else {
 			store=0;
 			fmtp++;
 		}
-		if('0'<=*fmtp && *fmtp<='9'){
+		if ('0'<=*fmtp && *fmtp<='9') {
 			width=0;
-			while('0'<=*fmtp && *fmtp<='9') width=width*10 + *fmtp++ - '0';
+			while('0'<=*fmtp && *fmtp<='9') {
+				width=width*10 + *fmtp++ - '0';
+			}
 		}
-		else
+		else {
 			width=-1;
-		type=*fmtp=='h' || *fmtp=='l' || *fmtp=='L'?*fmtp++:'n';
-		if(!icvt[(uint8_t)(*fmtp)]) goto NonSpecial;
-		if(!(*icvt[(uint8_t)(*fmtp)])(f, &arg, store, width, type)){
+		}
+		type = *fmtp=='h' || *fmtp=='l' || *fmtp=='L'?*fmtp++:'n';
+		if (!icvt[(uint8_t)(*fmtp)]) {
+			goto NonSpecial;
+		}
+		if (!(*icvt[(uint8_t)(*fmtp)])(f, &arg, store, width, type)) {
 			va_end(arg);
 			return ncvt?ncvt:EOF;
 		}
-		if(*fmtp=='\0') break;
-		if(store) ncvt++;
+		if (*fmtp=='\0') {
+			break;
+		}
+		if (store) {
+			ncvt++;
+		}
 	}
 	va_end(arg);
 	return ncvt;

--- a/sys/src/regress/libc/scanf.c
+++ b/sys/src/regress/libc/scanf.c
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <stdio.h>
+
+void
+main()
+{
+	// Basic test
+	{
+		char *str = "123 456 789\n";
+		int a = -1, b = -1, c = -1;
+		sscanf(str, "%d %d %d\n", &a, &b, &c);
+
+		if (a != 123 || b != 456 || c != 789) {
+			print("FAIL - expected %s, found %d %d %d\n", str, a, b, c);
+			exits("FAIL");
+		}
+	}
+
+	// Hex parsing
+	{
+		char *str = "0x0 0x1d";
+		int a = -1, b = -1;
+		sscanf(str, "%x %x", &a, &b);
+
+		if (a != 0x0 || b != 0x1d) {
+			print("FAIL - expected %s, found %x %x\n", str, a, b);
+			exits("FAIL");
+		}
+	}
+
+	print("PASS\n");
+	exits(nil);
+}


### PR DESCRIPTION
Shows importance of brackets around blocks!
Lack of brackets caused scanf to fail to parse more than one value
Add test for scanf

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>