### PR TITLE
Tidy up APIC code, try to handle multiple function PCI devices

### DIFF
--- a/sys/src/9/amd64/apic.h
+++ b/sys/src/9/amd64/apic.h
@@ -20,8 +20,8 @@ typedef	struct	Apic	Apic;
 
 struct Ioapic {
 	Lock l;					/* IOAPIC: register access */
-	uint32_t*	addr;				/* IOAPIC: register base */
-	uintptr_t	paddr;				/* physical address */
+	uint32_t*	addr;			/* IOAPIC: register base */
+	uintptr_t	paddr;			/* physical address */
 	int	nrdt;				/* IOAPIC: size of RDT */
 	int	gsib;				/* IOAPIC: global RDT index */
 };

--- a/sys/src/9/amd64/devacpi.c
+++ b/sys/src/9/amd64/devacpi.c
@@ -634,20 +634,14 @@ static char *dumpfadt(char *start, char *end, Fadt *fp)
 	start = seprint(start, end, "acpi: fadt: pmprofile: $%p\n", fp->pmprofile);
 	start = seprint(start, end, "acpi: fadt: sciint: $%p\n", fp->sciint);
 	start = seprint(start, end, "acpi: fadt: smicmd: $%p\n", fp->smicmd);
-	start =
-		seprint(start, end, "acpi: fadt: acpienable: $%p\n", fp->acpienable);
-	start =
-		seprint(start, end, "acpi: fadt: acpidisable: $%p\n", fp->acpidisable);
+	start = seprint(start, end, "acpi: fadt: acpienable: $%p\n", fp->acpienable);
+	start = seprint(start, end, "acpi: fadt: acpidisable: $%p\n", fp->acpidisable);
 	start = seprint(start, end, "acpi: fadt: s4biosreq: $%p\n", fp->s4biosreq);
 	start = seprint(start, end, "acpi: fadt: pstatecnt: $%p\n", fp->pstatecnt);
-	start =
-		seprint(start, end, "acpi: fadt: pm1aevtblk: $%p\n", fp->pm1aevtblk);
-	start =
-		seprint(start, end, "acpi: fadt: pm1bevtblk: $%p\n", fp->pm1bevtblk);
-	start =
-		seprint(start, end, "acpi: fadt: pm1acntblk: $%p\n", fp->pm1acntblk);
-	start =
-		seprint(start, end, "acpi: fadt: pm1bcntblk: $%p\n", fp->pm1bcntblk);
+	start = seprint(start, end, "acpi: fadt: pm1aevtblk: $%p\n", fp->pm1aevtblk);
+	start = seprint(start, end, "acpi: fadt: pm1bevtblk: $%p\n", fp->pm1bevtblk);
+	start = seprint(start, end, "acpi: fadt: pm1acntblk: $%p\n", fp->pm1acntblk);
+	start = seprint(start, end, "acpi: fadt: pm1bcntblk: $%p\n", fp->pm1bcntblk);
 	start = seprint(start, end, "acpi: fadt: pm2cntblk: $%p\n", fp->pm2cntblk);
 	start = seprint(start, end, "acpi: fadt: pmtmrblk: $%p\n", fp->pmtmrblk);
 	start = seprint(start, end, "acpi: fadt: gpe0blk: $%p\n", fp->gpe0blk);
@@ -656,25 +650,20 @@ static char *dumpfadt(char *start, char *end, Fadt *fp)
 	start = seprint(start, end, "acpi: fadt: pm1cntlen: $%p\n", fp->pm1cntlen);
 	start = seprint(start, end, "acpi: fadt: pm2cntlen: $%p\n", fp->pm2cntlen);
 	start = seprint(start, end, "acpi: fadt: pmtmrlen: $%p\n", fp->pmtmrlen);
-	start =
-		seprint(start, end, "acpi: fadt: gpe0blklen: $%p\n", fp->gpe0blklen);
-	start =
-		seprint(start, end, "acpi: fadt: gpe1blklen: $%p\n", fp->gpe1blklen);
+	start = seprint(start, end, "acpi: fadt: gpe0blklen: $%p\n", fp->gpe0blklen);
+	start = seprint(start, end, "acpi: fadt: gpe1blklen: $%p\n", fp->gpe1blklen);
 	start = seprint(start, end, "acpi: fadt: gp1base: $%p\n", fp->gp1base);
 	start = seprint(start, end, "acpi: fadt: cstcnt: $%p\n", fp->cstcnt);
 	start = seprint(start, end, "acpi: fadt: plvl2lat: $%p\n", fp->plvl2lat);
 	start = seprint(start, end, "acpi: fadt: plvl3lat: $%p\n", fp->plvl3lat);
 	start = seprint(start, end, "acpi: fadt: flushsz: $%p\n", fp->flushsz);
