### PR TITLE
Re-enable the SMP control flag

### DIFF
--- a/sys/src/9/amd64/main.c
+++ b/sys/src/9/amd64/main.c
@@ -164,9 +164,7 @@ options(int argc, char* argv[])
 		}
 	}
 	vflag = dbgflg['v'];
-	// hack.
-	//nosmp = dbgflg['n'];
-	//acpionly = dbgflg['z'];
+	nosmp = dbgflg['n'];
 }
 
 void


### PR DESCRIPTION
It turns out that harvey now correctly handles argc, argv from
multiboot.

This means we can once again start using jmk's dbflg infrastructure.

This is important as Go programs don't currently work on smp -- WIP!

If you boot a kernel with the following cmdline:
harvey -n1

smp will be disabled and Go programs run just fine.

N.B.: argc works just like programs; switches and the rest being at argv[1]!
So put in that noise word.

Here is the kexec command I used for harvey to disable SMP:
kexec -l harvey -c 'harvey -n1' -e

Note that harvey is the first argument, not -n1.

You can, similarly, put this in syslinux.cfg or other files.

We should find other uses of dbgflg and reenable them. Further, the DBG
macro is designed to work with dbgflg, though the nasty awk script that
set all this up is long gone -- we may need to extend build.

It's nice to have this old friend back.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>