### PR TITLE
Fix build when u-root and tmpfs sources are absent from $GOPATH

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,7 +10,10 @@ GO111MODULE=on go get ./util/src/harvey/cmd/...
 
 echo Fetching u-root and building it...
 GO111MODULE=on go get github.com/u-root/u-root@c6181ee270c59d542825e89a7c02c8c25b30373b golang.org/x/sys@05986578812163b26672dabd9b425240ae2bb0ad
-GO111MODULE=on go install github.com/u-root/u-root
+# Download u-root sources into $GOPATH because that's what u-root expects.
+# See https://github.com/u-root/u-root/issues/805
+# and https://github.com/u-root/u-root/issues/583
+GO111MODULE=off go get -d github.com/u-root/u-root
 
 echo Fetch harvey-os.org commands and build them into $GOBIN
 GO111MODULE=on go get harvey-os.org/cmd/...@bcfa7228c80c35fc627c077fdd5918db2181489e

--- a/sys/src/9/amd64/build.json
+++ b/sys/src/9/amd64/build.json
@@ -2,9 +2,8 @@
 	{
 		"Name": "cpu",
 		"Pre": [
-		    "u-root -o uroot.cpio plan9",
-		    "gzip -f -k uroot.cpio",
-		    "go build -o tmpfs harvey-os.org/cmd/tmpfs/"
+			"u-root -o uroot.cpio plan9",
+			"gzip -f -k uroot.cpio"
 		],
 		"Env": [
 			"CONF=cpu",


### PR DESCRIPTION
u-root expects the sources are there in $GOPATH, so download it before
running it.

Remove an unnecessary tmpfs build since it's already being built during
bootstrap.

Signed-off-by: Fazlul Shahriar <fshahriar@gmail.com>