-	start =
-		seprint(start, end, "acpi: fadt: flushstride: $%p\n", fp->flushstride);
+	start = seprint(start, end, "acpi: fadt: flushstride: $%p\n", fp->flushstride);
 	start = seprint(start, end, "acpi: fadt: dutyoff: $%p\n", fp->dutyoff);
 	start = seprint(start, end, "acpi: fadt: dutywidth: $%p\n", fp->dutywidth);
 	start = seprint(start, end, "acpi: fadt: dayalrm: $%p\n", fp->dayalrm);
 	start = seprint(start, end, "acpi: fadt: monalrm: $%p\n", fp->monalrm);
 	start = seprint(start, end, "acpi: fadt: century: $%p\n", fp->century);
-	start =
-		seprint(start, end, "acpi: fadt: iapcbootarch: $%p\n",
-				 fp->iapcbootarch);
+	start = seprint(start, end, "acpi: fadt: iapcbootarch: $%p\n", fp->iapcbootarch);
 	start = seprint(start, end, "acpi: fadt: flags: $%p\n", fp->flags);
 	start = dumpGas(start, end, "acpi: fadt: resetreg: ", &fp->resetreg);
 	start = seprint(start, end, "acpi: fadt: resetval: $%p\n", fp->resetval);
@@ -691,8 +680,7 @@ static char *dumpfadt(char *start, char *end, Fadt *fp)
 	return start;
 }
 
-static Atable *parsefadt(Atable *parent,
-								char *name, uint8_t *p, size_t rawsize)
+static Atable *parsefadt(Atable *parent, char *name, uint8_t *p, size_t rawsize)
 {
 	Atable *t;
 	Fadt *fp;
@@ -791,7 +779,7 @@ static char *dumpmsct(char *start, char *end, Atable *table)
 		return start;
 
 	start = seprint(start, end, "acpi: msct: %d doms %d clkdoms %#p maxpa\n",
-					 msct->ndoms, msct->nclkdoms, msct->maxpa);
+		msct->ndoms, msct->nclkdoms, msct->maxpa);
 	for (int i = 0; i < table->nchildren; i++) {
 		Atable *domtbl = table->children[i]->tbl;
 		Mdom *st = domtbl->tbl;
@@ -808,8 +796,7 @@ static char *dumpmsct(char *start, char *end, Atable *table)
  * XXX: should perhaps update our idea of available memory.
  * Else we should remove this code.
  */
-static Atable *parsemsct(Atable *parent,
-                                char *name, uint8_t *raw, size_t rawsize)
+static Atable *parsemsct(Atable *parent, char *name, uint8_t *raw, size_t rawsize)
 {
 	Atable *t;
 	uint8_t *r, *re;
@@ -880,23 +867,21 @@ static char *dumpsrat(char *start, char *end, Atable *table)
 			continue;
 		switch (st->type) {
 			case SRlapic:
-				start =
-					seprint(start, end,
-							 "\tlapic: dom %d apic %d sapic %d clk %d\n",
-							 st->lapic.dom, st->lapic.apic, st->lapic.sapic,
-							 st->lapic.clkdom);
+				start = seprint(start, end,
+					 "\tlapic: dom %d apic %d sapic %d clk %d\n",
+					 st->lapic.dom, st->lapic.apic, st->lapic.sapic,
+					 st->lapic.clkdom);
 				break;
 			case SRmem:
 				start = seprint(start, end, "\tmem: dom %d %#p %#p %c%c\n",
-								 st->mem.dom, st->mem.addr, st->mem.len,
-								 st->mem.hplug ? 'h' : '-',
-								 st->mem.nvram ? 'n' : '-');
+					 st->mem.dom, st->mem.addr, st->mem.len,
+					 st->mem.hplug ? 'h' : '-',
+					 st->mem.nvram ? 'n' : '-');
 				break;
 			case SRlx2apic:
-				start =
-					seprint(start, end, "\tlx2apic: dom %d apic %d clk %d\n",
-							 st->lx2apic.dom, st->lx2apic.apic,
-							 st->lx2apic.clkdom);
+				start = seprint(start, end, "\tlx2apic: dom %d apic %d clk %d\n",
+					 st->lx2apic.dom, st->lx2apic.apic,
+					 st->lx2apic.clkdom);
 				break;
 			default:
 				start = seprint(start, end, "\t<unknown srat entry>\n");
@@ -906,10 +891,8 @@ static char *dumpsrat(char *start, char *end, Atable *table)
 	return start;
 }
 
-static Atable *parsesrat(Atable *parent,
-                                char *name, uint8_t *p, size_t rawsize)
+static Atable *parsesrat(Atable *parent, char *name, uint8_t *p, size_t rawsize)
 {
-
 	Atable *t, *tt;
 	uint8_t *pe;
 	int stlen, flags;
@@ -991,8 +974,8 @@ static char *dumpslit(char *start, char *end, Slit *sl)
 	start = seprint(start, end, "acpi slit:\n");
 	for (i = 0; i < sl->rowlen * sl->rowlen; i++) {
 		start = seprint(start, end,
-						 "slit: %x\n",
-						 sl->e[i / sl->rowlen][i % sl->rowlen].dist);
+			 "slit: %x\n",
+			 sl->e[i / sl->rowlen][i % sl->rowlen].dist);
 	}
 	start = seprint(start, end, "\n");
 	return start;
@@ -1200,8 +1183,7 @@ static char *dumpmadt(char *start, char *end, Atable *apics)
 	return start;
 }
 
