### PR TITLE
remove coreboot and devcoreboot from the build

### DIFF
--- a/sys/src/9/amd64/build.json
+++ b/sys/src/9/amd64/build.json
@@ -30,7 +30,6 @@
 					"bridge",
 					"cap",
 					"cons",
-					"coreboot",
 					"draw",
 					"dup",
 					"env",

--- a/sys/src/9/amd64/core.json
+++ b/sys/src/9/amd64/core.json
@@ -73,7 +73,6 @@
 			"backtrace.c",
 			"../port/dev9p.c",
 			"../port/devbridge.c",
-			"coreboot.c",
 			"ctype.c",
 			"devarch.c",
 			"../port/devdraw.c",

--- a/sys/src/9/port/port.json
+++ b/sys/src/9/port/port.json
@@ -19,7 +19,6 @@
 			"../port/dev.c",
 			"../port/devcap.c",
 			"../port/devcons.c",
-			"../port/devcoreboot.c",
 			"../port/devdup.c",
 			"../port/devenv.c",
 			"../port/devfdmux.c",


### PR DESCRIPTION
Somebody can fix them later but they were breaking
for an apu2 user.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>