### PR TITLE
Add support for PC Engines APU2 by fixing asm, multiboot

### DIFF
--- a/sys/src/9/amd64/archamd64.c
+++ b/sys/src/9/amd64/archamd64.c
@@ -299,6 +299,7 @@ cpuidhz(uint32_t *info0, uint32_t *info1, CpuHypervisor hypervisor)
 		case 0x00600f10:		/* K10 Opteron 6272, FX 6xxx/4xxx */
 		case 0x00600f20:		/* K10 Opteron 63xx, FX 3xxx/8xxx/9xxx */
 		case 0x00700f00:		/* Athlon II X4 5xxx */
+		case 0x00730f00:		/* AMD GX-412TC SOC */
 		case 0x00800f10:		/* Ryzen 5 and 7 */
 		case 0x00810f10:		/* Ryzen 3 */
 			msr = rdmsr(0xc0010064);

--- a/sys/src/9/amd64/asm.c
+++ b/sys/src/9/amd64/asm.c
@@ -279,7 +279,7 @@ asmmapinit(uintmem addr, uintmem size, int type)
 		 * and how much of it is occupied, might need to be known
 		 * for setting up allocators later.
 		 */
-		if(addr < 1*MiB || addr+size < sys->pmstart)
+		if(addr+size < sys->pmstart)
 			break;
 		if(addr < sys->pmstart){
 			size -= sys->pmstart - addr;

--- a/sys/src/9/amd64/multiboot.c
+++ b/sys/src/9/amd64/multiboot.c
@@ -123,7 +123,10 @@ multiboot(uint32_t magic, uint32_t pmbi, int vflag)
 			case 2:
 				if(vflag)
 					print("reserved");
-				else
+				else if (addr == 0) {
+					print("addr 0 is memory, not reserved\n");
+					asmmapinit(addr, len, 1);
+				} else
 					asmmapinit(addr, len, mmap->type);
 				break;
 			case 3:


### PR DESCRIPTION
Add the signature.

Fix allocator issues. coreboot reports page 0 as reserved and this breaks
the address space map allocator. Coreboot also reports memory starting at
0xc0000 as usable, and the asm code would toss that -- in the process, tossing
all of memory.

asm has turned out to be a bit fragile. It can't function without having memory
start at 0. But the code is a bit subtle, so be careful if you decide to adjust it.

Add a comment to mmuinit to explain an error message that is seen all too often.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>