### PR TITLE
Add plan9_$ARCH folder, use centre instead of ufs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,6 @@ util/harvey.raw
 **/*.h.gch
 
 .vscode
-linux_amd64/
+/linux_amd64/
+/plan9_amd64/
+/usr/harvey/lib/cache/

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,7 +20,7 @@ GO111MODULE=on go get harvey-os.org/cmd/...@8978eaed48985e0d89d36e383ece0a6a382e
 
 echo FIXME -- once we get more architectures, this needs to be done in sys/src/cmds/build.json
 echo Build tmpfs command into amd64 plan 9 bin
-GO111MODULE=on GOOS=plan9 GOARCH=amd64 go build -o amd64/bin/tmpfs harvey-os.org/cmd/tmpfs
+GO111MODULE=on GOOS=plan9 GOARCH=amd64 go build -o plan9_amd64/bin/tmpfs harvey-os.org/cmd/tmpfs
 
 # this will make booting a VM easier
 mkdir -p tmp

--- a/clean.json
+++ b/clean.json
@@ -3,7 +3,9 @@
 		"Name": "clean",
 		"Pre": [
 			"rm -rf $ARCH/lib/*.a $ARCH/bin/*",
-			"rm -f cfg/pxe/tftpboot/harvey.32bit"
+			"rm -f cfg/pxe/tftpboot/harvey.32bit",
+			"rm -rf plan9_$ARCH/bin/*",
+			"rm -rf linux_$ARCH/bin/*"
 		],
 		"Projects": [
 			"/sys/src/9/$ARCH/clean.json",

--- a/lib/namespace
+++ b/lib/namespace
@@ -29,6 +29,7 @@ mount -a /srv/factotum /mnt
 
 # standard bin
 bind /$cputype/bin /bin
+bind -a /plan9_$cputype/bin /bin
 bind -a /rc/bin /bin
 bind -a /apex/$cputype/bin /bin
 

--- a/sys/src/9/amd64/build.json
+++ b/sys/src/9/amd64/build.json
@@ -117,7 +117,7 @@
 				"sed": "/$ARCH/bin/sed",
 				"srv": "/$ARCH/bin/srv",
 				"startdisk": "startdisk",
-				"tmpfs": "/$ARCH/bin/tmpfs",
+				"tmpfs": "/plan9_$ARCH/bin/tmpfs",
 				"usbd": "/$ARCH/bin/usb/usbd",
 				"venti": "/$ARCH/bin/venti/venti",
 				"vga": "/$ARCH/bin/aux/vga",

--- a/util/GO9PCPU
+++ b/util/GO9PCPU
@@ -3,8 +3,8 @@ set -e
 
 trap : 2
 
-$HARVEY/util/ufs -root=$HARVEY &
-ufspid=$!
+$HARVEY/linux_amd64/bin/centre -i "" -ninep-dir=$HARVEY &
+centrepid=$!
 
 export machineflag=q35
 if [ "$(uname)" = "Linux" ] && [ -e /dev/kvm ]; then
@@ -40,7 +40,7 @@ EOF
 echo $cmd
 eval $cmd
 
-kill $ufspid
+kill $centrepid
 wait
 
 # TO ENABLE FACTOTUM replace append with this

--- a/util/GO9PTERM
+++ b/util/GO9PTERM
@@ -3,8 +3,8 @@ set -e
 
 trap : 2
 
-$HARVEY/util/ufs -root=$HARVEY &
-ufspid=$!
+$HARVEY/linux_amd64/bin/centre -i "" -ninep-dir=$HARVEY &
+centrepid=$!
 
 export machineflag=q35
 if [ "$(uname)" = "Linux" ] && [ -e /dev/kvm ]; then
@@ -48,7 +48,7 @@ EOF
 echo $cmd
 eval $cmd
 
-kill $ufspid
+kill $centrepid
 wait
 
 # TO ENABLE FACTOTUM replace append with this


### PR DESCRIPTION
Need to decide what to keep in the util folder - I made changes to the GO9P* scripts I think we should keep.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>