### PR TITLE
clang11 requires -fcommon flag for harvey

### DIFF
--- a/amd64/clang.json
+++ b/amd64/clang.json
@@ -2,6 +2,7 @@
 	{
 		"Name": "buildflags",
 		"Cflags": [
+			"-fcommon",
 			"-mstack-alignment=4"
 		]
 	}

--- a/sys/src/9/amd64/clang.json
+++ b/sys/src/9/amd64/clang.json
@@ -2,6 +2,7 @@
 	{
 		"Name": "buildflags",
 		"Cflags": [
+			"-fcommon",
 			"-mno-implicit-float"
 		]
 	}


### PR DESCRIPTION
clang11 requires -fcommon flag to put tentative definitions into the common section

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>