### PR TITLE
implement invlpg

### DIFF
--- a/sys/src/9/amd64/l64v.S
+++ b/sys/src/9/amd64/l64v.S
@@ -253,10 +253,7 @@ wrmsr:
 
 .global invlpg
 invlpg:
-#	MOVQ	%rdi, va+0(FP)
-
-#	INVLPG	va+0(FP)
-
+	invlpg (%rdi)
 	RET
 
 .global wbinvd


### PR DESCRIPTION
It was never turned on because I never understood the syntax.
This does NOT solve the Go problem on SMP.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>