### PR TITLE
Extend initial map to 64M

### DIFF
--- a/sys/src/9/amd64/entry.S
+++ b/sys/src/9/amd64/entry.S
@@ -264,8 +264,8 @@ _warp64:
 	addl	$PGLSZ(1), %edx
 	movl	%edx, PDO(KZERO+3*PGLSZ(1))(%eax)	/* PDE for KZERO 6-8MiB */
 
-	// and up through 12 (and on to 16). This sucks, we'll make it better later. //
-	// We'll just have init the pml2 at compile time. Apologies.
+	// and up through 16 (and on to 64). This sucks, we'll make it better later. //
+	// Note that at some point, we create the whole map.
 	addl	$PGLSZ(1), %edx
 	movl	%edx, PDO(KZERO+4*PGLSZ(1))(%eax)	/* PDE for KZERO 8-10MiB */
 	addl	$PGLSZ(1), %edx
@@ -274,6 +274,61 @@ _warp64:
 	movl	%edx, PDO(KZERO+6*PGLSZ(1))(%eax)	/* PDE for KZERO 12-14MiB */
 	addl	$PGLSZ(1), %edx
 	movl	%edx, PDO(KZERO+7*PGLSZ(1))(%eax)	/* PDE for KZERO 14-16MiB */
+
+	// and up to 64! I tried a loop but it's harder than I thought.
+	// better code welcome.
+	// Warning: you've only got 256M to work with. This is a foundational mistake,
+	// and it's way harder to fix than I thought. So, ugly.
+	// 16 -> 32
+	movl	%edx, PDO(KZERO+8*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+9*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+10*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+11*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+12*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+13*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+14*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+15*PGLSZ(1))(%eax)
+
+	// 32 -> 48
+	movl	%edx, PDO(KZERO+16*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+17*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+18*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+19*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+20*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+21*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+22*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+23*PGLSZ(1))(%eax)
+
+	// 48 -> 64
+	movl	%edx, PDO(KZERO+24*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+25*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+26*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+27*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+28*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+29*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+30*PGLSZ(1))(%eax)
+	addl	$PGLSZ(1), %edx
+	movl	%edx, PDO(KZERO+31*PGLSZ(1))(%eax)
 
 	movl	%eax, %edx			/* PD at PML4 + 2*PTSZ */
 	addl	$(PTSZ|PteRW|PteP), %edx	/* PT at PML4 + 3*PTSZ */

--- a/sys/src/9/amd64/main.c
+++ b/sys/src/9/amd64/main.c
@@ -499,11 +499,6 @@ main(uint32_t mbmagic, uint32_t mbaddress)
 		panic("mach and machp() are different!!\n");
 	assert(sizeof(Mach) <= PGSZ);
 
-	// The kernel has a limited area identity mapped for it.  If when loaded
-	// it goes beyond that area, we'll have problems.  If the identity
-	// mapping changes, change this assert.
-	assert(((uintptr_t)end - KZERO) < 16*MiB);
-
 	/*
 	 * Check that our data is on the right boundaries.
 	 * This works because the immediate value is in code.


### PR DESCRIPTION
This will allow us to include a big u-root and that u-root can
contain u-root and ALL harvey binaries, i.e. all of amd64/bin.

We're going to want a better compression than just gzip.

-rw-r--r-- 1 rminnich rminnich 70192397 Aug 31 20:43 /tmp/initramfs.plan9_amd64.cpio.gz
-rw-r--r-- 1 rminnich rminnich 23180974 Aug 31 20:25 /tmp/initramfs.plan9_amd64.cpio.lzma

But we are, definitely, going to be able to have pretty much anything we need ... in the initramfs.
This is going to be pretty slick. Boot harvey, get the full graphical environment, THEN mount the
server from 9p. This would include rio etc. This is gonna be very nice.

Graham, tmpfs needs lzma added.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>