### PR TITLE
Fix build for gcc version 10

### DIFF
--- a/amd64/gcc.json
+++ b/amd64/gcc.json
@@ -2,6 +2,7 @@
 	{
 		"Name": "buildflags",
 		"Cflags": [
+			"-fcommon",
 			"-fno-pie",
 			"-fvar-tracking",
 			"-fvar-tracking-assignments"

--- a/sys/src/9/amd64/gcc.json
+++ b/sys/src/9/amd64/gcc.json
@@ -2,6 +2,7 @@
 	{
 		"Name": "buildflags",
 		"Cflags": [
+			"-fcommon",
 			"-fno-pie",
 			"-fvar-tracking",
 			"-fvar-tracking-assignments"


### PR DESCRIPTION
gcc 10 defaults to `-fno-common`, which results in a lot of "multiple
definition" errors when linking. As suggested by the gcc documentation,
we workaround the issue for now by setting the `-fcommon` flag:
https://gcc.gnu.org/gcc-10/porting_to.html#common

Signed-off-by: Fazlul Shahriar <fshahriar@gmail.com>