### PR TITLE
Makes the order of events in init clearer in the log

### DIFF
--- a/sys/src/cmd/init.c
+++ b/sys/src/cmd/init.c
@@ -73,7 +73,7 @@ main(int argc, char *argv[])
 	iscpu = strcmp(service, "cpu")==0;
 
 	if(iscpu && manual == 0){
-	        print("init: starting cpurc");
+	        print("init: starting cpurc\n");
 		fexec(cpustart);
 	}
 
@@ -186,7 +186,7 @@ rcexec(void)
 	else if(manual || iscpu){
 		execl("/boot/rc", "rc", "-m/boot/rcmain", "-i", nil);
 	}else if(strcmp(service, "terminal") == 0){
-	        print ("init: starting termrc");
+	        print ("init: starting termrc\n");
 		execl("/bin/rc", "rc", "-c", ". /rc/bin/termrc; home=/usr/$user; cd; . lib/profile", nil);
 	}
 	else

--- a/sys/src/cmd/init.c
+++ b/sys/src/cmd/init.c
@@ -73,6 +73,7 @@ main(int argc, char *argv[])
 	iscpu = strcmp(service, "cpu")==0;
 
 	if(iscpu && manual == 0){
+	        print("init: starting cpurc");
 		fexec(cpustart);
 	}
 
@@ -184,8 +185,10 @@ rcexec(void)
 		execl("/bin/rc", "rc", "-c", cmd, nil);
 	else if(manual || iscpu){
 		execl("/boot/rc", "rc", "-m/boot/rcmain", "-i", nil);
-	}else if(strcmp(service, "terminal") == 0)
+	}else if(strcmp(service, "terminal") == 0){
+	        print ("init: starting termrc");
 		execl("/bin/rc", "rc", "-c", ". /rc/bin/termrc; home=/usr/$user; cd; . lib/profile", nil);
+	}
 	else
 		execl("/bin/rc", "rc", nil);
 }


### PR DESCRIPTION
This is a tiny PR that adds some messages indicating when termrc and cpurc are started by the init process. This makes the order of events in the init process more clear to everyone.