### PR TITLE
bootstrap.sh: remove GOBIN for cross-compiled binary

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,7 +6,6 @@ GO111MODULE=on GOBIN="$(pwd)/util" go get -u github.com/Harvey-OS/ninep/cmd/ufs
 # GO111MODULE=on GOBIN="$(pwd)/util" go get -f -u bldy.build/bldy
 GO111MODULE=on GOBIN="$(pwd)/util" go get ./util/src/harvey/cmd/...
 
-GOOS=plan9 GOARCH=amd64 GO111MODULE=on go get golang.org/dl/gotip
 
 # this will make booting a VM easier
 mkdir -p tmp

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,8 +6,7 @@ GO111MODULE=on GOBIN="$(pwd)/util" go get -u github.com/Harvey-OS/ninep/cmd/ufs
 # GO111MODULE=on GOBIN="$(pwd)/util" go get -f -u bldy.build/bldy
 GO111MODULE=on GOBIN="$(pwd)/util" go get ./util/src/harvey/cmd/...
 
-GOOS=plan9 GOARCH=amd64 GO111MODULE=on GOBIN="$(pwd)/util" go get golang.org/dl/gotip
-
+GOOS=plan9 GOARCH=amd64 GO111MODULE=on go get golang.org/dl/gotip
 
 # this will make booting a VM easier
 mkdir -p tmp


### PR DESCRIPTION
Go otherwise complains:
go get: cannot install cross-compiled binaries when GOBIN is set

Signed-off-by: Daniel Maslowski <info@orangecms.org>