### PR TITLE
remove delay(1000) in devacpi.c

### DIFF
--- a/sys/src/9/amd64/devacpi.c
+++ b/sys/src/9/amd64/devacpi.c
@@ -1547,7 +1547,7 @@ static void parsexsdt(Atable *root)
 			}
 		}
 	}
-	kmprint("FINATABLE\n\n\n\n"); delay(1000);
+	kmprint("FINATABLE\n\n\n\n");
 	finatable(root, &slice);
 }
 


### PR DESCRIPTION
This broke on hardware.
Also, tell Ron not to put delays like that in code.
It's a bad practice.
And also keep it to a separate line to make git blame
easier.