-static Atable *parsemadt(Atable *parent,
-                                char *name, uint8_t *p, size_t size)
+static Atable *parsemadt(Atable *parent, char *name, uint8_t *p, size_t size)
 {
 	Atable *t, *tt;
 	uint8_t *pe;
@@ -1331,8 +1313,7 @@ static Atable *parsemadt(Atable *parent,
 	return apics;
 }
 
-static Atable *parsedmar(Atable *parent,
-                                char *name, uint8_t *raw, size_t rawsize)
+static Atable *parsedmar(Atable *parent, char *name, uint8_t *raw, size_t rawsize)
 {
 	Atable *t, *tt;
 	int i;
@@ -1856,27 +1837,25 @@ static void acpiintr(Ureg *u, void *v)
 	int i;
 	unsigned int sts, en;
 
-	print("acpi: intr\n");
-
 	for (i = 0; i < ngpes; i++)
 		if (getgpests(i)) {
-			print("gpe %d on\n", i);
+			print("acpiintr: gpe %d on\n", i);
 			en = getgpeen(i);
 			setgpeen(i, 0);
 			clrgpests(i);
 			if (en != 0)
-				print("acpiitr: calling gpe %d\n", i);
+				print("acpiintr: calling gpe %d\n", i);
 			//  queue gpe for calling gpe->ho in the
 			//  aml process.
 			//  enable it again when it returns.
 		}
 	sts = getpm1sts();
 	en = getpm1en();
-	print("acpiitr: pm1sts %#p pm1en %#p\n", sts, en);
+	print("acpiintr: pm1sts %#p pm1en %#p\n", sts, en);
 	if (sts & en)
-		print("have enabled events\n");
+		print("acpiintr: have enabled events\n");
 	if (sts & 1)
-		print("power button\n");
+		print("acpiintr: power button\n");
 	// XXX serve other interrupts here.
 	setpm1sts(sts);
 }
@@ -2002,7 +1981,6 @@ void acpistart(void)
 int acpiinit(void)
 {
 	static int once = 0;
-	//die("acpiinit");
 	if (! once)
 		acpiinitonce();
 	once++;
@@ -2024,8 +2002,7 @@ static Chan *acpiattach(char *spec)
 	return c;
 }
 
-static Walkqid*acpiwalk(Chan *c, Chan *nc, char **name,
-								int nname)
+static Walkqid*acpiwalk(Chan *c, Chan *nc, char **name, int nname)
 {
 	/*
 	 * Note that devwalk hard-codes a test against the location of 'devgen',
@@ -2085,8 +2062,8 @@ acpimemread(Chan *c, void *a, int32_t n, int64_t off)
 	//print("ACPI Qraw: rsd %p %p %d %p\n", rsd, a, n, (void *)off);
 	if (off == 0){
 		uint32_t pa = (uint32_t)PADDR(rsd);
-		print("FIND RSD");
-		print("PA OF rsd is %lx, \n", pa);
+		print("FIND RSD\n");
+		print("PA OF rsd is %lx\n", pa);
 		return readmem(0, a, n, &pa, sizeof(pa));
 	}
 	if (off == PADDR(rsd)) {

--- a/sys/src/9/amd64/devacpi.c
+++ b/sys/src/9/amd64/devacpi.c
@@ -1751,7 +1751,7 @@ static unsigned int getbanked(uintptr_t ra, uintptr_t rb, int sz)
 static unsigned int setbanked(uintptr_t ra, uintptr_t rb, int sz, int v)
 {
 	unsigned int r;
-	print("setbanked: ra %#x rb %#x sz %d value %#x\n", ra, rb, sz, v);
+	//print("setbanked: ra %#x rb %#x sz %d value %#x\n", ra, rb, sz, v);
 
 	r = -1;
 	switch (sz) {
@@ -1851,11 +1851,11 @@ static void acpiintr(Ureg *u, void *v)
 		}
 	sts = getpm1sts();
 	en = getpm1en();
-	print("acpiintr: pm1sts %#p pm1en %#p\n", sts, en);
-	if (sts & en)
-		print("acpiintr: have enabled events\n");
-	if (sts & 1)
-		print("acpiintr: power button\n");
+	//print("acpiintr: pm1sts %#p pm1en %#p\n", sts, en);
+	//if (sts & en)
+	//	print("acpiintr: have enabled events\n");
+	//if (sts & 1)
+	//	print("acpiintr: power button\n");
 	// XXX serve other interrupts here.
 	setpm1sts(sts);
 }

--- a/sys/src/9/amd64/fns.h
+++ b/sys/src/9/amd64/fns.h
@@ -244,7 +244,6 @@ extern void apicsipi(int, uintmem);
 extern void apicnmi(int, int, int);
 
 extern void ioapicinit(int, int, uintmem);
-extern void ioapicintrinit(int, int, int, int, uint32_t);
 extern void ioapiconline(void);
 
 /*

--- a/sys/src/9/amd64/io.h
+++ b/sys/src/9/amd64/io.h
@@ -49,9 +49,9 @@ enum {
 };
 
 enum {
-	IdtPIC		= 32,			/* external i8259 interrupts */
+	IdtPIC		= 32,		/* external i8259 interrupts */
 
-	IdtLINT0	= 48,			/* local APIC interrupts */
+	IdtLINT0	= 48,		/* local APIC interrupts */
 	IdtLINT1	= 49,
 	IdtTIMER	= 50,
 	IdtERROR	= 51,
@@ -62,7 +62,7 @@ enum {
 
 	IdtSYSCALL	= 64,
 
-	IdtIOAPIC	= 65,			/* external APIC interrupts */
+	IdtIOAPIC	= 65,		/* external APIC interrupts */
 
 	IdtMAX		= 255,
 };
@@ -98,25 +98,25 @@ typedef struct ACVctl {
 
 enum {
 	BusCBUS		= 0,	/* Corollary CBUS */
-	BusCBUSII,			/* Corollary CBUS II */
-	BusEISA,			/* Extended ISA */
-	BusFUTURE,			/* IEEE Futurebus */
-	BusINTERN,			/* Internal bus */
-	BusISA,				/* Industry Standard Architecture */
-	BusMBI,				/* Multibus I */
-	BusMBII,			/* Multibus II */
-	BusMCA,				/* Micro Channel Architecture */
-	BusMPI,				/* MPI */
-	BusMPSA,			/* MPSA */
-	BusNUBUS,			/* Apple Macintosh NuBus */
-	BusPCI,				/* Peripheral Component Interconnect */
-	BusPCMCIA,			/* PC Memory Card International Association */
-	BusTC,				/* DEC TurboChannel */
-	BusVL,				/* VESA Local bus */
-	BusVME,				/* VMEbus */
-	BusXPRESS,			/* Express System Bus */
-	BusLAPIC,	/* Local APIC, fake type */
-	BusIPI,	/* IPIs, fake type like the LAPIC */
+	BusCBUSII,		/* Corollary CBUS II */
+	BusEISA,		/* Extended ISA */
+	BusFUTURE,		/* IEEE Futurebus */
+	BusINTERN,		/* Internal bus */
+	BusISA,			/* Industry Standard Architecture */
+	BusMBI,			/* Multibus I */
+	BusMBII,		/* Multibus II */
+	BusMCA,			/* Micro Channel Architecture */
+	BusMPI,			/* MPI */
+	BusMPSA,		/* MPSA */
+	BusNUBUS,		/* Apple Macintosh NuBus */
+	BusPCI,			/* Peripheral Component Interconnect */
+	BusPCMCIA,		/* PC Memory Card International Association */
+	BusTC,			/* DEC TurboChannel */
+	BusVL,			/* VESA Local bus */
+	BusVME,			/* VMEbus */
+	BusXPRESS,		/* Express System Bus */
+	BusLAPIC,		/* Local APIC, fake type */
+	BusIPI,			/* IPIs, fake type like the LAPIC */
 };
 
 #define MKBUS(t,b,d,f)	(((t)<<24)|(((b)&0xFF)<<16)|(((d)&0x1F)<<11)|(((f)&0x07)<<8))

--- a/sys/src/9/amd64/ioapic.c
+++ b/sys/src/9/amd64/ioapic.c
@@ -306,8 +306,6 @@ acpi_make_rdt(Vctl *v, int irq, int bustype, int busno, int devno, int fno)
 		} else {
 			/* Need to query ACPI at some point to handle this */
 			print("Non-ISA IRQ %d not found in MADT, aborting\n", irq);
-			print("Bustype: %d\n", bustype);
-			print("todo[%d] b:%d d:%d f:%d\n", todoidx, busno, devno, fno);
 			todo[todoidx].v = *v;
 			todo[todoidx].lo = lo | TMlevel | IPlow | Im;
 			todo[todoidx].valid = 1;
@@ -373,7 +371,7 @@ ioapicdump(void)
 	Apic *apic;
 	uint32_t hi, lo;
 
-	//if(!DBGFLG)
+	if(!DBGFLG)
 		return;
 	for(i = 0; i < Napic; i++){
 		apic = &xioapic[i];
@@ -808,12 +806,12 @@ acpiirq(uint32_t tbdf, int gsi)
 	*v = vinfotodo->v;
 	v->Vkey.irq = gsi;
 	devno = BUSDNO(v->Vkey.tbdf)<<2|(pin-1);
-	//if (DBGFLG)
+	if (DBGFLG)
 		print("acpiirq: tbdf %#8.8x busno %d devno %d\n",
 	    		v->Vkey.tbdf, busno, devno);
 
 	ioapic_nr = acpi_irq2ioapic(gsi);
-	//if (DBGFLG)
+	if (DBGFLG)
 		print("ioapic_nr for gsi %d is %d\n", gsi, ioapic_nr);
 	if (ioapic_nr < 0) {
 		error("Could not find an IOAPIC for global irq!\n");
@@ -821,7 +819,7 @@ acpiirq(uint32_t tbdf, int gsi)
 	//ioapicdump();
 	ioapicintrinit(busno, ioapic_nr, gsi - xioapic[ioapic_nr].Ioapic.gsib,
 	               devno, BUSFNO(tbdf), vinfotodo->lo);
-	//if (DBGFLG)
+	if (DBGFLG)
 		print("ioapicinrinit seems to have worked\n");
 	poperror();
 

--- a/sys/src/9/amd64/ioapic.c
+++ b/sys/src/9/amd64/ioapic.c
@@ -28,20 +28,24 @@ typedef struct Rdt Rdt;
 extern Atable *apics; 		/* APIC info */
 int mpisabusno = -1;
 
+/* Rbus chains, one for each device bus: each rbus matches a device to an rdt */
 struct Rbus {
 	Rbus	*next;
 	int	devno;
+	int	fno;
 	Rdt	*rdt;
 };
 
+
+/* Each rdt describes an ioapic input pin (intin, from the bus/device) */
 struct Rdt {
-	Apic	*apic;
-	int	intin;
+	Apic		*apic;
+	int		intin;
 	uint32_t	lo;
 	uint32_t	hi;
 
-	int	ref;				/* could map to multiple busses */
-	int	enabled;				/* times enabled */
+	int		ref;			/* could map to multiple busses */
+	int		enabled;		/* times enabled */
 };
 
 enum {						/* IOAPIC registers */
@@ -136,7 +140,7 @@ rtblput(Apic* apic, int sel, uint32_t hi, uint32_t lo)
 	ioapicwrite(apic, sel, lo);
 }
 
-Rdt*
+static Rdt*
 rdtlookup(Apic *apic, int intin)
 {
 	int i;
@@ -150,7 +154,8 @@ rdtlookup(Apic *apic, int intin)
 	return nil;
 }
 
-int compatible(uint32_t new, uint32_t old)
+static int
+compatible(uint32_t new, uint32_t old)
 {
 	uint32_t newtop = new & ~0xff;
 	uint32_t oldtop = old & ~0xff;
@@ -165,8 +170,9 @@ int compatible(uint32_t new, uint32_t old)
 	print("REALLY not the same\n");
 	return 0;
 }
-void
-ioapicintrinit(int busno, int apicno, int intin, int devno, uint32_t lo)
+
+static void
+ioapicintrinit(int busno, int apicno, int intin, int devno, int fno, uint32_t lo)
 {
 	Rbus *rbus;
 	Rdt *rdt;
@@ -196,29 +202,31 @@ ioapicintrinit(int busno, int apicno, int intin, int devno, uint32_t lo)
 	}
 
 	rdt = rdtlookup(apic, intin);
-	if(rdt == nil){
+	if (rdt == nil) {
 		rdt = &rdtarray[nrdtarray++];
 		rdt->apic = apic;
 		rdt->intin = intin;
 		rdt->lo = lo;
-	}else{
-		if(! compatible(lo, rdt->lo)){
+	} else {
+		if (!compatible(lo, rdt->lo)) {
 			print("ioapicintrinit: multiple irq botch bus %d %d/%d/%d lo %d vs %d\n",
 				busno, apicno, intin, devno, lo, rdt->lo);
 			return;
 		}
-		print("dup rdt %d %d %d %d %.8x\n", busno, apicno, intin, devno, lo);
+		print("ioapicintrinit: dup rdt %d %d %d %d %.8x\n", busno, apicno, intin, devno, lo);
 	}
 	rdt->ref++;
 	rbus = malloc(sizeof *rbus);
 	rbus->rdt = rdt;
 	rbus->devno = devno;
+	rbus->fno = fno;
 	rbus->next = rdtbus[busno];
 	rdtbus[busno] = rbus;
 	print("%s: success\n", __func__);
 }
 
-static int acpi_irq2ioapic(int irq)
+static int
+acpi_irq2ioapic(int irq)
 {
 	int ioapic_idx = 0;
 	Apic *apic;
@@ -256,7 +264,8 @@ static int acpi_irq2ioapic(int irq)
  *		like implementing a motherboard driver for each different motherboard,
  *		or some complex auto-detection scheme, or just configure PCI devices to
  *		use MSI instead). */
-static int acpi_make_rdt(Vctl *v, int tbdf, int irq, int busno, int devno)
+static int
+acpi_make_rdt(Vctl *v, int irq, int bustype, int busno, int devno, int fno)
 {
 	Atable *at;
 	Apicst *st, *lst;
@@ -291,14 +300,14 @@ static int acpi_make_rdt(Vctl *v, int tbdf, int irq, int busno, int devno)
 		lo = pol | edge_level;
 		gsi_irq = st->intovr.intr;
 	} else {
-		if (BUSTYPE(tbdf) == BusISA) {
+		if (bustype == BusISA) {
 			lo = IPhigh | TMedge;
 			gsi_irq = irq;
 		} else {
 			/* Need to query ACPI at some point to handle this */
 			print("Non-ISA IRQ %d not found in MADT, aborting\n", irq);
-			print("Bustype: %d\n", BUSTYPE(tbdf));
-			print("todo[%d] b:%d d:%d f:%d\n", todoidx, BUSBNO(tbdf), BUSDNO(tbdf), BUSFNO(tbdf));
+			print("Bustype: %d\n", bustype);
+			print("todo[%d] b:%d d:%d f:%d\n", todoidx, busno, devno, fno);
 			todo[todoidx].v = *v;
 			todo[todoidx].lo = lo | TMlevel | IPlow | Im;
 			todo[todoidx].valid = 1;
@@ -313,7 +322,7 @@ static int acpi_make_rdt(Vctl *v, int tbdf, int irq, int busno, int devno)
 		return -1;
 	}
 	ioapicintrinit(busno, ioapic_nr, gsi_irq - xioapic[ioapic_nr].Ioapic.gsib,
-	               devno, lo);
+	               devno, fno, lo);
 	return 0;
 }
 
@@ -385,9 +394,9 @@ ioapicdump(void)
 		print("iointr bus %d:\n", i);
 		for(; rbus != nil; rbus = rbus->next){
 			rdt = rbus->rdt;
-			print(" apic %ld devno %#x (%d %d) intin %d lo %#x ref %d\n",
+			print(" apic %ld devno %#x (%d %d) fno %d intin %d lo %#x ref %d\n",
 				rdt->apic-xioapic, rbus->devno, rbus->devno>>2,
-				rbus->devno & 0x03, rdt->intin, rdt->lo, rdt->ref);
+				rbus->devno & 0x03, rbus->fno, rdt->intin, rdt->lo, rdt->ref);
 		}
 	}
 }
@@ -489,7 +498,7 @@ ioapicintrdd(uint32_t* hi, uint32_t* lo)
 	*lo |= Pm|MTf;
 }
 
-int
+static int
 nextvec(void)
 {
 	uint vecno;
@@ -582,7 +591,8 @@ ioapicintrdisable(int vecno)
 }
 
 /* From Akaros, not sure we want this but for now ... */
-static int ioapic_exists(void)
+static int
+ioapic_exists(void)
 {
 	/* not foolproof, if we called this before parsing */
 	for (int i = 0; i < Napic; i++)
@@ -591,12 +601,14 @@ static int ioapic_exists(void)
 	return 0;
 }
 
-Rdt *rbus_get_rdt(int busno, int devno)
+static Rdt *
+rbus_get_rdt(int busno, int devno, int fno)
 {
 	Rbus *rbus;
 	for (rbus = rdtbus[busno]; rbus != nil; rbus = rbus->next) {
-		if (rbus->devno == devno)
+		if (rbus->devno == devno && rbus->fno == fno) {
 			return rbus->rdt;
+		}
 	}
 	return 0;
 }
@@ -617,16 +629,18 @@ Rdt *rbus_get_rdt(int busno, int devno)
  * In plan9, this was ioapicintrenable(), which also unmasked.  We don't have a
  * deinit/disable method that would tear down the route yet.  All the plan9 one
  * did was dec enabled and mask the entry. */
-int bus_irq_setup(Vctl *v)
+int
+bus_irq_setup(Vctl *v)
 {
 	//Rbus *rbus;
 	Rdt *rdt;
-	int busno = -1, devno = -1, vno;
+	int bustype = BUSTYPE(v->Vkey.tbdf);
+	int busno = -1, devno = -1, fno = 0, vno;
 	Pcidev *p;
 
        	if (!ioapic_exists()) {
 		panic("%s: no ioapics?", __func__);
-		switch (BUSTYPE(v->Vkey.tbdf)) {
+		switch (bustype) {
 			//case BusLAPIC:
 			//case BusIPI:
 			//break;
@@ -641,7 +655,7 @@ int bus_irq_setup(Vctl *v)
 			return -1; //irq_h->dev_irq + IdtPIC;
 		}
 	}
-	switch (BUSTYPE(v->Vkey.tbdf)) {
+	switch (bustype) {
 	case BusLAPIC:
 		/* nxm used to set the initial 'isr' method (i think equiv to our
 		 * check_spurious) to apiceoi for non-spurious lapic vectors.  in
@@ -692,19 +706,20 @@ int bus_irq_setup(Vctl *v)
 		 * we subtract 1, since the PCI intp maps 1 -> INTA, 2 -> INTB, etc,
 		 * and the MP spec uses 0 -> INTA, 1 -> INTB, etc. */
 		devno = BUSDNO(v->Vkey.tbdf) << 2 | (devno - 1);
+		fno = BUSFNO(v->Vkey.tbdf);
 		break;
 	default:
 		panic("Unknown bus type, TBDF %p", v->Vkey.tbdf);
 	}
 	/* busno and devno are set, regardless of the bustype, enough to find rdt.
 	 * these may differ from the values in tbdf. */
-	rdt = rbus_get_rdt(busno, devno);
+	rdt = rbus_get_rdt(busno, devno, fno);
 	if (!rdt) {
 		/* second chance.  if we didn't find the item the first time, then (if
 		 * it exists at all), it wasn't in the MP tables (or we had no tables).
 		 * So maybe we can figure it out via ACPI. */
-		acpi_make_rdt(v, v->Vkey.tbdf, v->Vkey.irq, busno, devno);
-		rdt = rbus_get_rdt(busno, devno);
+		acpi_make_rdt(v, v->Vkey.irq, bustype, busno, devno, fno);
+		rdt = rbus_get_rdt(busno, devno, fno);
 	}
 	if (!rdt) {
 		print("Unable to build IOAPIC route for irq %d\n", v->Vkey.irq);
@@ -748,7 +763,8 @@ int bus_irq_setup(Vctl *v)
 	return vno;
 }
 
-int acpiirq(uint32_t tbdf, int gsi)
+int
+acpiirq(uint32_t tbdf, int gsi)
 {
 	Proc *up = externup();
 	int ioapic_nr;
@@ -776,7 +792,7 @@ int acpiirq(uint32_t tbdf, int gsi)
 		}
 	}
 
-	print("acpiirq: vinfotodo b:%d d:%d f:%d\n", BUSBNO(tbdf), BUSDNO(tbdf), BUSFNO(tbdf));
+	print("acpiirq: vinfotodo b:%d d:%d f:%d gsi:%d\n", BUSBNO(tbdf), BUSDNO(tbdf), BUSFNO(tbdf), gsi);
 
 	if (vinfotodo == nil)
 		error("Unknown tbdf");
@@ -804,7 +820,7 @@ int acpiirq(uint32_t tbdf, int gsi)
 	}
 	//ioapicdump();
 	ioapicintrinit(busno, ioapic_nr, gsi - xioapic[ioapic_nr].Ioapic.gsib,
-	               devno, vinfotodo->lo);
+	               devno, BUSFNO(tbdf), vinfotodo->lo);
 	//if (DBGFLG)
 		print("ioapicinrinit seems to have worked\n");
 	poperror();

--- a/sys/src/9/amd64/main.c
+++ b/sys/src/9/amd64/main.c
@@ -621,6 +621,7 @@ if (1){	acpiinit(); hi("	acpiinit();\n");}
 	trapinit();
 	printinit();
 	apiconline();
+	ioapiconline();
 	/* Forcing to single core if desired */
 	if(!nosmp) {
 		sipi();

--- a/sys/src/9/amd64/mpacpi.c
+++ b/sys/src/9/amd64/mpacpi.c
@@ -16,6 +16,7 @@
 
 extern int mpisabusno;
 
+// Initialise all local and IO APICs
 int mpacpi(int ncleft)
 {
 	char *already;
@@ -58,8 +59,9 @@ int mpacpi(int ncleft)
 				} else if (ncleft != 0) {
 					ncleft--;
 					apicinit(st->lapic.id, mt->lapicpa, bp);
-				} else
+				} else {
 					already = "(off)";
+				}
 
 				print("apic proc %d/%d apicid %d %s\n", np - 1, apic->Lapic.machno,
 					   st->lapic.id, already);
@@ -73,14 +75,13 @@ int mpacpi(int ncleft)
 				apic = xioapic + st->ioapic.id;
 				if (apic->useable) {
 					already = "(mp)";
-					goto pr1;
+				} else {
+					ioapicinit(st->ioapic.id, st->ioapic.ibase, st->ioapic.addr);
 				}
-				ioapicinit(st->ioapic.id, st->ioapic.ibase, st->ioapic.addr);
-pr1:
+
 				apic->Ioapic.gsib = st->ioapic.ibase;
 				print("ioapic %d ", st->ioapic.id);
-				print("addr %p ibase %d %s\n", st->ioapic.addr, st->ioapic.ibase,
-					   already);
+				print("addr %p ibase %d %s\n", st->ioapic.addr, st->ioapic.ibase, already);
 				break;
 		}
 	}

--- a/sys/src/9/amd64/trap.c
+++ b/sys/src/9/amd64/trap.c
@@ -54,6 +54,7 @@ intrenable(int irq, void (*f)(Ureg*, void*), void* a, int tbdf, char *name)
 {
 	int vno;
 	Vctl *v;
+
 	if(f == nil){
 		print("intrenable: nil handler for %d, tbdf %#x for %s\n",
 			irq, tbdf, name);

--- a/sys/src/9/port/devcons.c
+++ b/sys/src/9/port/devcons.c
@@ -781,8 +781,8 @@ consread(Chan *c, void *buf, int32_t n, int64_t off)
 	char *b, *bp, ch, *s, *e;
 	char tmp[512];		/* Qswap is 381 bytes at clu */
 	int i, k, id, send;
-	int32_t offset, nread;
-
+	int32_t nread;
+	int64_t offset;
 
 	if(n <= 0)
 		return n;

--- a/sys/src/9/riscv/fns.h
+++ b/sys/src/9/riscv/fns.h
@@ -216,8 +216,6 @@ extern void apicpri(int);
 extern void apicsipi(int, uintmem);
 
 extern void ioapicinit(int, uintmem);
-extern void ioapicintrinit(int, int, int, int, uint32_t);
-extern void ioapiconline(void);
 
 /*
  * archamd64.c

--- a/sys/src/cmd/acpi/irq.c
+++ b/sys/src/cmd/acpi/irq.c
@@ -138,14 +138,14 @@ failed:
 
 	UINT64 pin = 0;
 	while (1) {
-		if (scanf("%x %x", &bus, &dev) < 0)
+		if (scanf("%x %x %x", &bus, &dev, &fn) < 0)
 			break;
 
 		AcpiDbgLevel = 0;
 		ACPI_PCI_ID id = (ACPI_PCI_ID){seg, bus, dev, fn};
 		status = AcpiOsReadPciConfiguration (&id, 0x3d, &pin, 8);
 		if (!ACPI_SUCCESS(status)){
-			printf("Can't read pin for bus %d dev %d\n", bus, dev);
+			printf("Can't read pin for bus %d dev %d fn %d\n", bus, dev, fn);
 			continue;
 		}
 

--- a/sys/src/cmd/acpi/irq.c
+++ b/sys/src/cmd/acpi/irq.c
@@ -154,7 +154,7 @@ failed:
 		status = RouteIRQ(&id, pin, &irq);
 		print("status %d, irq %d\n", status, irq);
 		AcpiDbgLevel = 0;
-		print("echo %d %d %d %d 0x%x > /dev/irqmap", seg, bus, dev, fn, irq);
+		print("echo %d %d %d %d 0x%x > /dev/irqmap\n", seg, bus, dev, fn, irq);
 
 		//ACPI_STATUS PrintDevices(void);
 		//status = PrintDevices();


### PR DESCRIPTION
If run on real hardware with multiple functions on a single PCI device, the original code falls over, since it doesn't seem to distinguish between functions of a PCI device.  This change attempts to improve that, and also to tidy up some code and debug statements