### PR TITLE
gdbserver wait for launched program to stop before attaching

### DIFF
--- a/sys/src/cmd/gdbserver/gdbserver.c
+++ b/sys/src/cmd/gdbserver/gdbserver.c
@@ -1355,11 +1355,11 @@ main(int argc, char **argv)
 			// before trying to attach
 			while (1) {
 				const char *status = getstatus(ks.threadid);
-				if (status && strcmp(status, "Stopped")) {
+				if (status && !strcmp(status, "Stopped")) {
 					break;
 				}
 			}
-			print("Process stopped.  Waiting for remote gdb connection...");
+			print("Process stopped.  Waiting for remote gdb connection...\n");
 			break;
 		}
 	} else if (pid != nil) {


### PR DESCRIPTION
otherwise when we try to get the segments of the program we're debugging, we could get those of the forked process *before* the exec.  Which really isn't what we want.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>