### PR TITLE
Fix problem when scripts invoke plan 9 binaries

### DIFF
--- a/sys/src/9/port/sysproc.c
+++ b/sys/src/9/port/sysproc.c
@@ -370,6 +370,11 @@ execac(Ar0* ar0, int flags, char *ufile, char **argv)
 		chan = nil;	/* in case namec errors out */
 		USED(chan);
 		chan = namec(p, Aopen, OEXEC, 0);
+		print("#!: namec returns %p, read header\n", chan);
+		hdrsz = chan->dev->read(chan, line, sizeof line, 0);
+		print("...read %d bytes\n", hdrsz);
+		if(hdrsz < 2)
+			error(Ebadexec);
 	}else{
 		chan = ichan;
 		incref(&ichan->r);


### PR DESCRIPTION
Given a script of the form:

i.e. a file name that is an a.out not an ELF and, further, is not /bin/rc.

It will fail with the odd error:
execac: elf64ldseg returned 0 segs!

This is hardly intuitive. Here's the problem:
The header that is read is a script header.
It is parsed to a name and args, the name being the target file (in this case an a.out).
Namec is called with the path from the #! file (e.g. /path/to/plan9/binary)
The new file is opened and a chan returned to execac.
Aoutldseg is called to check the line. But it is the line for the old file. The line is still the #! header.
Aaoutldseg says "this !# is not an a.out" and returns -1
The elf parser is called, and it says "not an elf", as it is using the new file.

Why does it work for ELF? b/c ELF does not use the header that was read at all. It reads
on its own. So if the file is an ELF there is no problem.

The problem is that in the case of a #! file we need to read the header on the new chan.

This still leaves open the problem of a #! that is *not* an rc script. The args as passed
to the binary seem vaguely wrong. For example, a script such as
!#/bin/ls
will, if invoked, show an ls for 'ls', i.e. gets gets 2 args, not one.

I wonder if anyone ever did a #! that was not an rc script. There are none that I can find in the tree.

This seems a foundational bug in Plan 9. What if two scripts are mutually invoking each other? How do you know
when to stop? It is similar to symlink chasing. I think #! handling is broken.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>