### PR TITLE
Fix crash in mount syscall when dc is 0

### DIFF
--- a/sys/src/9/port/sysfile.c
+++ b/sys/src/9/port/sysfile.c
@@ -1248,9 +1248,9 @@ sysmount(Ar0* ar0, ...)
 	va_start(list, ar0);
 
 	/*
-	 * int mount(int fd, int afd, char* old, int flag, char* aname);
+	 * int mount(int fd, int afd, char* old, int flag, char* aname, int dc);
 	 * should be
-	 * long mount(int fd, int afd, char* old, int flag, char* aname);
+	 * long mount(int fd, int afd, char* old, int flag, char* aname, int dc);
 	 */
 	fd = va_arg(list, int);
 	afd = va_arg(list, int);
@@ -1260,7 +1260,33 @@ sysmount(Ar0* ar0, ...)
 	dc = va_arg(list, int);
 	va_end(list);
 
+	if(dc == 0){
+		error(Ebadarg);
+	}
 	ar0->i = bindmount(dc, fd, afd, nil, old, flag, aname);
+}
+
+void
+sysmount_(Ar0* ar0, ...)
+{
+	int afd, fd, flag;
+	char *aname, *old;
+	va_list list;
+	va_start(list, ar0);
+
+	/*
+	 * int mount(int fd, int afd, char* old, int flag, char* aname);
+	 *
+	 * Deprecated; should be for backwards compatibility only.
+	 */
+	fd = va_arg(list, int);
+	afd = va_arg(list, int);
+	old = va_arg(list, char*);
+	flag = va_arg(list, int);
+	aname = va_arg(list, char*);
+	va_end(list);
+
+	ar0->i = bindmount('M', fd, afd, nil, old, flag, aname);
 }
 
 void

--- a/sys/src/sysconf.json
+++ b/sys/src/sysconf.json
@@ -365,12 +365,13 @@
 		{
 			"Args": [
 				"int32_t",
+				"int32_t",
 				"char*",
 				"int32_t",
 				"char*"
 			],
 			"Id": 46,
-			"Name": "mount",
+			"Name": "mount_",
 			"Ret": [
 				"int32_t"
 			]
@@ -438,6 +439,21 @@
 			"Name": "nsec",
 			"Ret": [
 				"int64_t"
+			]
+		},
+		{
+			"Args": [
+				"int32_t",
+				"int32_t",
+				"char*",
+				"int32_t",
+				"char*",
+				"int32_t"
+			],
+			"Id": 54,
+			"Name": "mount",
+			"Ret": [
+				"int32_t"
 			]
 		}
 	],


### PR DESCRIPTION
When dc is 0, we try to do a bind, but since the `name` argument is nil,
we crash with `invalid address`. The fix falls back to 'M' in this case,
which also helps plan9 programs that doesn't know about dc.

Fixes #998

Signed-off-by: Fazlul Shahriar <fshahriar@gmail.com>