### PR TITLE
launch program support for gdbserver, elf symbol support for acid

### DIFF
--- a/sys/include/a.out.h
+++ b/sys/include/a.out.h
@@ -7,8 +7,6 @@
  * in the LICENSE file.
  */
 
-// TODO rename
-
 typedef	struct	Exec	Exec;
 struct	Exec
 {
@@ -47,14 +45,3 @@ struct	Exec
 #define	MAX_MAGIC	28			/* <= 90 */
 
 #define	DYN_MAGIC	0x80000000		/* dlm */
-
-typedef	struct	Sym	Sym;
-struct	Sym
-{
-	int64_t	value;
-	//uint	sig;
-	char	type;
-	char	*name;
-	uint8_t	binding;
-	uint8_t	symtype;
-};

--- a/sys/include/a.out.h
+++ b/sys/include/a.out.h
@@ -7,6 +7,8 @@
  * in the LICENSE file.
  */
 
+// TODO rename
+
 typedef	struct	Exec	Exec;
 struct	Exec
 {
@@ -50,7 +52,9 @@ typedef	struct	Sym	Sym;
 struct	Sym
 {
 	int64_t	value;
-	uint	sig;
+	//uint	sig;
 	char	type;
 	char	*name;
+	uint8_t	binding;
+	uint8_t	symtype;
 };

--- a/sys/include/elf.h
+++ b/sys/include/elf.h
@@ -28,14 +28,14 @@ typedef struct {
 } E64hdr;
 
 typedef struct {
-	int	type;		/* entry type */
+	int		type;		/* entry type */
 	uint32_t	offset;		/* file offset */
 	uint32_t	vaddr;		/* virtual address */
 	uint32_t	paddr;		/* physical address */
-	int	filesz;		/* file size */
+	int		filesz;		/* file size */
 	uint32_t	memsz;		/* memory size */
-	int	flags;		/* entry flags */
-	int	align;		/* memory/file alignment */
+	int		flags;		/* entry flags */
+	int		align;		/* memory/file alignment */
 } Phdr;
 
 typedef struct {

--- a/sys/include/elf.h
+++ b/sys/include/elf.h
@@ -75,6 +75,15 @@ typedef struct {
 	uint64_t	entsize;	/* entry size if table */
 } S64hdr;
 
+typedef struct {
+	uint32_t	st_name;	/* Symbol name */
+	uint8_t		st_info;	/* Type and Binding attributes */
+	uint8_t		st_other;	/* Reserved */
+	uint16_t	st_shndx;	/* Section table index */
+	uint64_t	st_value;	/* Symbol value */
+	uint64_t	st_size;	/* Size of object (e.g., common) */
+} E64Sym;
+
 enum {
 	/* Ehdr codes */
 	MAG0 = 0,		/* ident[] indexes */
@@ -136,13 +145,32 @@ enum {
 	X = 0x1,
 
 	/* Shdr Codes */
-	Progbits = 1,	/* section types */
+	Progbits = 1,		/* section types */
+	Symtab = 2,
 	Strtab = 3,
 	Nobits = 8,
 
-	Swrite = 1,	/* section attributes */
+	Swrite = 1,		/* section attributes */
 	Salloc = 2,
 	Sexec = 4,
+
+	STB_LOCAL = 0,		/* Symbol bindings */
+	STB_GLOBAL = 1,
+	STB_WEAK = 2,
+	STB_LOOS = 10,
+	STB_HIOS = 12,
+	STB_LOPROC = 13,
+	STB_HIPROC = 15,
+
+	STT_NOTYPE = 0, 	/* Symbol types */
+	STT_OBJECT = 1,
+	STT_FUNC = 2,
+	STT_SECTION = 3,
+	STT_FILE = 4,
+	STT_LOOS = 10,
+	STT_HIOS = 12,
+	STT_LOPROC = 13,
+	STT_HIPROC = 15,
 };
 
 #define	ELF_MAG		((0x7f<<24) | ('E'<<16) | ('L'<<8) | 'F')

--- a/sys/include/elf.h
+++ b/sys/include/elf.h
@@ -84,6 +84,16 @@ typedef struct {
 	uint64_t	st_size;	/* Size of object (e.g., common) */
 } E64Sym;
 
+
+typedef struct Sym {
+	int64_t	value;
+	char	*name;
+	uint8_t	binding;
+	uint8_t	symtype;
+	uint	sig;
+	char	type;
+} Sym;
+
 enum {
 	/* Ehdr codes */
 	MAG0 = 0,		/* ident[] indexes */
@@ -145,10 +155,10 @@ enum {
 	X = 0x1,
 
 	/* Shdr Codes */
-	Progbits = 1,		/* section types */
-	Symtab = 2,
-	Strtab = 3,
-	Nobits = 8,
+	SHT_PROGBITS = 1,	/* section types */
+	SHT_SYMTAB = 2,
+	SHT_STRTAB = 3,
+	SHT_NOBITS = 8,
 
 	Swrite = 1,		/* section attributes */
 	Salloc = 2,

--- a/sys/include/elf.h
+++ b/sys/include/elf.h
@@ -86,12 +86,10 @@ typedef struct {
 
 
 typedef struct Sym {
-	int64_t	value;
-	char	*name;
-	uint8_t	binding;
-	uint8_t	symtype;
-	uint	sig;
-	char	type;
+	int64_t		value;
+	uint		sig;
+	char		type;
+	char		*name;
 } Sym;
 
 enum {

--- a/sys/include/elf.h
+++ b/sys/include/elf.h
@@ -179,6 +179,8 @@ enum {
 	STT_HIOS = 12,
 	STT_LOPROC = 13,
 	STT_HIPROC = 15,
+
+	SHN_UNDEF = 0,
 };
 
 #define	ELF_MAG		((0x7f<<24) | ('E'<<16) | ('L'<<8) | 'F')

--- a/sys/include/mach.h
+++ b/sys/include/mach.h
@@ -10,7 +10,6 @@
 /*
  *	Architecture-dependent application data
  */
-//#include "a.out.h"
 #include "elf.h"
 /*
  *	Supported architectures:
@@ -261,6 +260,7 @@ typedef struct Fhdr
 	int8_t		bigendian;	/* big endian or not */
 	uint64_t	stroff;		/* strtab offset in file */
 	uint64_t	strsz;		/* size of strtab seg */
+	uint16_t	bssidx;		/* index of bss section */	
 } Fhdr;
 
 extern	int	asstype;	/* dissembler type - machdata.c */

--- a/sys/include/mach.h
+++ b/sys/include/mach.h
@@ -11,6 +11,7 @@
  *	Architecture-dependent application data
  */
 #include "a.out.h"
+//#include "elf.h"
 /*
  *	Supported architectures:
  *		mips,
@@ -238,7 +239,6 @@ typedef struct Fhdr
 	char		*name;		/* identifier of executable */
 	uint8_t		type;		/* file type - see codes above */
 	uint8_t		hdrsz;		/* header size */
-	uint8_t		_magic;		/* _MAGIC() magic */
 	uint8_t		spare;
 	int32_t		magic;		/* magic number */
 	uint64_t	txtaddr;	/* text address */

--- a/sys/include/mach.h
+++ b/sys/include/mach.h
@@ -133,12 +133,12 @@ typedef	struct	Machdata Machdata;
 struct Map {
 	int	nsegs;			/* number of segments */
 	struct segment {		/* per-segment map */
-		char	*name;		/* the segment name */
-		int	fd;		/* file descriptor */
-		int	inuse;		/* in use - not in use */
-		int	cache;		/* should cache reads? */
-		uint64_t	b;		/* base */
-		uint64_t	e;		/* end */
+		char		*name;	/* the segment name */
+		int		fd;	/* file descriptor */
+		int		inuse;	/* in use - not in use */
+		int		cache;	/* should cache reads? */
+		uint64_t	b;	/* base */
+		uint64_t	e;	/* end */
 		int64_t	f;		/* offset within file */
 	} seg[1];			/* actually n of these */
 };
@@ -184,50 +184,50 @@ enum {					/* bits in rflags field */
  *		and set in the debugger startup.
  */
 struct Mach{
-	char	*name;
-	int	mtype;			/* machine type code */
-	Reglist *reglist;		/* register set */
-	int32_t	regsize;		/* sizeof registers in bytes */
-	int32_t	fpregsize;		/* sizeof fp registers in bytes */
-	char	*pc;			/* pc name */
-	char	*sp;			/* sp name */
-	char	*link;			/* link register name */
-	char	*sbreg;			/* static base register name */
-	uint64_t	sb;			/* static base register value */
-	int	pgsize;			/* page size */
-	uint64_t	kbase;			/* kernel base address */
-	uint64_t	ktmask;			/* ktzero = kbase & ~ktmask */
-	uint64_t	utop;			/* user stack top */
-	int	pcquant;		/* quantization of pc */
-	int	szaddr;			/* sizeof(void*) */
-	int	szreg;			/* sizeof(register) */
-	int	szfloat;		/* sizeof(float) */
-	int	szdouble;		/* sizeof(double) */
+	char		*name;
+	int		mtype;		/* machine type code */
+	Reglist 	*reglist;	/* register set */
+	int32_t		regsize;	/* sizeof registers in bytes */
+	int32_t		fpregsize;	/* sizeof fp registers in bytes */
+	char		*pc;		/* pc name */
+	char		*sp;		/* sp name */
+	char		*link;		/* link register name */
+	char		*sbreg;		/* static base register name */
+	uint64_t	sb;		/* static base register value */
+	int		pgsize;		/* page size */
+	uint64_t	kbase;		/* kernel base address */
+	uint64_t	ktmask;		/* ktzero = kbase & ~ktmask */
+	uint64_t	utop;		/* user stack top */
+	int		pcquant;	/* quantization of pc */
+	int		szaddr;		/* sizeof(void*) */
+	int		szreg;		/* sizeof(register) */
+	int		szfloat;	/* sizeof(float) */
+	int		szdouble;	/* sizeof(double) */
 };
 
 extern	Mach	*mach;			/* Current machine */
 
 typedef uint64_t	(*Rgetter)(Map*, char*);
-typedef	void	(*Tracer)(Map*, uint64_t, uint64_t, Symbol*);
+typedef	void		(*Tracer)(Map*, uint64_t, uint64_t, Symbol*);
 
 struct	Machdata {		/* Machine-dependent debugger support */
 	uint8_t	bpinst[4];			/* break point instr. */
 	int16_t	bpsize;				/* size of break point instr. */
 
 	uint16_t	(*swab)(uint16_t);		/* ushort to local byte order */
-	uint32_t	(*swal)(uint32_t);			/* ulong to local byte order */
+	uint32_t	(*swal)(uint32_t);		/* ulong to local byte order */
 	uint64_t	(*swav)(uint64_t);		/* uvlong to local byte order */
-	int	(*ctrace)(Map*, uint64_t, uint64_t, uint64_t, Tracer); /* C traceback */
+	int		(*ctrace)(Map*, uint64_t, uint64_t, uint64_t, Tracer); /* C traceback */
 	uint64_t	(*findframe)(Map*, uint64_t, uint64_t, uint64_t,
-				     uint64_t);/* frame finder */
-	char*	(*excep)(Map*, Rgetter);	/* last exception */
+				     uint64_t);		/* frame finder */
+	char*		(*excep)(Map*, Rgetter);	/* last exception */
 	uint32_t	(*bpfix)(uint64_t);		/* breakpoint fixup */
-	int	(*sftos)(char*, int, void*);	/* single precision float */
-	int	(*dftos)(char*, int, void*);	/* double precision float */
-	int	(*foll)(Map*, uint64_t, Rgetter, uint64_t*);/* follow set */
-	int	(*das)(Map*, uint64_t, char, char*, int);	/* symbolic disassembly */
-	int	(*hexinst)(Map*, uint64_t, char*, int); 	/* hex disassembly */
-	int	(*instsize)(Map*, uint64_t);	/* instruction size */
+	int		(*sftos)(char*, int, void*);	/* single precision float */
+	int		(*dftos)(char*, int, void*);	/* double precision float */
+	int		(*foll)(Map*, uint64_t, Rgetter, uint64_t*);	/* follow set */
+	int		(*das)(Map*, uint64_t, char, char*, int);	/* symbolic disassembly */
+	int		(*hexinst)(Map*, uint64_t, char*, int); 	/* hex disassembly */
+	int		(*instsize)(Map*, uint64_t);	/* instruction size */
 };
 
 /*
@@ -235,26 +235,26 @@ struct	Machdata {		/* Machine-dependent debugger support */
  */
 typedef struct Fhdr
 {
-	char	*name;		/* identifier of executable */
-	uint8_t	type;		/* file type - see codes above */
-	uint8_t	hdrsz;		/* header size */
-	uint8_t	_magic;		/* _MAGIC() magic */
-	uint8_t	spare;
-	int32_t	magic;		/* magic number */
+	char		*name;		/* identifier of executable */
+	uint8_t		type;		/* file type - see codes above */
+	uint8_t		hdrsz;		/* header size */
+	uint8_t		_magic;		/* _MAGIC() magic */
+	uint8_t		spare;
+	int32_t		magic;		/* magic number */
 	uint64_t	txtaddr;	/* text address */
-	int64_t	txtoff;		/* start of text in file */
+	int64_t		txtoff;		/* start of text in file */
 	uint64_t	dataddr;	/* start of data segment */
-	int64_t	datoff;		/* offset to data seg in file */
-	int64_t	symoff;		/* offset of symbol table in file */
+	int64_t		datoff;		/* offset to data seg in file */
+	int64_t		symoff;		/* offset of symbol table in file */
 	uint64_t	entry;		/* entry point */
-	int64_t	sppcoff;	/* offset of sp-pc table in file */
-	int64_t	lnpcoff;	/* offset of line number-pc table in file */
-	int32_t	txtsz;		/* text size */
-	int32_t	datsz;		/* size of data seg */
-	int32_t	bsssz;		/* size of bss */
-	int32_t	symsz;		/* size of symbol table */
-	int32_t	sppcsz;		/* size of sp-pc table */
-	int32_t	lnpcsz;		/* size of line number-pc table */
+	int64_t		sppcoff;	/* offset of sp-pc table in file */
+	int64_t		lnpcoff;	/* offset of line number-pc table in file */
+	int32_t		txtsz;		/* text size */
+	int32_t		datsz;		/* size of data seg */
+	int32_t		bsssz;		/* size of bss */
+	int32_t		symsz;		/* size of symbol table */
+	int32_t		sppcsz;		/* size of sp-pc table */
+	int32_t		lnpcsz;		/* size of line number-pc table */
 } Fhdr;
 
 extern	int	asstype;	/* dissembler type - machdata.c */
@@ -264,14 +264,13 @@ Map*		attachproc(int, int, int, Fhdr*);
 int		beieee80ftos(char*, int, void*);
 int		beieeesftos(char*, int, void*);
 int		beieeedftos(char*, int, void*);
-uint16_t		beswab(uint16_t);
-uint32_t		beswal(uint32_t);
-uint64_t		beswav(uint64_t);
-uint64_t		ciscframe(Map*, uint64_t, uint64_t, uint64_t,
-				  uint64_t);
+uint16_t	beswab(uint16_t);
+uint32_t	beswal(uint32_t);
+uint64_t	beswav(uint64_t);
+uint64_t	ciscframe(Map*, uint64_t, uint64_t, uint64_t, uint64_t);
 int		cisctrace(Map*, uint64_t, uint64_t, uint64_t, Tracer);
 int		crackhdr(int fd, Fhdr*);
-uint64_t		file2pc(char*, int32_t);
+uint64_t	file2pc(char*, int32_t);
 int		fileelem(Sym**, uint8_t *, char*, int);
 int32_t		fileline(char*, int, uint64_t);
 int		filesym(int, char*, int);
@@ -295,10 +294,10 @@ int		isar(Biobuf*);
 int		leieee80ftos(char*, int, void*);
 int		leieeesftos(char*, int, void*);
 int		leieeedftos(char*, int, void*);
-uint16_t		leswab(uint16_t);
-uint32_t		leswal(uint32_t);
-uint64_t		leswav(uint64_t);
-uint64_t		line2addr(int32_t, uint64_t, uint64_t);
+uint16_t	leswab(uint16_t);
+uint32_t	leswal(uint32_t);
+uint64_t	leswav(uint64_t);
+uint64_t	line2addr(int32_t, uint64_t, uint64_t);
 Map*		loadmap(Map*, int, Fhdr*);
 int		localaddr(Map*, char*, char*, uint64_t*, Rgetter);
 int		localsym(Symbol*, int);
@@ -309,7 +308,7 @@ int		nextar(Biobuf*, int, char*);
 Map*		newmap(Map*, int);
 void		objtraverse(void(*)(Sym*, void*), void*);
 int		objtype(Biobuf*, char**);
-uint64_t		pc2sp(uint64_t);
+uint64_t	pc2sp(uint64_t);
 int32_t		pc2line(uint64_t);
 int		put1(Map*, uint64_t, uint8_t*, int);
 int		put2(Map*, uint64_t, uint16_t);
@@ -318,8 +317,7 @@ int		put8(Map*, uint64_t, uint64_t);
 int		puta(Map*, uint64_t, uint64_t);
 int		readar(Biobuf*, int, int64_t, int);
 int		readobj(Biobuf*, int);
-uint64_t		riscframe(Map*, uint64_t, uint64_t, uint64_t,
-				  uint64_t);
+uint64_t	riscframe(Map*, uint64_t, uint64_t, uint64_t, uint64_t);
 int		risctrace(Map*, uint64_t, uint64_t, uint64_t, Tracer);
 int		setmap(Map*, int, uint64_t, uint64_t, int64_t, char*);
 Sym*		symbase(int32_t*);

--- a/sys/include/mach.h
+++ b/sys/include/mach.h
@@ -10,8 +10,8 @@
 /*
  *	Architecture-dependent application data
  */
-#include "a.out.h"
-//#include "elf.h"
+//#include "a.out.h"
+#include "elf.h"
 /*
  *	Supported architectures:
  *		mips,

--- a/sys/include/mach.h
+++ b/sys/include/mach.h
@@ -231,7 +231,7 @@ struct	Machdata {		/* Machine-dependent debugger support */
 };
 
 /*
- *	Common a.out header describing all architectures
+ *	Common executable header describing all architectures
  */
 typedef struct Fhdr
 {
@@ -255,6 +255,12 @@ typedef struct Fhdr
 	int32_t		symsz;		/* size of symbol table */
 	int32_t		sppcsz;		/* size of sp-pc table */
 	int32_t		lnpcsz;		/* size of line number-pc table */
+
+	// TODO work out which of the above are no longer useful
+	// and which should be uint64
+	int8_t		bigendian;	/* big endian or not */
+	uint64_t	stroff;		/* strtab offset in file */
+	uint64_t	strsz;		/* size of strtab seg */
 } Fhdr;
 
 extern	int	asstype;	/* dissembler type - machdata.c */

--- a/sys/include/mach.h
+++ b/sys/include/mach.h
@@ -261,6 +261,7 @@ typedef struct Fhdr
 	uint64_t	stroff;		/* strtab offset in file */
 	uint64_t	strsz;		/* size of strtab seg */
 	uint16_t	bssidx;		/* index of bss section */	
+	uint16_t	dbglineidx;	/* index of debug_line section */
 } Fhdr;
 
 extern	int	asstype;	/* dissembler type - machdata.c */

--- a/sys/src/cmd/acid/acid.h
+++ b/sys/src/cmd/acid/acid.h
@@ -52,7 +52,7 @@ Extern Map*	symmap;
 Extern Lsym*	hash[Hashsize];
 Extern long	dogc;
 Extern Rplace*	ret;
-Extern char*	aout;
+Extern char*	exe;
 Extern int	gotint;
 Extern Gc*	gcl;
 Extern int	stacked;

--- a/sys/src/cmd/acid/builtin.c
+++ b/sys/src/cmd/acid/builtin.c
@@ -1011,10 +1011,10 @@ patom(uint8_t type, Store *res)
 		Bprint(bout, "%.2x", (int)res->ival&0xff);
 		break;
 	case 'X':
-		Bprint(bout, "%.8lux", (uint32_t)res->ival);
+		Bprint(bout, "%.8lx", (uint32_t)res->ival);
 		break;
 	case 'x':
-		Bprint(bout, "%.4lux", (uint32_t)res->ival&0xffff);
+		Bprint(bout, "%.4lx", (uint32_t)res->ival&0xffff);
 		break;
 	case 'D':
 		Bprint(bout, "%d", (int)res->ival);
@@ -1035,10 +1035,10 @@ patom(uint8_t type, Store *res)
 		Bprint(bout, "%lld", res->ival);
 		break;
 	case 'W':
-		Bprint(bout, "%.8llux", res->ival);
+		Bprint(bout, "%.8llx", res->ival);
 		break;
 	case 'Y':
-		Bprint(bout, "%.16llux", res->ival);
+		Bprint(bout, "%.16llx", res->ival);
 		break;
 	case 'o':
 		Bprint(bout, "0%.11o", (int)res->ival&0xffff);

--- a/sys/src/cmd/acid/builtin.c
+++ b/sys/src/cmd/acid/builtin.c
@@ -203,7 +203,7 @@ newproc(Node *r, Node *args)
 	char *argv[Maxarg], buf[Strsize];
 
 	i = 1;
-	argv[0] = aout;
+	argv[0] = exe;
 
 	if(args) {
 		expr(args, &res);

--- a/sys/src/cmd/acid/main.c
+++ b/sys/src/cmd/acid/main.c
@@ -46,7 +46,7 @@ main(int argc, char *argv[])
 
 	argv0 = argv[0];
 	pid = 0;
-	aout = "8.out";
+	exe = "8.out";
 	quiet = 1;
 
 	mtype = 0;
@@ -80,27 +80,27 @@ main(int argc, char *argv[])
 
 	if(argc > 0) {
 		if(remote)
-			aout = argv[0];
+			exe = argv[0];
 		else
 		if(isnumeric(argv[0])) {
 			pid = strtol(argv[0], 0, 0);
 			snprint(prog, sizeof(prog), "/proc/%d/text", pid);
-			aout = prog;
+			exe = prog;
 			if(argc > 1)
-				aout = argv[1];
+				exe = argv[1];
 			else if(kernel)
-				aout = system();
+				exe = system();
 		}
 		else {
 			if(kernel) {
 				fprint(2, "acid: -k requires a pid\n");
 				usage();
 			}
-			aout = argv[0];
+			exe = argv[0];
 		}
 	} else
 	if(remote)
-		aout = "/mips/9ch";
+		exe = "/mips/9ch";
 
 	fmtinstall('x', xfmt);
 	fmtinstall('L', Lfmt);
@@ -116,7 +116,7 @@ main(int argc, char *argv[])
 	if(mtype && machbyname(mtype) == 0)
 		print("unknown machine %s", mtype);
 
-	if (attachfiles(aout, pid) < 0)
+	if (attachfiles(exe, pid) < 0)
 		varreg();		/* use default register set on error */
 
 	loadmodule("/sys/lib/acid/port");
@@ -168,21 +168,21 @@ main(int argc, char *argv[])
 }
 
 static int
-attachfiles(char *aout, int pid)
+attachfiles(char *exe, int pid)
 {
 	interactive = 0;
 	if(setjmp(err))
 		return -1;
 
-	if(aout) {				/* executable given */
+	if(exe) {				/* executable given */
 		if(wtflag)
-			text = open(aout, ORDWR);
+			text = open(exe, ORDWR);
 		else
-			text = open(aout, OREAD);
+			text = open(exe, OREAD);
 
 		if(text < 0)
-			error("%s: can't open %s: %r\n", argv0, aout);
-		readtext(aout);
+			error("%s: can't open %s: %r\n", argv0, exe);
+		readtext(exe);
 	}
 	if(pid)					/* pid given */
 		sproc(pid);

--- a/sys/src/cmd/gdbserver/gdbserver.c
+++ b/sys/src/cmd/gdbserver/gdbserver.c
@@ -330,14 +330,16 @@ get_packet(char *buffer)
 		if (ch == '#') {
 			xmitcsum = hex_to_bin(gdbstub_read_wait()) << 4;
 			xmitcsum += hex_to_bin(gdbstub_read_wait());
-		if (checksum != xmitcsum)
-			syslog(0, "gdbserver", "BAD CSUM Computed 0x%x want 0x%x", xmitcsum, checksum);
-			if (checksum != xmitcsum)
+			if (checksum != xmitcsum) {
+				syslog(0, "gdbserver", "BAD CSUM Computed 0x%x want 0x%x", xmitcsum, checksum);
+			}
+			if (checksum != xmitcsum) {
 				/* failed checksum */
 				write_char('-');
-			else
+			} else {
 				/* successful transfer */
 				write_char('+');
+			}
 		}
 		buffer[count] = 0;
 	} while (checksum != xmitcsum);

--- a/sys/src/cmd/ktrace.c
+++ b/sys/src/cmd/ktrace.c
@@ -11,6 +11,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <mach.h>
+#include <a.out.h>
 #include <ctype.h>
 
 static	int	rtrace(uint64_t, uint64_t, uint64_t);

--- a/sys/src/cmd/strip.c
+++ b/sys/src/cmd/strip.c
@@ -11,6 +11,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <mach.h>
+#include <a.out.h>
 
 void
 error(char* fmt, ...)

--- a/sys/src/libmach/executable.c
+++ b/sys/src/libmach/executable.c
@@ -36,11 +36,12 @@ typedef struct {
 	int32_t dummy;			/* padding to ensure extra long */
 } ExecHdr;
 
-static	int	elfdotout(int, Fhdr*, ExecHdr*);
-static	void	setsym(Fhdr*, int32_t, int32_t, int32_t, int64_t);
-static	void	setdata(Fhdr*, uint64_t, int32_t, int64_t, int32_t);
-static	void	settext(Fhdr*, uint64_t, uint64_t, int32_t, int64_t);
-static	void	hswal(void*, int, uint32_t(*)(uint32_t));
+static int	elfdotout(int, Fhdr*, ExecHdr*);
+static void	setsym(Fhdr*, int32_t, int32_t, int32_t, int64_t);
+static void	setdata(Fhdr*, uint64_t, int32_t, int64_t, int32_t);
+static void	settext(Fhdr*, uint64_t, uint64_t, int32_t, int64_t);
+static void	setstr(Fhdr *fp, int64_t stroff, uint64_t strsz);
+static void	hswal(void*, int, uint32_t(*)(uint32_t));
 
 /*
  *	definition of per-executable file type structures
@@ -181,15 +182,11 @@ hswal(void *v, int n, uint32_t (*swap)(uint32_t))
 static int
 elf64dotout(int fd, Fhdr *fp, ExecHdr *hp)
 {
-	E64hdr *ep;
-	P64hdr *ph;
 	uint16_t (*swab)(uint16_t);
 	uint32_t (*swal)(uint32_t);
 	uint64_t (*swav)(uint64_t);
-	int i, it, id, is, phsz;
-	uint64_t uvl;
 
-	ep = &hp->e.E64hdr;
+	E64hdr *ep = &hp->e.E64hdr;
 	if(ep->ident[DATA] == ELFDATA2LSB) {
 		swab = leswab;
 		swal = leswal;
@@ -202,6 +199,7 @@ elf64dotout(int fd, Fhdr *fp, ExecHdr *hp)
 		werrstr("bad ELF64 encoding - not big or little endian");
 		return 0;
 	}
+	fp->bigendian = ep->ident[DATA] == ELFDATA2MSB;
 
 	ep->type = swab(ep->type);
 	ep->machine = swab(ep->machine);
@@ -231,12 +229,13 @@ elf64dotout(int fd, Fhdr *fp, ExecHdr *hp)
 		break;
 	}
 
+	// Program headers
 	if(ep->phentsize != sizeof(P64hdr)) {
-		werrstr("bad ELF64 header size");
+		werrstr("bad ELF64 program header size");
 		return 0;
 	}
-	phsz = sizeof(P64hdr)*ep->phnum;
-	ph = malloc(phsz);
+	int phsz = sizeof(P64hdr)*ep->phnum;
+	P64hdr *ph = malloc(phsz);
 	if(!ph)
 		return 0;
 	seek(fd, ep->phoff, 0);
@@ -244,7 +243,8 @@ elf64dotout(int fd, Fhdr *fp, ExecHdr *hp)
 		free(ph);
 		return 0;
 	}
-	for(i = 0; i < ep->phnum; i++) {
+
+	for(int i = 0; i < ep->phnum; i++) {
 		ph[i].type = swal(ph[i].type);
 		ph[i].flags = swal(ph[i].flags);
 		ph[i].offset = swav(ph[i].offset);
@@ -256,16 +256,14 @@ elf64dotout(int fd, Fhdr *fp, ExecHdr *hp)
 	}
 
 	/* find text, data and symbols and install them */
-	it = id = is = -1;
-	for(i = 0; i < ep->phnum; i++) {
-		if(ph[i].type == LOAD
-		&& (ph[i].flags & (R|X)) == (R|X) && it == -1)
+	int it = -1, id = -1;
+	for(int i = 0; i < ep->phnum; i++) {
+		if(ph[i].type == LOAD && (ph[i].flags & (R|X)) == (R|X) && it == -1)
 			it = i;
-		else if(ph[i].type == LOAD
-		&& (ph[i].flags & (R|W)) == (R|W) && id == -1)
+		else if(ph[i].type == LOAD && (ph[i].flags & (R|W)) == (R|W) && id == -1)
 			id = i;
-		else if(ph[i].type == NOPTYPE && is == -1)
-			is = i;
+		//else if(ph[i].type == NOPTYPE && is == -1)
+		//	is = i;
 	}
 	if(it == -1 || id == -1) {
 		werrstr("No ELF64 TEXT or DATA sections");
@@ -274,12 +272,67 @@ elf64dotout(int fd, Fhdr *fp, ExecHdr *hp)
 	}
 
 	settext(fp, ep->elfentry, ph[it].vaddr, ph[it].memsz, ph[it].offset);
-	/* 8c: out of fixed registers */
-	uvl = ph[id].memsz - ph[id].filesz;
+	uint64_t uvl = ph[id].memsz - ph[id].filesz;
 	setdata(fp, ph[id].vaddr, ph[id].filesz, ph[id].offset, uvl);
-	if(is != -1)
-		setsym(fp, ph[is].filesz, 0, ph[is].memsz, ph[is].offset);
 	free(ph);
+
+	// Section headers - get the symbol table offset from here
+	if (ep->shentsize != sizeof(S64hdr)) {
+		werrstr("bad ELF64 section header size");
+		return 0;
+	}
+	int shsz = sizeof(S64hdr)*ep->shnum;
+	S64hdr *sh = malloc(shsz);
+	if (!sh) {
+		return 0;
+	}
+	seek(fd, ep->shoff, 0);
+	if (read(fd, sh, shsz) < 0) {
+		free(sh);
+		return 0;
+	}
+
+	for (int i = 0; i < ep->shnum; i++) {
+		sh[i].name = swal(sh[i].name);
+		sh[i].type = swal(sh[i].type);
+		sh[i].flags = swav(sh[i].flags);
+		sh[i].addr = swav(sh[i].addr);
+		sh[i].offset = swav(sh[i].offset);
+		sh[i].size = swav(sh[i].size);
+		sh[i].link = swal(sh[i].link);
+		sh[i].info = swal(sh[i].info);
+		sh[i].addralign = swav(sh[i].addralign);
+		sh[i].entsize = swav(sh[i].entsize);
+	}
+
+	int isym = -1, istr = -1;
+	for (int i = 0; i < ep->shnum; i++) {
+		if (sh[i].type == Symtab && isym == -1) {
+			// Assume the first is the one we want for now
+			// There may be more than one if it's dynamic, but we
+			// don't support than, so hopefully this is ok for now
+			isym = i;
+		} else if (sh[i].type == Strtab && istr == -1) {
+			// Assume first is the one we want for now, but we
+			// should probably check that the name is '.strtab' to
+			// distinguish from .shstrtab.
+			istr = i;
+			break;
+		}
+	}
+
+	if (isym != -1) {
+		print("isym: %d\n", isym);
+		setsym(fp, sh[isym].size, 0, sh[isym].size, sh[isym].offset);
+	}
+
+	if (istr != -1) {
+		print("istr: %d\n", istr);
+		setstr(fp, sh[istr].offset, sh[istr].size);
+	}
+
+	free(sh);
+
 	return 1;
 }
 
@@ -317,8 +370,7 @@ setdata(Fhdr *fp, uint64_t a, int32_t s, int64_t off, int32_t bss)
 }
 
 static void
-setsym(Fhdr *fp, int32_t symsz, int32_t sppcsz, int32_t lnpcsz,
-       int64_t symoff)
+setsym(Fhdr *fp, int32_t symsz, int32_t sppcsz, int32_t lnpcsz, int64_t symoff)
 {
 	fp->symsz = symsz;
 	fp->symoff = symoff;
@@ -328,3 +380,9 @@ setsym(Fhdr *fp, int32_t symsz, int32_t sppcsz, int32_t lnpcsz,
 	fp->lnpcoff = fp->sppcoff+fp->sppcsz;
 }
  
+static void
+setstr(Fhdr *fp, int64_t stroff, uint64_t strsz)
+{
+	fp->stroff = stroff;
+	fp->strsz = strsz;
+}

--- a/sys/src/libmach/executable.c
+++ b/sys/src/libmach/executable.c
@@ -310,7 +310,7 @@ elf64dotout(int fd, Fhdr *fp, ExecHdr *hp)
 		int idbg_line = -1;
 		for (int i = 0; i < ep->shnum; i++) {
 			const char *secname = &shstrtab[sh[i].name];
-			print("secname[%d] = %s\n", i, secname);
+			//print("secname[%d] = %s\n", i, secname);
 			if (sh[i].type == SHT_PROGBITS
 				&& !strcmp(".debug_line", secname)
 				&& idbg_line == -1) {

--- a/sys/src/libmach/executable.c
+++ b/sys/src/libmach/executable.c
@@ -290,7 +290,7 @@ static int
 elfdotout(int fd, Fhdr *fp, ExecHdr *hp)
 {
 	/* bitswap the header according to the DATA format */
-	E64hdr ep = &hp->e.E64hdr;
+	E64hdr *ep = &hp->e.E64hdr;
 	if(ep->ident[CLASS] == ELFCLASS64)
 		return elf64dotout(fd, fp, hp);
 

--- a/sys/src/libmach/executable.c
+++ b/sys/src/libmach/executable.c
@@ -38,10 +38,8 @@ typedef struct {
 
 static	int	elfdotout(int, Fhdr*, ExecHdr*);
 static	void	setsym(Fhdr*, int32_t, int32_t, int32_t, int64_t);
-static	void	setdata(Fhdr*, uint64_t, int32_t, int64_t,
-				  int32_t);
-static	void	settext(Fhdr*, uint64_t, uint64_t, int32_t,
-				  int64_t);
+static	void	setdata(Fhdr*, uint64_t, int32_t, int64_t, int32_t);
+static	void	settext(Fhdr*, uint64_t, uint64_t, int32_t, int64_t);
 static	void	hswal(void*, int, uint32_t(*)(uint32_t));
 
 /*
@@ -49,15 +47,15 @@ static	void	hswal(void*, int, uint32_t(*)(uint32_t));
  */
 
 typedef struct Exectable{
-	int32_t	magic;			/* big-endian magic number of file */
-	char	*name;			/* executable identifier */
-	char	*dlmname;		/* dynamically loadable module identifier */
-	uint8_t	type;			/* Internal code */
-	uint8_t	_magic;			/* _MAGIC() magic */
-	Mach	*mach;			/* Per-machine data */
-	int32_t	hsize;			/* header size */
-	uint32_t	(*swal)(uint32_t);		/* beswal or leswal */
-	int	(*hparse)(int, Fhdr*, ExecHdr*);
+	int32_t		magic;			/* big-endian magic number of file */
+	char		*name;			/* executable identifier */
+	char		*dlmname;		/* dynamically loadable module identifier */
+	uint8_t		type;			/* Internal code */
+	uint8_t		_magic;			/* _MAGIC() magic */
+	Mach		*mach;			/* Per-machine data */
+	int32_t		hsize;			/* header size */
+	uint32_t	(*swal)(uint32_t);	/* beswal or leswal */
+	int		(*hparse)(int, Fhdr*, ExecHdr*);
 } ExecTable;
 
 extern	Mach	mamd64;
@@ -231,10 +229,6 @@ elf64dotout(int fd, Fhdr *fp, ExecHdr *hp)
 		fp->type = FAMD64;
 		fp->name = "amd64 ELF64 executable";
 		break;
-	case POWER64:
-		fp->type = FPOWER64;
-		fp->name = "power64 ELF64 executable";
-		break;
 	}
 
 	if(ep->phentsize != sizeof(P64hdr)) {
@@ -295,18 +289,11 @@ elf64dotout(int fd, Fhdr *fp, ExecHdr *hp)
 static int
 elfdotout(int fd, Fhdr *fp, ExecHdr *hp)
 {
-//	Ehdr *ep;
-	E64hdr *ep;
-
 	/* bitswap the header according to the DATA format */
-	ep = &hp->e.E64hdr;
-//	if(ep->ident[CLASS] == ELFCLASS32)
-//		return elf32dotout(fd, fp, hp);
-//	else if(ep->ident[CLASS] == ELFCLASS64)
+	E64hdr ep = &hp->e.E64hdr;
 	if(ep->ident[CLASS] == ELFCLASS64)
 		return elf64dotout(fd, fp, hp);
 
-//	werrstr("bad ELF class - not 32- nor 64-bit");
 	werrstr("bad ELF class - not 64-bit");
 	return 0;
 }
@@ -340,3 +327,4 @@ setsym(Fhdr *fp, int32_t symsz, int32_t sppcsz, int32_t lnpcsz,
 	fp->lnpcsz = lnpcsz;
 	fp->lnpcoff = fp->sppcoff+fp->sppcsz;
 }
+ 

--- a/sys/src/libmach/executable.c
+++ b/sys/src/libmach/executable.c
@@ -11,7 +11,7 @@
 #include	<libc.h>
 #include	<bio.h>
 #include	<mach.h>
-#include	"elf.h"
+//#include	"elf.h"
 
 /*
  *	All a.out header types.  The dummy entry allows canonical
@@ -257,12 +257,12 @@ elf64dotout(int fd, Fhdr *fp, ExecHdr *hp)
 
 	int isym = -1, istr = -1;
 	for (int i = 0; i < ep->shnum; i++) {
-		if (sh[i].type == Symtab && isym == -1) {
+		if (sh[i].type == SHT_SYMTAB && isym == -1) {
 			// Assume the first is the one we want for now
 			// There may be more than one if it's dynamic, but we
 			// don't support than, so hopefully this is ok for now
 			isym = i;
-		} else if (sh[i].type == Strtab && istr == -1) {
+		} else if (sh[i].type == SHT_STRTAB && istr == -1) {
 			// Assume first is the one we want for now, but we
 			// should probably check that the name is '.strtab' to
 			// distinguish from .shstrtab.

--- a/sys/src/libmach/obj.c
+++ b/sys/src/libmach/obj.c
@@ -187,7 +187,7 @@ objlookup(int id, char *name, int type, uint sig)
 	s = names[id];
 	if(s && strcmp(s->name, name) == 0) {
 		s->type = type;
-		s->sig = sig;
+		//s->sig = sig;
 		return;
 	}
 
@@ -232,7 +232,7 @@ objlookup(int id, char *name, int type, uint sig)
 	sp = malloc(sizeof(Symtab));
 	sp->s.name = name;
 	sp->s.type = type;
-	sp->s.sig = sig;
+	//sp->s.sig = sig;
 	sp->s.value = islocal(type) ? MAXOFF : 0;
 	names[id] = &sp->s;
 	sp->next = hash[h];

--- a/sys/src/libmach/obj.c
+++ b/sys/src/libmach/obj.c
@@ -62,7 +62,8 @@ struct	Obj		/* functions to handle each intermediate (.$O) file */
 
 static Obj	obj[] =
 {			/* functions to identify and parse each type of obj */
-	[Maxobjtype ]=	{0, 0, 0},
+	[ObjAmd64] =	{"amd64 .6", _is6, _read6},
+	[Maxobjtype] =	{0, 0, 0},
 };
 
 struct	Symtab
@@ -187,7 +188,7 @@ objlookup(int id, char *name, int type, uint sig)
 	s = names[id];
 	if(s && strcmp(s->name, name) == 0) {
 		s->type = type;
-		//s->sig = sig;
+		s->sig = sig;
 		return;
 	}
 
@@ -232,7 +233,7 @@ objlookup(int id, char *name, int type, uint sig)
 	sp = malloc(sizeof(Symtab));
 	sp->s.name = name;
 	sp->s.type = type;
-	//sp->s.sig = sig;
+	sp->s.sig = sig;
 	sp->s.value = islocal(type) ? MAXOFF : 0;
 	names[id] = &sp->s;
 	sp->next = hash[h];

--- a/sys/src/libmach/setmach.c
+++ b/sys/src/libmach/setmach.c
@@ -25,10 +25,8 @@ struct machtab
 	Machdata	*machdata;		/* machine functions */
 };
 
-extern	Mach		mmips, msparc, m68020, mi386, mamd64,
-			marm, mmips2be, mmips2le, mpower, mpower64, malpha, msparc64;
-extern	Machdata	mipsmach, mipsmachle, sparcmach, m68020mach, i386mach,
-			armmach, mipsmach2le, powermach, alphamach, sparc64mach;
+extern	Mach		mamd64;
+extern	Machdata	i386mach;
 
 /*
  *	machine selection table.  machines with native disassemblers should

--- a/sys/src/libmach/sym.c
+++ b/sys/src/libmach/sym.c
@@ -11,7 +11,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <mach.h>
-#include <elf.h>
+//#include <elf.h>
 
 #define	HUGEINT	0x7fffffff
 #define	NNAME	20		/* a relic of the past */

--- a/sys/src/libmach/sym.c
+++ b/sys/src/libmach/sym.c
@@ -433,7 +433,7 @@ buildtbls(void)
 	int j, nh, ng, nt;
 	File *f;
 	Txtsym *tp;
-	Hist *hp;
+	//Hist *hp;
 	Sym *p, **ap;
 
 	//print("ntxt: %d, nglob: %d, nauto: %d, fmax: %d, nfiles: %d, nhist: %d\n", ntxt, nglob, nauto, fmax, nfiles, nhist);
@@ -481,7 +481,7 @@ buildtbls(void)
 	ng = nt = nh = 0;
 	f = 0;
 	tp = 0;
-	hp = hist;
+	//hp = hist;
 	ap = autos;
 
 	// Skip first null symbol

--- a/sys/src/libmach/sym.c
+++ b/sys/src/libmach/sym.c
@@ -32,38 +32,38 @@ struct hist {				/* Stack of include files & #line directives */
 };
 
 struct file {				/* Per input file header to history stack */
-	uint64_t	addr;			/* address of first text sym */
+	uint64_t	addr;		/* address of first text sym */
 	union {
 		Txtsym	*txt;		/* first text symbol */
 		Sym	*sym;		/* only during initilization */
 	};
-	int	n;			/* size of history stack */
-	Hist	*hist;			/* history stack */
+	int		n;		/* size of history stack */
+	Hist		*hist;		/* history stack */
 };
 
-static	int	debug = 0;
+static	int		debug = 0;
 
-static	Sym	**autos;		/* Base of auto variables */
-static	File	*files;			/* Base of file arena */
-static	int	fmax;			/* largest file path index */
-static	Sym	**fnames;		/* file names path component table */
-static	Sym	**globals;		/* globals by addr table */
-static	Hist	*hist;			/* base of history stack */
-static	int	isbuilt;		/* internal table init flag */
-static	int32_t	nauto;			/* number of automatics */
-static	int32_t	nfiles;			/* number of files */
-static	int32_t	nglob;			/* number of globals */
-static	int32_t	nhist;			/* number of history stack entries */
-static	int32_t	nsym;			/* number of symbols */
-static	int	ntxt;			/* number of text symbols */
-static	uint8_t	*pcline;		/* start of pc-line state table */
-static	uint8_t 	*pclineend;		/* end of pc-line table */
-static	uint8_t	*spoff;			/* start of pc-sp state table */
-static	uint8_t	*spoffend;		/* end of pc-sp offset table */
-static	Sym	*symbols;		/* symbol table */
-static	Txtsym	*txt;			/* Base of text symbol table */
-static	uint64_t	txtstart;		/* start of text segment */
-static	uint64_t	txtend;			/* end of text segment */
+static	Sym		**autos;	/* Base of auto variables */
+static	File		*files;		/* Base of file arena */
+static	int		fmax;		/* largest file path index */
+static	Sym		**fnames;	/* file names path component table */
+static	Sym		**globals;	/* globals by addr table */
+static	Hist		*hist;		/* base of history stack */
+static	int		isbuilt;	/* internal table init flag */
+static	int32_t		nauto;		/* number of automatics */
+static	int32_t		nfiles;		/* number of files */
+static	int32_t		nglob;		/* number of globals */
+static	int32_t		nhist;		/* number of history stack entries */
+static	int32_t		nsym;		/* number of symbols */
+static	int		ntxt;		/* number of text symbols */
+static	uint8_t		*pcline;	/* start of pc-line state table */
+static	uint8_t 	*pclineend;	/* end of pc-line table */
+static	uint8_t		*spoff;		/* start of pc-sp state table */
+static	uint8_t		*spoffend;	/* end of pc-sp offset table */
+static	Sym		*symbols;	/* symbol table */
+static	Txtsym		*txt;		/* Base of text symbol table */
+static	uint64_t	txtstart;	/* start of text segment */
+static	uint64_t	txtend;		/* end of text segment */
 
 static void	cleansyms(void);
 static int32_t	decodename(Biobuf*, Sym*);


### PR DESCRIPTION
Some debugger/libmach changes:
- Add elf symbol support to libmach
- Fix up acid as far as being able to run and set breakpoints.  Can now load elf symbols, set breakpoints, etc.  Not used extensively though.  No support for dwarf data in programs, so no line numbers, etc.
- Add ability for gdbserver to launch programs and immediately break in _main (hang).  Make debugging **much** easier
- Add support for gdbserver continuing to completion without error (previously assumed it would hit a breakpoint)