### PR TITLE
WIP: Demo of using decompress and cpio with ramdisk

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,6 +21,7 @@ GO111MODULE=on go get harvey-os.org/cmd/...@8978eaed48985e0d89d36e383ece0a6a382e
 echo FIXME -- once we get more architectures, this needs to be done in sys/src/cmds/build.json
 echo Build tmpfs command into amd64 plan 9 bin
 GO111MODULE=on GOOS=plan9 GOARCH=amd64 go build -o plan9_amd64/bin/tmpfs harvey-os.org/cmd/tmpfs
+GO111MODULE=on GOOS=plan9 GOARCH=amd64 go build -o plan9_amd64/bin/decompress harvey-os.org/cmd/decompress
 
 # this will make booting a VM easier
 mkdir -p tmp

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,8 +20,17 @@ GO111MODULE=on go get harvey-os.org/cmd/...@8978eaed48985e0d89d36e383ece0a6a382e
 
 echo FIXME -- once we get more architectures, this needs to be done in sys/src/cmds/build.json
 echo Build tmpfs command into amd64 plan 9 bin
-GO111MODULE=on GOOS=plan9 GOARCH=amd64 go build -o plan9_amd64/bin/tmpfs harvey-os.org/cmd/tmpfs
+#GO111MODULE=on GOOS=plan9 GOARCH=amd64 go build -o plan9_amd64/bin/tmpfs harvey-os.org/cmd/tmpfs
 GO111MODULE=on GOOS=plan9 GOARCH=amd64 go build -o plan9_amd64/bin/decompress harvey-os.org/cmd/decompress
+GO111MODULE=on GOOS=plan9 GOARCH=amd64 go build -o plan9_amd64/bin/cpio github.com/u-root/u-root/cmds/core/cpio
+
+# Could use uroot cpio to build the image on the host
+# Maybe create a compress go tool to allow us to use our tools for compression too
+#GO111MODULE=on go install github.com/u-root/u-root/cmds/core/cpio
+
+# Make a test .cpio.lzma
+# TODO put in a better place - we don't know the arch here
+find plan9_amd64/bin -depth -print | cpio -ov --format=newc | xz -z --format=lzma > sys/src/9/amd64/ramdiskarchive.cpio.lzma
 
 # this will make booting a VM easier
 mkdir -p tmp

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/u-root/u-root v7.0.1-0.20200915215200-c370a343c8b0+incompatible
 	github.com/ulikunitz/xz v0.5.8 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
 	golang.org/x/tools v0.0.0-20200811215021-48a8ffc5b207 // indirect
 	google.golang.org/grpc v1.30.0 // indirect
 	harvey-os.org v0.0.0-20200920202139-8978eaed4898 // indirect

--- a/rc/bin/cpurc
+++ b/rc/bin/cpurc
@@ -5,6 +5,16 @@ date > /env/boottime
 # mount points
 mntgen -s slashn && chmod 666 /srv/slashn
 
+# Decompress the kernel ramdisk image into the kernel
+# Needs to be done in two steps, since cpio can't read
+# directly from decompress using a pipe
+# (This is a demo and should probably all go somewhere else)
+cd '#@'
+decompress /boot/ramdiskarchive > ramdiskarchive.cpio
+cpio i < ramdiskarchive.cpio
+rm -f ramdiskarchive.cpio
+cd ..
+
 # name translation, cs sets /dev/sysname
 ndb/cs
 sysname=`{cat /dev/sysname}

--- a/sys/src/9/amd64/build.json
+++ b/sys/src/9/amd64/build.json
@@ -96,6 +96,7 @@
 				"cat": "/$ARCH/bin/cat",
 				"crs": "/$ARCH/bin/acpi/crs",
 				"date": "/$ARCH/bin/date",
+				"decompress": "/plan9_$ARCH/bin/decompress",
 				"echo": "/$ARCH/bin/echo",
 				"ed": "/$ARCH/bin/ed",
 				"factotum": "/$ARCH/bin/auth/factotum",

--- a/sys/src/9/amd64/build.json
+++ b/sys/src/9/amd64/build.json
@@ -94,6 +94,7 @@
 				"bind": "/$ARCH/bin/bind",
 				"boot": "/sys/src/9/boot/bootcpu.elf.out",
 				"cat": "/$ARCH/bin/cat",
+				"cpio": "/plan9_$ARCH/bin/cpio",
 				"crs": "/$ARCH/bin/acpi/crs",
 				"date": "/$ARCH/bin/date",
 				"decompress": "/plan9_$ARCH/bin/decompress",
@@ -118,11 +119,10 @@
 				"sed": "/$ARCH/bin/sed",
 				"srv": "/$ARCH/bin/srv",
 				"startdisk": "startdisk",
-				"tmpfs": "/plan9_$ARCH/bin/tmpfs",
+				"ramdiskarchive": "ramdiskarchive.cpio.lzma",
 				"usbd": "/$ARCH/bin/usb/usbd",
 				"venti": "/$ARCH/bin/venti/venti",
-				"vga": "/$ARCH/bin/aux/vga",
-				"uroot": "uroot.cpio.lzma"
+				"vga": "/$ARCH/bin/aux/vga"
 			},
 			"Systab": "/sys/src/libc/9syscall/sys.h"
 		},

--- a/sys/src/9/port/devroot.c
+++ b/sys/src/9/port/devroot.c
@@ -20,7 +20,7 @@ enum
 	Qboot = 0x1000,
 
 	Nrootfiles = 32,
-	Nbootfiles = 32,
+	Nbootfiles = 64,
 };
 
 typedef struct Dirlist Dirlist;


### PR DESCRIPTION
This can start the discussion of how to build a ramdisk image to store in the kernel, then extract it to devramfs on boot.

Couldn't just pipe decompress into cpio since cpio appeared to seek.  Needed to work with an intermediate file.