### PR TITLE
Make Haswell boot fast

### DIFF
--- a/sys/src/9/amd64/archamd64.c
+++ b/sys/src/9/amd64/archamd64.c
@@ -192,13 +192,14 @@ cpuidhz(uint32_t *info0, uint32_t *info1, CpuHypervisor hypervisor)
 //print("msr 2a is 0x%x >> 22 0x%x\n", rdmsr(0x2a), rdmsr(0x2a)>>22);
 			break;
 		case 0x000306a0:		/* i7,5,3 3xxx */
+		case 0x000206c0:		/* i7,5,3 4xxx */
 		case 0x000506e0:		/* i7,5,3 6xxx */
 			// reading msr 0xcd gets a GPF on this CPU.
 			// per the coreboot irc:
 			// <icon[m]> rminnich: if you need the base for the core's clock multiplier, it's 100MHz since sandybridge
 			// Which, going by the Good Book (35-46 volume 3C) is index 5.
 			f = 5;
-			// This will likely be true of many of the CPUs below. FSB did a *long* time ago.
+			// This will likely be true of many of the CPUs below. FSB died a *long* time ago.
 			// fallthrough
 		case 0x000006e0:		/* Core Duo */
 		case 0x000006f0:		/* Core 2 Duo/Quad/Extreme */
@@ -211,7 +212,6 @@ cpuidhz(uint32_t *info0, uint32_t *info1, CpuHypervisor hypervisor)
 		case 0x000106c0:		/* Atom (45nm, 32nm) */
 		case 0x000106e0:		/* i7,5,3 8xx */
 		case 0x000206a0:		/* i7,5,3 2xxx */
-		case 0x000206c0:		/* i7,5,3 4xxx */
 		case 0x000306f0:		/* i7,5,3 5xxx */
 		case 0x00050650:		/* i9 7900X */
 		case 0x000806e0:		/* i7,5,3 85xx */


### PR DESCRIPTION
We can probably move other more modern platforms up as well. At least
this one is booting much quicker now.

Signed-off-by: Daniel Maslowski <info@orangecms.org>