### PR TITLE
ahci: update ahci identification and init, remove support for esb

### DIFF
--- a/sys/src/9/amd64/ahci.h
+++ b/sys/src/9/amd64/ahci.h
@@ -96,6 +96,8 @@ typedef struct {
 	uint32_t	cccports;
 	uint32_t	emloc;
 	uint32_t	emctl;
+	uint32_t	cap2;		/* host capabilities extended */
+	uint32_t	bohc;		/* bios/os handoff control and status */
 } Ahba;
 
 enum {
@@ -203,9 +205,11 @@ typedef struct {
 	uint32_t	scr1;
 	uint32_t	scr3;
 	uint32_t	ci;		/* command issue */
-	uint32_t	ntf;
-	unsigned char	res2[8];
-	uint32_t	vendor;
+	uint32_t	ntf;		/* scr4 */
+	uint32_t	fbs;		/* FIS-based switching control */
+	uint32_t	devslp;		/* device sleep */
+	unsigned char	res2[40];	/* reserved */
+	unsigned char	vendor[16];
 } Aport;
 
 enum {


### PR DESCRIPTION
sdiahci was hanging when trying to intialise on a Skylake i7-6700K,
when calling ahciidle for port 5.  This appears to have been caused
by writing to 0x90 in the PCI register.  Commenting it out removes
the hang (though I haven't tested beyond that).

There seems to be a bit of init code being called for almost all
Intel controllers - this probably wasn't the original intention.
Given that the PCI registers would change from controller to
controller, this is probably not the best way to do it.  Given
that the code is quite old and therefore the controllers also,
it might be best to remove controller specific init code, follow
the AHCI spec, and see how far we can get.

I restructured the code to put more of the initialisation code in
one place.  This makes it a bit easier to see the same steps being
carried out multiple times.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>