### PR TITLE
WIP: require u-root support

### DIFF
--- a/sys/src/9/amd64/build.json
+++ b/sys/src/9/amd64/build.json
@@ -1,11 +1,6 @@
 [
 	{
 		"Name": "cpu",
-		"Pre": [
-		    "u-root -o uroot.cpio plan9",
-		    "gzip -f -k uroot.cpio",
-		    "go build -o tmpfs harvey-os.org/cmd/tmpfs/"
-		],
 		"Env": [
 			"CONF=cpu",
 			"GO111MODULE=off",
@@ -99,34 +94,11 @@
 			"Ramfiles": {
 				"bind": "/$ARCH/bin/bind",
 				"boot": "/sys/src/9/boot/bootcpu.elf.out",
-				"cat": "/$ARCH/bin/cat",
-				"crs": "/$ARCH/bin/acpi/crs",
-				"date": "/$ARCH/bin/date",
-				"echo": "/$ARCH/bin/echo",
-				"ed": "/$ARCH/bin/ed",
-				"factotum": "/$ARCH/bin/auth/factotum",
-				"fdisk": "/$ARCH/bin/disk/fdisk",
-				"fossil": "/$ARCH/bin/fossil/fossil",
-				"grep": "/$ARCH/bin/grep",
-				"ipconfig": "/$ARCH/bin/ip/ipconfig",
-				"irq": "/$ARCH/bin/acpi/irq",
-				"ls": "/$ARCH/bin/ls",
+				"bind": "/$ARCH/bin/bind",
 				"mount": "/$ARCH/bin/mount",
-				"nvram": "/util/nvram",
-				"pci": "/rc/bin/pci",
-				"prep": "/$ARCH/bin/disk/prep",
-				"ps": "/$ARCH/bin/ps",
-				"ratrace": "/$ARCH/bin/ratrace",
 				"rc": "/$ARCH/bin/rc",
 				"rcmain": "/rc/lib/rcmain",
-				"realemu": "/$ARCH/bin/aux/realemu",
-				"sed": "/$ARCH/bin/sed",
-				"srv": "/$ARCH/bin/srv",
-				"startdisk": "startdisk",
 				"tmpfs": "/$ARCH/bin/tmpfs",
-				"usbd": "/$ARCH/bin/usb/usbd",
-				"venti": "/$ARCH/bin/venti/venti",
-				"vga": "/$ARCH/bin/aux/vga",
 				"uroot": "uroot.cpio.lzma"
 			},
 			"Systab": "/sys/src/libc/9syscall/sys.h"

--- a/sys/src/9/amd64/u-root.json
+++ b/sys/src/9/amd64/u-root.json
@@ -7,7 +7,24 @@
 			"GOARCH=amd64"
 		],
 		"Pre": [
-			"u-root -o uroot.cpio -files /amd64/bin:amd64/bin -files /rc/bin:rc/bin -files /lib/ndb:lib/ndb $UROOTEXTRARGS plan9 $UROOTEXTRAPACKAGES",
+			"mkdir -p amd64/bin",
+			"rm -rf amd64/bin/fossil amd64/bin/venti  amd64/bin/regress",
+			"rm -f amd64/bin/ttf2subf",
+			"rm -f amd64/bin/tmpfs",
+			"rm -f amd64/bin/zenith",
+			"rm -f amd64/bin/acme",
+			"rm -f amd64/bin/vncs",
+			"rm -f amd64/bin/cifscmd",
+			"rm -f amd64/bin/aquarela",
+			"rm -f amd64/bin/jay",
+			"rm -f amd64/bin/vncv",
+			"rm -f amd64/bin/rio",
+			"rm -f amd64/bin/cifs",
+			"rm -f amd64/bin/scat",
+			"rm -f amd64/bin/vac",
+			"rm -f amd64/bin/vacfs",
+			"rm -f amd64/bin/plot",
+			"u-root -o uroot.cpio -files amd64/bin:amd64/bin -files /rc/bin:rc/bin -files /lib/ndb:lib/ndb $UROOTEXTRARGS plan9 $UROOTEXTRAPACKAGES",
 			"lzma -f -k uroot.cpio"
 		],
 		"#Pre": [


### PR DESCRIPTION
remove a bunch of binaries that are in the compressed initramfs.

For now, to boot, you have to
/boot/tmpfs /boot/uroot&
(wait ...)
/boot/mount /srv/tmpfs /initramfs
/boot/bind /initramfs/amd64/bin /bin

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>