### PR TITLE
Allow us to easily renumber harvey system call numbers

### DIFF
--- a/sys/src/sysconf.json
+++ b/sys/src/sysconf.json
@@ -19,6 +19,7 @@
 			"Name": "local"
 		}
 	],
+	"SyscallBase": 1024,
 	"Syscalls": [
 		{
 			"Id": 0,

--- a/util/src/harvey/cmd/mksys/mksys.go
+++ b/util/src/harvey/cmd/mksys/mksys.go
@@ -69,6 +69,7 @@ type Bootmethods struct {
 }
 
 type Sysconf struct {
+	SyscallBase uint32
 	Syscalls    []Syscall
 	Syserrors   []Syserror
 	Bootmethods []Bootmethods
@@ -116,6 +117,11 @@ func main() {
 	syscalls := sysconf.Syscalls
 	syserrors := sysconf.Syserrors
 	bootmethods := sysconf.Bootmethods
+	// Adjust the syscall # for Harvey system calls to 1024 + number
+	// The plan is that we can then bring in a plan 9 system call interface
+	// and easily run native Plan 9 binaries, including Plan 9 Go binaries.
+	// This is a bit of a hack but OTOH it makes for a pretty easy change.
+	// Boot tested.
 	for i := range syscalls {
 		if syscalls[i].Define == "" {
 			syscalls[i].Define = strings.ToUpper(syscalls[i].Name)
@@ -126,6 +132,7 @@ func main() {
 		if syscalls[i].Libname == "" {
 			syscalls[i].Libname = syscalls[i].Name
 		}
+		syscalls[i].Id += sysconf.SyscallBase
 	}
 
 	switch *mode {


### PR DESCRIPTION
This change allows us to easily offset Harvey system call numbers from some base. The base is now in sysconf.json as SyscallBase.

This will in turn let us, if we wish, also support traditional Plan 9 system calls.