### PR TITLE
shrink u-root back to go programs

### DIFF
--- a/sys/src/9/amd64/build.json
+++ b/sys/src/9/amd64/build.json
@@ -1,10 +1,6 @@
 [
 	{
 		"Name": "cpu",
-		"Pre": [
-			"u-root -o uroot.cpio plan9",
-			"gzip -f -k uroot.cpio"
-		],
 		"Env": [
 			"CONF=cpu",
 			"GO111MODULE=off",

--- a/sys/src/9/amd64/u-root.json
+++ b/sys/src/9/amd64/u-root.json
@@ -6,12 +6,12 @@
 			"GOOS=plan9",
 			"GOARCH=amd64"
 		],
-		"Pre": [
+		"#Pre only do this when KZERO is 0xffffffff_80000000": [
 			"u-root -o uroot.cpio -files /amd64/bin:amd64/bin -files /rc/bin:rc/bin -files /lib/ndb:lib/ndb $UROOTEXTRARGS plan9 $UROOTEXTRAPACKAGES",
 			"lzma -f -k uroot.cpio"
 		],
-		"#Pre": [
-			"bash -c 'cd / && u-root -o uroot.cpio -files amd64/bin plan9' ",
+		"Pre": [
+			"u-root -o uroot.cpio plan9",
 			"lzma -f -k uroot.cpio"
 		]
 	}


### PR DESCRIPTION
It would have been nice had we been able to include all of plan 9 bin in
the initramfs. There is a problem.

For historical reasons, the amd64 KZERO is at 0xffffffff_f0000000, i.e.,
the top 256M of the 64-bit space. The u-root cpio that includes all
of /amd64/bin, when uncompressed, is 240M!

We have no space left in that top 256M, and that won't do.

It would be best, in future, if we can get KZERO to 0xffffffff_800000000,
thus making the top of the 64-bit space 2G, not 256M. I've tried this
several times and failed; there are a lot of interlocking parts that
don't make it easy.

So, for now, only put Go programs in u-root.cpio.

The new centre program makes supporting network root so easy that we
hardly need this anyway.

note that with only the go programs, u-root is not 240M, but quite
tidy:
-rw-r--r-- 1 rminnich rminnich 6945512 Sep  7 17:35 uroot.cpio
-rw-r--r-- 1 rminnich rminnich 2056706 Sep  7 17:35 uroot.cpio.lzma

you read that right, 2M. Even uncompressed, it's only 7M. The bloat
comes from all that statically linked C code. U-root does its trick
with rewriting all those Go commands to one source tree and compiling that,
and for that reason, it is quite compact.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>