### PR TITLE
readdir for 9p2000.L

### DIFF
--- a/sys/include/fcall.h
+++ b/sys/include/fcall.h
@@ -137,6 +137,8 @@ enum
 	Rlcreate,
 	Tlerror =	Terror - DotLOffset,
 	Rlerror,
+	Treaddir = 	40,
+	Rreaddir
 };
 
 uint	convM2S(uint8_t*, uint, Fcall*);
@@ -145,6 +147,7 @@ uint	sizeS2M(Fcall*);
 
 int	statcheck(uint8_t *abuf, uint nbuf);
 uint	convM2D(uint8_t*, uint, Dir*, char*);
+uint	convLM2D(uint8_t*, uint, Dir*);
 uint	convD2M(Dir*, uint8_t*, uint);
 uint	sizeD2M(Dir*);
 

--- a/sys/src/9/port/devmnt.c
+++ b/sys/src/9/port/devmnt.c
@@ -741,7 +741,7 @@ mntrdwr(int type, Chan *c, void *buf, int32_t n, int64_t off)
 		if(nr > nreq)
 			nr = nreq;
 
-		if(type == Tread)
+		if((type == Tread) || (type == Treaddir))
 			r->b = bl2mem((uint8_t*)uba, r->b, nr);
 		else if(cache)
 			mfcwrite(c, (uint8_t*)uba, nr, off);
@@ -951,6 +951,9 @@ mntrpcread(Mnt *mnt, Mntrpc *r)
 	t = nb->rp[BIT32SZ];
 	switch(t){
 	case Rread:
+		hlen = BIT32SZ+BIT8SZ+BIT16SZ+BIT32SZ;
+		break;
+	case Rreaddir:
 		hlen = BIT32SZ+BIT8SZ+BIT16SZ+BIT32SZ;
 		break;
 	default:

--- a/sys/src/libc/9sys/convM2D.c
+++ b/sys/src/libc/9sys/convM2D.c
@@ -101,3 +101,45 @@ convM2D(uint8_t *buf, uint nbuf, Dir *d, char *strs)
 
 	return p - buf;
 }
+
+uint
+convLM2D(uint8_t *buf, uint nbuf, Dir *d)
+{
+	uint8_t *p, *ebuf;
+
+	if(nbuf < 22)
+		return 0;
+
+	p = buf;
+	ebuf = buf + nbuf;
+	//qid[13] offset[8] type[1] name[s]
+
+	d->qid.type = GBIT8(p);
+	p += BIT8SZ;
+	d->qid.vers = GBIT32(p);
+	p += BIT32SZ;
+	d->qid.path = GBIT64(p);
+	p += BIT64SZ;
+
+	// scarf offset in length
+	d->length = GBIT64(p);
+	p += BIT64SZ;
+
+	d->type = GBIT8(p);
+	p += BIT8SZ;
+	// ignore the offset.
+	// No mode information.
+	d->mode = 0;
+	// No time information.
+	d->atime = 0;
+	d->mtime = 0;
+	// nothing to do with type for now.
+
+	if(p + BIT16SZ > ebuf)
+		return 0;
+	//ns = GBIT16(p);
+	p += BIT16SZ;
+	// TODO: null terminate?
+	d->name =  (char *)p;
+	return p - buf;
+}

--- a/sys/src/libc/9sys/convM2S.c
+++ b/sys/src/libc/9sys/convM2S.c
@@ -298,6 +298,19 @@ convM2S(uint8_t *ap, uint nap, Fcall *f)
 		p += f->count;
 		break;
 
+	case Rreaddir:
+		if(p+BIT32SZ > ep) {
+			return 0;
+		}
+		f->count = GBIT32(p);
+		p += BIT32SZ;
+		if(p+f->count > ep) {
+			return 0;
+		}
+		f->data = (char*)p;
+		p += f->count;
+		break;
+
 	case Rwrite:
 		if(p+BIT32SZ > ep)
 			return 0;

--- a/sys/src/libc/9sys/convS2M.c
+++ b/sys/src/libc/9sys/convS2M.c
@@ -134,6 +134,12 @@ sizeS2M(Fcall *f)
 		n += BIT32SZ;
 		break;
 
+	case Treaddir:
+		n += BIT32SZ;
+		n += BIT64SZ;
+		n += BIT32SZ;
+		break;
+
 	case Twrite:
 		n += BIT32SZ;
 		n += BIT64SZ;
@@ -326,6 +332,15 @@ convS2M(Fcall *f, uint8_t *ap, uint nap)
 		break;
 
 	case Tread:
+		PBIT32(p, f->fid);
+		p += BIT32SZ;
+		PBIT64(p, f->offset);
+		p += BIT64SZ;
+		PBIT32(p, f->count);
+		p += BIT32SZ;
+		break;
+
+	case Treaddir:
 		PBIT32(p, f->fid);
 		p += BIT32SZ;
 		PBIT64(p, f->offset);


### PR DESCRIPTION
Working read of 9P2000.L directories. Note that you can cat
but not ls -l yet, as we don't have stat, and the first thing
ls does is stat the directory.

This works with a 9P2000.L server running at 192.168.0.1!8080
srv tcp!192.168.0.1!8080 x
mount -M N /srv/x /n/x
cat /n/x

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>