### PR TITLE
Fix exec on 9P2000.L (devmntn)

### DIFF
--- a/sys/src/9/port/devmntn.c
+++ b/sys/src/9/port/devmntn.c
@@ -349,7 +349,12 @@ mntopencreate(int type, Chan *c, char *name, int omode, int perm)
 	}
 	r->request.type = type;
 	r->request.fid = c->fid;
-	r->request.mode = omode;
+	// 9P2000.L -- another mess?
+	if (omode == OEXEC)
+		r->request.mode = OREAD;
+	else
+		r->request.mode = omode;
+
 	if(type == Tcreate){
 		r->request.perm = perm;
 		r->request.name = name;


### PR DESCRIPTION
9P2000.L servers don't seem to understand OEXEC.

devmntn mntopencreate will now convert OEXEC to OREAD.

Exec over 9P2000.L mounts work now.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>