### PR TITLE
uarti8250: make COM1 and COM2 poll, or any uart with poll or tbdf==-1

### DIFF
--- a/sys/src/9/386/uarti8250.c
+++ b/sys/src/9/386/uarti8250.c
@@ -139,7 +139,7 @@ static Ctlr i8250ctlr[2] = {
 {	.io	= Uart1,
 	.irq	= Uart1IRQ,
 	.tbdf	= -1,
-	.poll	= 0, },
+	.poll	= 1, },
 };
 
 static Uart i8250uart[2] = {
@@ -566,6 +566,11 @@ i8250enable(Uart* uart, int ie)
 	Ctlr *ctlr;
 
 	ctlr = uart->regs;
+
+	// old school uarts, with poll or tbdf = -1, can no longer
+	// be supported for interrupts. Sorry.
+	if (ctlr->poll || (ctlr->tbdf == -1))
+		ie = 0;
 
 	/*
 	 * Check if there is a FIFO.

--- a/sys/src/9/port/devuart.c
+++ b/sys/src/9/port/devuart.c
@@ -159,10 +159,15 @@ uartreset(void)
 
 	tail = nil;
 	for(i = 0; physuart[i] != nil; i++){
-		if(physuart[i]->pnp == nil)
+		print("Check uart %s ...", physuart[i]->name);
+		if(physuart[i]->pnp == nil) {
+			print("no pnp, returning\n");
 			continue;
-		if((p = physuart[i]->pnp()) == nil)
+		}
+		if((p = physuart[i]->pnp()) == nil) {
+			print("pnp returns nil, returning\n");
 			continue;
+		}
 		if(uartlist != nil)
 			tail->next = p;
 		else
@@ -172,6 +177,7 @@ uartreset(void)
 		uartnuart++;
 	}
 
+	print("Found %d uarts\n", uartnuart);
 	if(uartnuart)
 		uart = malloc(uartnuart*sizeof(Uart*));
 


### PR DESCRIPTION
now that UARTs are showing up in #t again, any attempt to use them, e.g.
echo hi >> '#t/eia0'
will get a panic, as our interrupt support code no longer supports
ancient hardware with a tbdf of -1.

Note that, cleverly, uart interrupts are never even enabled until the
device is opened, which is why we did not see this problem earlier

We made this change I believe in the mod 2000s as part of the Fast-OS effort,
as we tried to drag the code forward from its 1990 base. It's a shame we
did not have code control back then.

i8250enable now checks to see if ctlr->tbdf is -1, or ctlr->poll is set;
if so, it disables interrupt enable.

The i8250poll code now runs, finally.

But what broke between 2011 and how such that serial consoles stopped working.
Therein lies a puzzle.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>