### PR TITLE
Initializing properly the FPU

### DIFF
--- a/sys/src/9/amd64/fpu.c
+++ b/sys/src/9/amd64/fpu.c
@@ -69,6 +69,7 @@ static Fxsave defaultFxsave;
 
 extern void _fxrstor(Fxsave*);
 extern void _fxsave(Fxsave*);
+extern void _fninit(void);
 
 
 static void
@@ -169,7 +170,8 @@ fpuprocsave(Proc* p)
 
 	// The process is dead so don't save anything
 	if (p->state == Moribund) {
-		return;
+        _fninit();
+	    return;
 	}
 
 	// Save the FPU state without handling pending unmasked exceptions.
@@ -261,6 +263,7 @@ fpuinit(void)
 	cr4 |= Osxmmexcpt|Osfxsr;
 	cr4put(cr4);
 
+    _fninit();
 	memset(&defaultFxsave, 0, sizeof(defaultFxsave));
 
 	fpusave(&defaultFxsave);

--- a/sys/src/9/amd64/l64fpu.S
+++ b/sys/src/9/amd64/l64fpu.S
@@ -22,7 +22,7 @@ _fnclex:
 
 .globl _fninit
 _fninit:
-	FINIT					/* no WAIT */
+	FNINIT					/* no WAIT */
 	ret
 
 .globl _fxrstor


### PR DESCRIPTION
- Solves -nan issue with printf
- regress/fpu/_fpustate now always works (not random)

Tested on *REAL* machine and with GCC (not Clang)

Signed-off-by: Álvaro Jurado <elbingmiss@gmail.com>