### PR TITLE
Revert "Renumber harvey system call numbers"

### DIFF
--- a/sys/src/9/amd64/syscall.c
+++ b/sys/src/9/amd64/syscall.c
@@ -252,7 +252,6 @@ syscall(unsigned int scallnr, Ureg *ureg)
 	Proc *up = externup();
 	if (up->plan9) {
 		uint64_t *a = (void*)ureg->sp;
-		scallnr = ureg->bp + 1024;
 		if (0)
 			print("up %p plan9 %d sp %#lx bp %#lx\n", up, up->plan9, ureg->sp, scallnr);
 		int i = 1;

--- a/sys/src/sysconf.json
+++ b/sys/src/sysconf.json
@@ -19,7 +19,6 @@
 			"Name": "local"
 		}
 	],
-	"SyscallBase": 1024,
 	"Syscalls": [
 		{
 			"Id": 0,

--- a/util/src/harvey/cmd/mksys/mksys.go
+++ b/util/src/harvey/cmd/mksys/mksys.go
@@ -69,7 +69,6 @@ type Bootmethods struct {
 }
 
 type Sysconf struct {
-	SyscallBase uint32
 	Syscalls    []Syscall
 	Syserrors   []Syserror
 	Bootmethods []Bootmethods
@@ -117,11 +116,6 @@ func main() {
 	syscalls := sysconf.Syscalls
 	syserrors := sysconf.Syserrors
 	bootmethods := sysconf.Bootmethods
-	// Adjust the syscall # for Harvey system calls to 1024 + number
-	// The plan is that we can then bring in a plan 9 system call interface
-	// and easily run native Plan 9 binaries, including Plan 9 Go binaries.
-	// This is a bit of a hack but OTOH it makes for a pretty easy change.
-	// Boot tested.
 	for i := range syscalls {
 		if syscalls[i].Define == "" {
 			syscalls[i].Define = strings.ToUpper(syscalls[i].Name)
@@ -132,7 +126,6 @@ func main() {
 		if syscalls[i].Libname == "" {
 			syscalls[i].Libname = syscalls[i].Name
 		}
-		syscalls[i].Id += sysconf.SyscallBase
 	}
 
 	switch *mode {


### PR DESCRIPTION
This reverts commit 839f2c9424bd390b6fac34dfb12ad79c5521d6bc.

It also removes the addition of 1024 to the plan 9 scall number.

Turns out we don't need it; up->plan9 is good enough.