### PR TITLE
Fix asmalloc if the first element in the list has to be removed

### DIFF
--- a/sys/src/9/amd64/asm.c
+++ b/sys/src/9/amd64/asm.c
@@ -225,11 +225,13 @@ asmalloc(uintmem addr, uintmem size, int type, int align)
 		if(assem->size == 0){
 			if(pp != nil)
 				pp->next = assem->next;
-			// Bug: What if assem == asmlist (first time in loop)
-			// and the size is 0?
-			// Then when set assem=>next = asmfreelist, you destroy
-			// the asmlist. The original code here failed if
-			// the first region was less than KSEG0 size.
+			// What if assem == asmlist
+			// and the assem->size is now zero, i.e. it is completely used?
+			// Then if the code were to set assem->next = asmfreelist,
+			// it would destroy the asmlist. The original code here failed if
+			// the first region size was less than size requested.
+			// That typically happened when allocating address space
+			// for KSEG0. This if below covers that case.
 			if (assem == asmlist)
 				asmlist = assem->next;
 			assem->next = asmfreelist;

--- a/sys/src/9/amd64/asm.c
+++ b/sys/src/9/amd64/asm.c
@@ -232,8 +232,7 @@ asmalloc(uintmem addr, uintmem size, int type, int align)
 			// the first region was less than KSEG0 size.
 			if (assem == asmlist)
 				asmlist = assem->next;
-			else
-				assem->next = asmfreelist;
+			assem->next = asmfreelist;
 			asmfreelist = assem;
                 }
 

--- a/sys/src/9/amd64/asm.c
+++ b/sys/src/9/amd64/asm.c
@@ -225,9 +225,17 @@ asmalloc(uintmem addr, uintmem size, int type, int align)
 		if(assem->size == 0){
 			if(pp != nil)
 				pp->next = assem->next;
-			assem->next = asmfreelist;
+			// Bug: What if assem == asmlist (first time in loop)
+			// and the size is 0?
+			// Then when set assem=>next = asmfreelist, you destroy
+			// the asmlist. The original code here failed if
+			// the first region was less than KSEG0 size.
+			if (assem == asmlist)
+				asmlist = assem->next;
+			else
+				assem->next = asmfreelist;
 			asmfreelist = assem;
-		}
+                }
 
 		unlock(&asmlock);
 		if(o != a)


### PR DESCRIPTION
If an asmalloc is large and hence consumes the first element in the list,
asmlist must be bumped to point to the next element. The code, as written,
would end up destroying asmlist and there would be no available memory
on boot. This code worked fine for well over 10 years until we found
an AMD platform with a Reserved region at the 4M mark, i.e.:

Memory
        0x0000000000001000 0x00000000000a0000 (651264)
Memory
        0x0000000000100000 0x0000000004000000 (66060288)
reserved
        0x0000000004000000 0x0000000004042000 (270336)
Memory
        0x0000000004042000 0x0000000076d00000 (1925963776)

That reserved hole broke asm completely.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>