### PR TITLE
Ensure vga physical segs are read/write+attached with default page size

### DIFF
--- a/sys/src/9/amd64/cbvga.c
+++ b/sys/src/9/amd64/cbvga.c
@@ -227,10 +227,11 @@ addvgaseg(char *name, uint32_t pa, uint32_t size)
 	Physseg seg;
 
 	memset(&seg, 0, sizeof seg);
-	seg.attr = SG_PHYSICAL;
+	seg.attr = SG_PHYSICAL | SG_READ | SG_WRITE;
 	seg.name = name;
 	seg.pa = pa;
 	seg.size = size;
+	seg.pgszi = -1;		// Default page size
 	addphysseg(&seg);
 }
 

--- a/sys/src/9/amd64/mmu.c
+++ b/sys/src/9/amd64/mmu.c
@@ -470,7 +470,7 @@ mmuput(uintptr_t va, Page *pg, uint attr)
 			*pte |= PtePS;
 			break;
 		default:
-			panic("mmuput: user pages must be 2M or 1G");
+			panic("mmuput: user pages must be 2M or 1G (pgsz:%d)", pgsz);
 		}
 	splx(pl);
 

--- a/sys/src/9/amd64/vga.c
+++ b/sys/src/9/amd64/vga.c
@@ -262,10 +262,11 @@ addvgaseg(char *name, uint32_t pa, uint32_t size)
 	Physseg seg;
 
 	memset(&seg, 0, sizeof seg);
-	seg.attr = SG_PHYSICAL;
+	seg.attr = SG_PHYSICAL | SG_READ | SG_WRITE;
 	seg.name = name;
 	seg.pa = pa;
 	seg.size = size;
+	seg.pgszi = -1;		// Default page size
 	addphysseg(&seg);
 }
 

--- a/sys/src/cmd/aux/vga/nvidia.c
+++ b/sys/src/cmd/aux/vga/nvidia.c
@@ -232,9 +232,6 @@ snarf(Vga* vga, Ctlr* ctlr)
 		case 0x0390:
 			nv->arch = NV040;
 			break;
-		case 0x0a60:	/* GT218 */
-			nv->arch = NV050;
-			break;
 		default:
 			error("%s: DID %#4.4x - %#x unsupported\n",
 				ctlr->name, nv->did, (nv->did & 0x0ff0));


### PR DESCRIPTION
Use same explicit nv codenames in nvidia code as nouveau
Make nvidia code a little safer so we can dump out data even if it's a little incomplete

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>