### PR TITLE
Make intel 0x506e0 boot

### DIFF
--- a/sys/src/9/amd64/archamd64.c
+++ b/sys/src/9/amd64/archamd64.c
@@ -192,6 +192,7 @@ cpuidhz(uint32_t *info0, uint32_t *info1, CpuHypervisor hypervisor)
 //print("msr 2a is 0x%x >> 22 0x%x\n", rdmsr(0x2a), rdmsr(0x2a)>>22);
 			break;
 		case 0x000306a0:		/* i7,5,3 3xxx */
+		case 0x000506e0:		/* i7,5,3 6xxx */
 			// reading msr 0xcd gets a GPF on this CPU.
 			// per the coreboot irc:
 			// <icon[m]> rminnich: if you need the base for the core's clock multiplier, it's 100MHz since sandybridge
@@ -212,7 +213,6 @@ cpuidhz(uint32_t *info0, uint32_t *info1, CpuHypervisor hypervisor)
 		case 0x000206a0:		/* i7,5,3 2xxx */
 		case 0x000206c0:		/* i7,5,3 4xxx */
 		case 0x000306f0:		/* i7,5,3 5xxx */
-		case 0x000506e0:		/* i7,5,3 6xxx */
 		case 0x00050650:		/* i9 7900X */
 		case 0x000806e0:		/* i7,5,3 85xx */
 		case 0x000906e0:		/* i7,5,3 77xx 8xxx */
@@ -228,8 +228,9 @@ cpuidhz(uint32_t *info0, uint32_t *info1, CpuHypervisor hypervisor)
 				msr = 0;
 				r = rdmsr(0x2a) & 0x1f;
 			}
-			if (f < 0)
+			if (f < 0) {
 				f = rdmsr(0xcd) & 0x07;
+			}
 //iprint("rdmsr Intel: %d\n", rdmsr(0x2a));
 //iprint("Intel msr.lo %d\n", r);
 //iprint("Intel msr.hi %d\n", f);


### PR DESCRIPTION
No longer hangs when trying to work out the clock multiplier

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>