### PR TITLE
devramfs: get it to work

### DIFF
--- a/sys/src/9/port/devramfs.c
+++ b/sys/src/9/port/devramfs.c
@@ -7,36 +7,37 @@
  * in the LICENSE file.
  */
 
-#include	"u.h"
-#include       "../port/lib.h"
-#include       "mem.h"
-#include       "dat.h"
-#include       "fns.h"
-#include	"../port/error.h"
+#include "u.h"
+#include "../port/lib.h"
+#include "mem.h"
+#include "dat.h"
+#include "fns.h"
+#include "../port/error.h"
 
 #define RAM_BLOCK_LEN 32768
 #define RAM_MAGIC 0xbedabb1e
 #define INVALID_FILE "Invalid ram file"
 
 struct RamFile {
-	unsigned int	magic;
-	char    name[KNAMELEN];
-	struct RamFile *parent;
-	struct RamFile *sibling;
+	unsigned int magic;
+	char name[KNAMELEN];
+	struct RamFile* parent;
+	struct RamFile* sibling;
 	uint64_t length;
 	uint64_t alloclength;
 	int perm;
 	int opencount;
 	int deleteonclose;
+	// A file is up to 4K 8192-byte blocks. That's 32M. Enough.
+	void* blocks[4096];
 	union {
-		uint8_t	*data;		// List of children if directory
 		struct RamFile* firstchild;
 	};
 };
 
-static struct RamFile *ramroot;
+static struct RamFile* ramroot;
 static QLock ramlock;
-static int devramdebug = 0;
+static int devramdebug = 1;
 
 static void
 printramfile(int offset, struct RamFile* file)
