### PR TITLE
bootstrap: get main/master for harvey/go and u-root dependencies

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,14 +9,14 @@ echo Building the build tool...
 GO111MODULE=on go get ./util/src/harvey/cmd/...
 
 echo Fetching u-root and building it...
-GO111MODULE=on go get github.com/u-root/u-root@c6181ee270c59d542825e89a7c02c8c25b30373b golang.org/x/sys@05986578812163b26672dabd9b425240ae2bb0ad
+GO111MODULE=on go get github.com/u-root/u-root@master
 # Download u-root sources into $GOPATH because that's what u-root expects.
 # See https://github.com/u-root/u-root/issues/805
 # and https://github.com/u-root/u-root/issues/583
 GO111MODULE=off go get -d github.com/u-root/u-root
 
 echo Fetch harvey-os.org commands and build them into $GOBIN
-GO111MODULE=on go get harvey-os.org/cmd/...@bcfa7228c80c35fc627c077fdd5918db2181489e
+GO111MODULE=on go get harvey-os.org/cmd/...@main
 
 echo FIXME -- once we get more architectures, this needs to be done in sys/src/cmds/build.json
 echo Build tmpfs command into amd64 plan 9 bin

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,11 @@ require (
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/google/goexpect v0.0.0-20200703111054-623d5ca06f56 // indirect
 	github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f // indirect
-	github.com/u-root/u-root v6.0.1-0.20200822172051-c6181ee270c5+incompatible
+	github.com/u-root/u-root v7.0.0+incompatible
+	github.com/ulikunitz/xz v0.5.8 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/tools v0.0.0-20200811215021-48a8ffc5b207 // indirect
 	google.golang.org/grpc v1.30.0 // indirect
-	harvey-os.org v0.0.0-20200818173457-bcfa7228c80c // indirect
+	harvey-os.org v0.0.0-20200907032339-e21673138b63 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,10 @@ github.com/u-root/u-root v6.0.1-0.20200728234108-3441aaa6cf0c+incompatible h1:vR
 github.com/u-root/u-root v6.0.1-0.20200728234108-3441aaa6cf0c+incompatible/go.mod h1:RYkpo8pTHrNjW08opNd/U6p/RJE7K0D8fXO0d47+3YY=
 github.com/u-root/u-root v6.0.1-0.20200822172051-c6181ee270c5+incompatible h1:CpPPb4peXHrnpXuWbKtFbnjdEOWRtzduR1VSTv8mBHk=
 github.com/u-root/u-root v6.0.1-0.20200822172051-c6181ee270c5+incompatible/go.mod h1:RYkpo8pTHrNjW08opNd/U6p/RJE7K0D8fXO0d47+3YY=
+github.com/u-root/u-root v7.0.0+incompatible h1:u+KSS04pSxJGI5E7WE4Bs9+Zd75QjFv+REkjy/aoAc8=
+github.com/u-root/u-root v7.0.0+incompatible/go.mod h1:RYkpo8pTHrNjW08opNd/U6p/RJE7K0D8fXO0d47+3YY=
+github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
+github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc h1:c0o/qxkaO2LF5t6fQrT4b5hzyggAkLLlCUjqfRxd8Q4=
@@ -52,6 +56,7 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -88,5 +93,9 @@ harvey-os.org v0.0.0-20200727215830-5b0d35efdc89 h1:SoXYkGtBs+F1uLdGh7BL9W3oNYSl
 harvey-os.org v0.0.0-20200727215830-5b0d35efdc89/go.mod h1:/HMTYlPsfQz7ekcuJuh28eeYCI6ZUQ7pdj6iaUZdyHU=
 harvey-os.org v0.0.0-20200818173457-bcfa7228c80c h1:FoxPIIGfbaLYWvK6NNhXs2qblOcxMMYtgCwPVHZ0FkA=
 harvey-os.org v0.0.0-20200818173457-bcfa7228c80c/go.mod h1:Nv7W5iTyeAM1h/Mmu+HnKiuZOAdmKBOEBMpZspUXBTQ=
+harvey-os.org v0.0.0-20200902150504-b086005f2d31 h1:M9jAgHW9tkEuh6n7BaHGNz/Sj2AdoQQ/D6vUHhhjnQI=
+harvey-os.org v0.0.0-20200902150504-b086005f2d31/go.mod h1:X8NM+nWMbxt33lc30c6Lp9mhrYoTPfSpqdG1HDJpDEk=
+harvey-os.org v0.0.0-20200907032339-e21673138b63 h1:g6SZnr+RdIZdblyoscrNmtOc4uK//Tt7VbWRtX+KyXo=
+harvey-os.org v0.0.0-20200907032339-e21673138b63/go.mod h1:X8NM+nWMbxt33lc30c6Lp9mhrYoTPfSpqdG1HDJpDEk=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/util/ci.sh
+++ b/util/ci.sh
@@ -23,13 +23,18 @@ pwd # in case you get lost
 # bootstrap Harvey build utilities - what you do on your host OS otherwise
 ./bootstrap.sh
 
+GO_MOD_PATH_UROOT=`grep github.com/u-root/u-root go.mod | cut -d " " -f 2`
+GO_MOD_PATH_HARVEY=`grep harvey-os.org go.mod | cut -d " " -f 2`
+echo u-root version: $(GO_MOD_PATH_UROOT)
+echo Harvey version: $(GO_MOD_PATH_HARVEY)
+
 # not that we really want this, but yea... Go modules
 mkdir -p ~/go/src/github.com/u-root/
-cp -r ~/go/pkg/mod/github.com/u-root/u-root@v*c6181ee* ~/go/src/github.com/u-root/u-root
+cp -r ~/go/pkg/mod/github.com/u-root/$(GO_MOD_PATH_UROOT) ~/go/src/github.com/u-root/u-root
 chmod +w ~/go/src/github.com/u-root/u-root -R
 (cd ~/go/src/github.com/u-root/u-root && dep ensure)
 
-cp -r ~/go/pkg/mod/harvey-os.org@v*bcfa722* ~/go/src/harvey-os.org
+cp -r ~/go/pkg/mod/$(GO_MOD_PATH_HARVEY) ~/go/src/harvey-os.org
 chmod +w ~/go/src/harvey-os.org -R
 
 # extend PATH to include the build tool and u-root


### PR DESCRIPTION
avoids having to update commit id in bootstrap continually at cost of modifiying go.sum and go.mod

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>