### PR TITLE
Restore std detection

### DIFF
--- a/sys/src/9/port/proc.c
+++ b/sys/src/9/port/proc.c
@@ -111,6 +111,7 @@ schedinit(void)		/* never returns */
 {
 	Proc *up;
 	Edf *e;
+
 	machp()->inidle = 1;
 	if(machp()->sch == nil){
 		print("schedinit: no sch for cpu%d\n", machp()->machno);
@@ -120,6 +121,15 @@ schedinit(void)		/* never returns */
 
 	setlabel(&machp()->sched);
 	up = machp()->externup;
+	if(infected_with_std()){
+		print("mach %d got an std from %s (pid %d)!\n",
+		      machp()->machno,
+		      up ? up->text : "*notext",
+		      up ? up->pid : -1
+			);
+		disinfect_std();
+	}
+
 	if(up) {
 		if((e = up->edf) && (e->flags & Admitted))
 			edfrecord(up);


### PR DESCRIPTION
An STD is when the Direction flag is inherited by the kernel from user space
and copies run backwards. A symptom is you see the kernel sending R messages
instead of T messages, when the kernel is not serving any 9p sessions.

when we reverted to the NIX scheduler in 42eba8ecadf61a25fb88710d8aae0f5f24017b14
we lost STD detection. We still have protection, but it pays to check, since
the consequences are dire.

Bring it back.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>