### PR TITLE
stat for 9P2000.L / devmntn

### DIFF
--- a/sys/include/fcall.h
+++ b/sys/include/fcall.h
@@ -97,6 +97,30 @@ struct	Fcall
 #define	NOFID		(uint32_t)~0U	/* Dummy fid */
 #define	IOHDRSZ		24	/* ample room for Twrite/Rread header (iounit) */
 
+// 9P2000.L, for some reason, lets callers closely tune what comes from a gettattr.
+// This *may* be because HPC file systems make getting at some types of metadata
+// expensive. Or it may be a pointless over-optimization; we suspect the latter.
+// Just ask for it all. Bandwidth is free.
+
+#define P9_GETATTR_MODE         0x00000001ULL
+#define P9_GETATTR_NLINK        0x00000002ULL
+#define P9_GETATTR_UID          0x00000004ULL
+#define P9_GETATTR_GID          0x00000008ULL
+#define P9_GETATTR_RDEV         0x00000010ULL
+#define P9_GETATTR_ATIME        0x00000020ULL
+#define P9_GETATTR_MTIME        0x00000040ULL
+#define P9_GETATTR_CTIME        0x00000080ULL
+#define P9_GETATTR_INO          0x00000100ULL
+#define P9_GETATTR_SIZE         0x00000200ULL
+#define P9_GETATTR_BLOCKS       0x00000400ULL
+
+#define P9_GETATTR_BTIME        0x00000800ULL
+#define P9_GETATTR_GEN          0x00001000ULL
+#define P9_GETATTR_DATA_VERSION 0x00002000ULL
+
+#define P9_GETATTR_BASIC        0x000007ffULL /* Mask for fields up to BLOCKS */
+#define P9_GETATTR_ALL          0x00003fffULL /* Mask for All fields above */
+
 enum
 {
 	Tversion =	100,
@@ -137,6 +161,8 @@ enum
 	Rlcreate,
 	Tlerror =	Terror - DotLOffset,
 	Rlerror,
+	Tgetattr =	Tstat - DotLOffset,
+	Rgetattr,
 	Treaddir = 	40,
 	Rreaddir
 };

--- a/sys/src/libc/9sys/convM2D.c
+++ b/sys/src/libc/9sys/convM2D.c
@@ -19,19 +19,22 @@ statcheck(uint8_t *buf, uint nbuf)
 
 	ebuf = buf + nbuf;
 
-	if(nbuf < STATFIXLEN || nbuf != BIT16SZ + GBIT16(buf))
+	if(nbuf < STATFIXLEN || nbuf != BIT16SZ + GBIT16(buf)) {
 		return -1;
+	}
 
 	buf += STATFIXLEN - 4 * BIT16SZ;
 
 	for(i = 0; i < 4; i++){
-		if(buf + BIT16SZ > ebuf)
+		if(buf + BIT16SZ > ebuf) {
 			return -1;
+		}
 		buf += BIT16SZ + GBIT16(buf);
 	}
 
-	if(buf != ebuf)
+	if(buf != ebuf) {
 		return -1;
+	}
 
 	return 0;
 }

--- a/sys/src/libc/9sys/convM2S.c
+++ b/sys/src/libc/9sys/convM2S.c
@@ -322,6 +322,14 @@ convM2S(uint8_t *ap, uint nap, Fcall *f)
 	case Rremove:
 		break;
 
+	case Rgetattr:
+		if(p+153 > ep)
+			return 0;
+		f->nstat = 153;
+		f->data = (char *)p;
+		p += 153;
+		break;
+
 	case Rstat:
 		if(p+BIT16SZ > ep)
 			return 0;


### PR DESCRIPTION
Sample session with a 9P2000.L server (e.g. ipfs):
srv tcp!192.168.0.1!8080 x
mount -M N /srv/x /n/x
ls -l /n/x

9P2000.L has two big problems: first, a directory read does not return
stat records, as it should; second, the stat has fields missing, particularly
the file name, a string for uid, and a string for gid.

These are hard to work around. The result in output like this:

% ls -l/n/x

------w-r--  0 '' '' 0 Feb  7  2006 /n/x/util

because a readdir does not return stat records, we are missing user, group, size information.

But:
192.168.0.7# ls -ld /n/x
d-rwxrwxr-x N 31 1000 1000 4096 Feb  7  2006 /n/x

Because in this case, the code does a stat on /n/x and gets a stat record back.

Now for the first case, what has to happen, but not in this PR, is on a readdir,
the code must do a full walk and stat *for every directory entry*. This means the
number of RPCs for a directory is 2x the number of directory entries, instead
of 1 total as it is in 9P2000. 64 directory entries will result in 129 RPCs
in 9P2000.L and 1 in 9P2000 (129: 1 for readdir, 128 for 2 RPCs for each entry).

Further, on a stat, the file name is not in the stat; we have to pull the name
from the channel. What happens if the name changed after the initial walk?
You'll have the wrong name in a stat. That's not great.

9P2000.L violates plan 9 rules in other small ways, such as including an inumber
in the stat, because few if any real Plan 9 systems have inumbers, but
Linux had its own requirements.

It does get time right. Plan 9 has a 32-bit time problem; 9P2000.L does not.

It's worth supporting 9P2000.L with all its defects, so here we take
another step on that journey.

The code in devmntn.c:mntstat is nasty. I'd just as soon it stayed that
way, rather than bring too much of 9P2000.L's non-plan9-like nature
into fcall.h and libc.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>