@@ -46,18 +47,18 @@ printramfile(int offset, struct RamFile* file)
 		print(" ");
 	}
 	print("ramfile: %x, magic:%x, name: %s, parent: %x, sibling:%x, length:%d, alloclength: %d, perm: %o\n",
-			file, file->magic, file->name, file->parent, file->sibling, file->length, file->alloclength, file->perm);
+	      file, file->magic, file->name, file->parent, file->sibling, file->length, file->alloclength, file->perm);
 }
 
 static void
 debugwalkinternal(int offset, struct RamFile* current)
 {
 	printramfile(offset, current);
-	for (current = current->firstchild; current != nil; current = current->sibling) {
-		if(current->perm & DMDIR){
-			debugwalkinternal(offset+1, current);
-		}else{
-			printramfile(offset,current);
+	for(current = current->firstchild; current != nil; current = current->sibling) {
+		if(current->perm & DMDIR) {
+			debugwalkinternal(offset + 1, current);
+		} else {
+			printramfile(offset, current);
 		}
 	}
 }
@@ -72,15 +73,15 @@ debugwalk()
 static void
 raminit(void)
 {
-	ramroot = (struct RamFile *)malloc(sizeof(struct RamFile));
-	if (ramroot == nil) {
-                error(Eperm);
+	ramroot = (struct RamFile*)malloc(sizeof(struct RamFile));
+	if(ramroot == nil) {
+		error(Eperm);
 	}
 	strcpy(ramroot->name, ".");
 	ramroot->magic = RAM_MAGIC;
 	ramroot->length = 0;
 	ramroot->alloclength = 0;
-	ramroot->perm = DMDIR|0777;
+	ramroot->perm = DMDIR | 0777;
 	ramroot->firstchild = nil;
 }
 
@@ -90,61 +91,60 @@ ramreset(void)
 }
 
 static Chan*
-ramattach(char *spec)
+ramattach(char* spec)
 {
-        Chan *c;
-        char *buf;
+	Chan* c;
+	char* buf;
 
-        c = newchan();
-        mkqid(&c->qid, (int64_t)ramroot, 0, QTDIR);
-        c->dev = devtabget('@', 0);
-        if(spec == nil)
-                spec = "";
-        buf = malloc(1+UTFmax+strlen(spec)+1);
-	if (buf == nil) {
-                error(Eperm);
+	c = newchan();
+	mkqid(&c->qid, (int64_t)ramroot, 0, QTDIR);
+	c->dev = devtabget('@', 0);
+	if(spec == nil)
+		spec = "";
+	buf = malloc(1 + UTFmax + strlen(spec) + 1);
+	if(buf == nil) {
+		error(Eperm);
 	}
-        sprint(buf, "#@%s", spec);
-        c->path = newpath(buf);
+	sprint(buf, "#@%s", spec);
+	c->path = newpath(buf);
 	c->mode = 0777;
-        free(buf);
-        return c;
+	free(buf);
+	return c;
 }
 
 static int
-ramgen(Chan *c, char *name, Dirtab *tab, int ntab, int pos, Dir *dp)
+ramgen(Chan* c, char* name, Dirtab* tab, int ntab, int pos, Dir* dp)
 {
 	Qid qid;
 	int i;
 
-	struct RamFile *current = (struct RamFile *)c->qid.path;
-	if(pos == DEVDOTDOT){
-		if(current->parent == nil){
+	struct RamFile* current = (struct RamFile*)c->qid.path;
+	if(pos == DEVDOTDOT) {
+		if(current->parent == nil) {
 			mkqid(&qid, (uintptr_t)current, 0, QTDIR);
 			devdir(c, qid, "#@", 0, "harvey", 0555, dp);
 			return 1;
 		} else {
-		        mkqid(&qid, (uintptr_t)current->parent, 0, QTDIR);
-		        devdir(c, qid, current->name, 0, "harvey", 0555, dp);
-		        return 1;
+			mkqid(&qid, (uintptr_t)current->parent, 0, QTDIR);
+			devdir(c, qid, current->name, 0, "harvey", 0555, dp);
+			return 1;
 		}
 	}
-	if(current->perm & DMDIR){
+	if(current->perm & DMDIR) {
 		current = current->firstchild;
-		if(current == nil){
+		if(current == nil) {
 			return -1;
 		}
 	}
-	for(i = 0; i < pos; i++){
+	for(i = 0; i < pos; i++) {
 		current = current->sibling;
-		if (current == nil){
+		if(current == nil) {
 			return -1;
 		}
-
 	}
 	mkqid(&qid, (uintptr_t)current, 0, current->perm & DMDIR ? QTDIR : 0);
 	devdir(c, qid, current->name, current->length, "harvey", current->perm, dp);
-	if(name == nil || strcmp(current->name, name) == 0){
+	if(name == nil || strcmp(current->name, name) == 0) {
 		return 1;
 	} else {
 		return 0;
@@ -152,60 +152,74 @@ ramgen(Chan *c, char *name, Dirtab *tab, int ntab, int pos, Dir *dp)
 }
 
 static Walkqid*
-ramwalk(Chan *c, Chan *nc, char **name, int nname)
+ramwalk(Chan* c, Chan* nc, char** name, int nname)
 {
-	Proc *up = externup();
+	Proc* up = externup();
 	qlock(&ramlock);
-	if(waserror()){
+	if(waserror()) {
 		qunlock(&ramlock);
 		nexterror();
 	}
-	Walkqid* wqid =  devwalk(c, nc, name, nname, 0, 0, ramgen);
-	qunlock(&ramlock);
+	Walkqid* wqid = devwalk(c, nc, name, nname, 0, 0, ramgen);
 	poperror();
+	qunlock(&ramlock);
 	return wqid;
 }
 
 static int32_t
-ramstat(Chan *c, uint8_t *dp, int32_t n)
+ramstat(Chan* c, uint8_t* dp, int32_t n)
 {
+	Proc* up = externup();
 	Dir dir;
 	Qid qid;
 	struct RamFile* current = (struct RamFile*)c->qid.path;
-	if (current->magic != RAM_MAGIC)
+
+	if(current->magic != RAM_MAGIC)
 		error(INVALID_FILE);
 
 	qlock(&ramlock);
+	if(waserror()) {
+		qunlock(&ramlock);
+		nexterror();
+	}
+
 	mkqid(&qid, c->qid.path, 0, current->perm & DMDIR ? QTDIR : 0);
 	devdir(c, qid, current->name, current->length, "harvey", 0555, &dir);
+
 	int32_t ret = convD2M(&dir, dp, n);
+	poperror();
 	qunlock(&ramlock);
 	return ret;
 }
 
 static Chan*
-ramopen(Chan *c, int omode)
+ramopen(Chan* c, int omode)
 {
-	Proc *up = externup();
+	Proc* up = externup();
 	qlock(&ramlock);
-	if(waserror()){
+	if(waserror()) {
 		qunlock(&ramlock);
 		nexterror();
 	}
 	Chan* ret = devopen(c, omode, nil, 0, ramgen);
 	struct RamFile* file = (struct RamFile*)c->qid.path;
-	if (file->magic != RAM_MAGIC)
+	if(file->magic != RAM_MAGIC)
 		panic("Invalid ram file");
 	qunlock(&ramlock);
 	poperror();
 	return ret;
 }
 
-static void
-delete(struct RamFile* file)
+static void delete(struct RamFile* file)
 {
-	qlock(&ramlock);
+	Proc* up = externup();
 	struct RamFile* prev = file->parent->firstchild;
+
+	qlock(&ramlock);
+	if(waserror()) {
+		qunlock(&ramlock);
+		nexterror();
+	}
 	if(prev == file) {
 		// This is the first file - make any sibling the first child
 		file->parent->firstchild = file->sibling;
@@ -213,55 +227,68 @@ delete(struct RamFile* file)
 		// Find previous file
 		for(; prev != nil && prev->sibling != file; prev = prev->sibling)
 			;
-		if(prev == nil){
-			qunlock(&ramlock);
+		if(prev == nil) {
 			error(Eperm);
 		} else {
 			prev->sibling = file->sibling;
 		}
 	}
-	if(!(file->perm & DMDIR)){
-		free(file->data);
+	if(!(file->perm & DMDIR)) {
+		for(int i = 0; i < nelem(file->blocks); i++)
+			free(file->blocks[i]);
 	}
 	file->magic = 0;
 	free(file);
-	if (devramdebug) debugwalk();
+	if(devramdebug)
+		debugwalk();
+	poperror();
 	qunlock(&ramlock);
 }
 
 static void
 ramclose(Chan* c)
 {
-        struct RamFile* file = (struct RamFile *)c->qid.path;
-	if (file->magic != RAM_MAGIC)
+	struct RamFile* file = (struct RamFile*)c->qid.path;
+	if(file->magic != RAM_MAGIC)
 		error(INVALID_FILE);
-        if(file->deleteonclose){
-               delete(file);
-        }
+	if(file->deleteonclose) {
+		delete(file);
+	}
 }
 
 static int32_t
-ramread(Chan *c, void *buf, int32_t n, int64_t off)
+ramread(Chan* c, void* buf, int32_t n, int64_t off)
 {
+	Proc* up = externup();
+	// first block, last block
+	int fb = off >> 13, fl = (off + n) >> 13, offinblock = off & 0x1fff;
+
+	// we only write one block.
+	if(fl != fb) {
+		n = 8192 - (off & 0x1fff);
+	}
+
 	qlock(&ramlock);
-	if (c->qid.type == QTDIR){
-		int32_t len =  devdirread(c, buf, n, nil, 0, ramgen);
+	if(waserror()) {
+		qunlock(&ramlock);
+		nexterror();
+	}
+	// For the first pass, we only handle the portion of a write
+	// that fits in a block. Well written software accommodaets partial
+	// writes and the rest we don't care about.
+	if(c->qid.type == QTDIR) {
+		int32_t len = devdirread(c, buf, n, nil, 0, ramgen);
+		poperror();
 		qunlock(&ramlock);
 		return len;
 	}
 	// Read file
-	struct RamFile *file = (void*)c->qid.path;
-	if (file->magic != RAM_MAGIC)
+	struct RamFile* file = (void*)c->qid.path;
+	if(file->magic != RAM_MAGIC)
 		error(INVALID_FILE);
-	int filelen = file->length;
-	if (off > filelen){
-		qunlock(&ramlock);
-		return 0;
-	}
-	if (off + n > filelen){
-		n = filelen - off;
-	}
-	memmove(buf, file->data, n);
+	if(file->blocks[fb])
+		memmove(buf, file->blocks[fb] + offinblock, n);
+	poperror();
 	qunlock(&ramlock);
 	return n;
 }
@@ -270,88 +297,88 @@ typedef double Align;
 typedef union Header Header;
 
 union Header {
-        struct {
-                Header* next;
-                uint    size;
-        } s;
-        Align   al;
+	struct {
+		Header* next;
+		uint size;
+	} s;
+	Align al;
 };
-
 
 static int32_t
 ramwrite(Chan* c, void* v, int32_t n, int64_t off)
 {
-	Header *p;
+	Proc* up = externup();
+	struct RamFile* file = (void*)c->qid.path;
+	// first block, last block
+	int fb = off >> 13, fl = (off + n) >> 13, offinblock = off & 0x1fff;
+
+	// we only write one block.
+	if(fl != fb) {
+		n = 8192 - (off & 0x1fff);
+	}
 
 	qlock(&ramlock);
-	struct RamFile *file = (void*)c->qid.path;
-	if (file->magic != RAM_MAGIC)
+	if(waserror()) {
+		qunlock(&ramlock);
+		nexterror();
+	}
+	if(file->magic != RAM_MAGIC)
 		error(INVALID_FILE);
-	if(n+off >= file->length){
-		uint64_t alloclength = file->alloclength;
-		while(alloclength < n + off)
-			alloclength += RAM_BLOCK_LEN;
-		if(alloclength > file->alloclength){
-			void *newfile = realloc(file->data, alloclength);
-			if(newfile == nil){
-				qunlock(&ramlock);
-				return 0;
-			}
-			file->data = newfile;
-			file->alloclength = alloclength;
-		}
-		file->length = n+off;
+	print("ramwrite: v %p n %#x off %#llx\n", v, n, off);
+	if(!file->blocks[fb]) {
+		file->blocks[fb] = mallocz(8192, 1);
+		if(!file->blocks[fb])
+			error("enomem");
 	}
-	if (devramdebug) {
-		p = (Header*)file->data - 1;
-		print("length of buffer=%d, header size=%d, header next=%x, start of write=%d, end of write=%d\n", file->alloclength, p->s.size, p->s.next, off, off + n);
+	if(devramdebug) {
+		print("length of start of write=%do\n", offinblock);
 	}
-	memmove(file->data + off, v, n);
+	memmove(file->blocks[fb] + offinblock, v, n);
+	poperror();
 	qunlock(&ramlock);
 	return n;
 }
 
 void
-ramcreate(Chan* c, char *name, int omode, int perm)
+ramcreate(Chan* c, char* name, int omode, int perm)
 {
-        Proc *up = externup();
+	Proc* up = externup();
 
-        if(c->qid.type != QTDIR)
-                error(Eperm);
+	if(c->qid.type != QTDIR)
+		error(Eperm);
 
-	struct RamFile* parent = (struct RamFile *)c->qid.path;
-	if (parent->magic != RAM_MAGIC)
+	struct RamFile* parent = (struct RamFile*)c->qid.path;
+	if(parent->magic != RAM_MAGIC)
 		error(INVALID_FILE);
 
-        omode = openmode(omode);
-        struct RamFile* file = (struct RamFile*)malloc(sizeof(struct RamFile));
-	if (file == nil) {
-                error(Eperm);
+	omode = openmode(omode);
+	struct RamFile* file = (struct RamFile*)malloc(sizeof(struct RamFile));
+	if(file == nil) {
+		error(Eperm);
 	}
-        file->length = 0;
+	file->length = 0;
 	file->magic = RAM_MAGIC;
-        strcpy(file->name, name);
-        file->perm = perm;
-        file->parent = parent;
+	strcpy(file->name, name);
+	file->perm = perm;
+	file->parent = parent;
 
 	qlock(&ramlock);
-        if(waserror()) {
-		free(file->data);
+	if(waserror()) {
 		free(file);
 		qunlock(&ramlock);
-                nexterror();
-        }
+		nexterror();
+	}
 
 	file->sibling = parent->firstchild;
 	parent->firstchild = file;
 	mkqid(&c->qid, (uintptr_t)file, 0, file->perm & DMDIR ? QTDIR : 0);
 
-        c->offset = 0;
-        c->mode = omode;
-        c->flag |= COPEN;
+	c->offset = 0;
+	c->mode = omode;
+	c->flag |= COPEN;
 	qunlock(&ramlock);
 
-        poperror();
+	poperror();
 }
 
 void
@@ -362,32 +389,32 @@ ramshutdown(void)
 void
 ramremove(Chan* c)
 {
-	struct RamFile* doomed = (struct RamFile *)c->qid.path;
-	if (doomed->magic != RAM_MAGIC)
+	struct RamFile* doomed = (struct RamFile*)c->qid.path;
+	if(doomed->magic != RAM_MAGIC)
 		error(INVALID_FILE);
-	if(doomed->opencount == 0){
+	if(doomed->opencount == 0) {
 		delete(doomed);
 	}
-	doomed->deleteonclose =1;
+	doomed->deleteonclose = 1;
 }
 
 Dev ramdevtab = {
-	.dc = '@',
-	.name = "ram",
+    .dc = '@',
+    .name = "ram",
 
-	.reset = ramreset,
-	.init = raminit,
-	.shutdown = ramshutdown,
-	.attach = ramattach,
-	.walk = ramwalk,
-	.stat = ramstat,
-	.open = ramopen,
-	.create = ramcreate,
-	.close = ramclose,
-	.read = ramread,
-	.bread = devbread,
-	.write = ramwrite,
-	.bwrite = devbwrite,
-	.remove = ramremove,
-	.wstat = devwstat,
+    .reset = ramreset,
+    .init = raminit,
+    .shutdown = ramshutdown,
+    .attach = ramattach,
+    .walk = ramwalk,
+    .stat = ramstat,
+    .open = ramopen,
+    .create = ramcreate,
+    .close = ramclose,
+    .read = ramread,
+    .bread = devbread,
+    .write = ramwrite,
+    .bwrite = devbwrite,
+    .remove = ramremove,
+    .wstat = devwstat,
 };


### PR DESCRIPTION
devramfs violated a lot of rules about writing drivers, in its not quite
right user (or lack of) of error etc.

It also panicked the kernel.

This verion will let your write up to a 16MiB file.

Needs work, but it's far more workable than what we had.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>