### PR TITLE
uartpci: add support for WCH CH382 uart pci card

### DIFF
--- a/sys/src/9/386/uarti8250.c
+++ b/sys/src/9/386/uarti8250.c
@@ -772,7 +772,6 @@ i8250console(char* cfg)
 {
 	int i;
 	Uart *uart;
-	Ctlr *ctlr;
 	char *cmd, *p;
 
 	/*
@@ -799,20 +798,28 @@ i8250console(char* cfg)
 		break;
 	}
 
+	i8250uartconsole(uart, cmd);
+}
+
+void
+i8250uartconsole(Uart *uart, char *cmd)
+{
 	/*
 	 * Does it exist?
 	 * Should be able to write/read
 	 * the Scratch Pad.
 	 */
-	ctlr = uart->regs;
+	Ctlr *ctlr = uart->regs;
 	csr8o(ctlr, Scr, 0x55);
-	if(csr8r(ctlr, Scr) != 0x55)
+	if (csr8r(ctlr, Scr) != 0x55) {
 		return;
+	}
 
 	(*uart->phys->enable)(uart, 0);
 	uartctl(uart, "b115200 l8 pn s1 i1");
-	if(*cmd != '\0')
+	if (cmd != nil && *cmd != '\0') {
 		uartctl(uart, cmd);
+	}
 
 	i8250consuart = uart;
 	consuartputs = i8250consputs;

--- a/sys/src/9/386/uartpci.c
+++ b/sys/src/9/386/uartpci.c
@@ -78,8 +78,8 @@ uartpcipnp(void)
 		switch((p->did<<16)|p->vid){
 		default:
 			continue;
-		case (0x3253<<16)|0x1c00:	/* WCH CH353 (vid not in pci db) */
-			uart = uartpci(ctlrno, p, 0, 0xc0, 2, 1843200, "WCH-CH353");
+		case (0x3253<<16)|0x1c00:	/* WCH CH382 (vid not in pci db) */
+			uart = uartpci(ctlrno, p, 0, 0xc0, 2, 1843200, "WCH-CH382");
 			if (uart == nil) {
 				continue;
 			}

--- a/sys/src/9/amd64/build.json
+++ b/sys/src/9/amd64/build.json
@@ -20,7 +20,9 @@
 					"int cpuserver = 1;",
 					"uint32_t kerndate = 1;"
 				],
+				"#Dev": "devs are in order of initialisation",
 				"Dev": [
+					"uart",
 					"acpi",
 					"arch",
 					"bridge",
@@ -50,7 +52,6 @@
 					"srv",
 					"ssl",
 					"tls",
-					"uart",
 					"usb",
 					"ws",
 					"v9p",

--- a/sys/src/9/amd64/fns.h
+++ b/sys/src/9/amd64/fns.h
@@ -77,6 +77,7 @@ void	i8042systemreset(void);
 int	mousecmd(int);
 void	mouseenable(void);
 void	i8250console(char*);
+void	i8250uartconsole(Uart*, char *);
 void*	i8250alloc(int, int, int);
 int64_t	i8254hz(uint32_t *info0, uint32_t *info1);
 void	idlehands(void);


### PR DESCRIPTION
Uart port offset found in linux.
Initialise devuart first to allow early connection to pci uart.
Can initialise by adding the following after the uart has been created in uartpci.c:
  i8250uartconsole(uart, nil);
(Would be better to drive it off the kernel args or some other cfg, but no good ideas yet)

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>