### PR TITLE
devmntn: start conversion to 9P2000.L

### DIFF
--- a/sys/src/9/port/devmnt.c
+++ b/sys/src/9/port/devmnt.c
@@ -133,8 +133,9 @@ mntversion(Chan *c, uint32_t msize, char *version, usize returnlen)
 		v = VERSION9P;
 
 	/* validity */
-	if(strncmp(v, VERSION9P, strlen(VERSION9P)) != 0)
-		error("bad 9P version specification");
+	// Let the server tell us. 
+	//if(strncmp(v, VERSION9P, strlen(VERSION9P)) != 0)
+		//error("bad 9P version specification");
 
 	mnt = c->mux;
 
@@ -308,8 +309,8 @@ mntauth(Chan *c, char *spec)
 
 }
 
-static Chan*
-mntattach(char *muxattach)
+Chan*
+mntattachversion(char *muxattach, char *version)
 {
 	Proc *up = externup();
 	Mnt *mnt;
@@ -328,7 +329,7 @@ mntattach(char *muxattach)
 	mnt = c->mux;
 
 	if(mnt == nil){
-		mntversion(c, 0, nil, 0);
+		mntversion(c, 0, version, 0);
 		mnt = c->mux;
 		if(mnt == nil)
 			error(Enoversion);
@@ -373,6 +374,12 @@ mntattach(char *muxattach)
 	if((bogus.flags & MCACHE) && mfcinit != nil)
 		c->flag |= CCACHE;
 	return c;
+}
+
+static Chan*
+mntattach(char *muxattach)
+{
+	return mntattachversion(muxattach, "9P2000");
 }
 
 Chan*

--- a/sys/src/9/port/portfns.h
+++ b/sys/src/9/port/portfns.h
@@ -205,6 +205,7 @@ void		mmuflush(void);
 void		mmuput(uintptr_t, Page*, uint);
 void		mmurelease(Proc*);
 void		mmuswitch(Proc*);
+Chan*		mntattachversion(char *muxattach, char *version);
 Chan*		mntauth(Chan*, char*);
 usize		mntversion(Chan*, uint32_t, char*, usize);
 void		mountfree(Mount*);


### PR DESCRIPTION
.L is the internet standard, like it or not.

devmntn will talk .L

This gets us here:
rminnich@rminnich-MacBookPro:~/go/src/github.com/hugelgupf/p9/cmd/p9ufs$ ./p9ufs -v -root /tmp :8080
2020/09/08 21:12:33 recv [r 0xc00000e038] [Tag 065535] Tversion{MSize: 131096, Version: 9P2000}
2020/09/08 21:12:33 send [w 0xc00000e038] [Tag 065535] Rversion{MSize: 0, Version: unknown}
2020/09/08 21:12:33 recv [r 0xc00000e038] [Tag 065535] Tversion{MSize: 131096, Version: 9P2000.L}
2020/09/08 21:12:33 send [w 0xc00000e038] [Tag 065535] Rversion{MSize: 131096, Version: 9P2000.L}
2020/09/08 21:12:33 unknown error: buffer contained no valid message
2020/09/08 21:12:33 send [w 0xc00000e038] [Tag 065535] Rlerror{Error: 5}

and here
192.168.0.8# srv tcp!192.168.0.1!8080 x
post...
192.168.0.8# mount -M N /srv/x /n/x
mntrpcread: convM2S failed
mount: mount /n/x: mount rpc error
192.168.0.8#

I plan to do one RPC every day or so.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>