### PR TITLE
ahci: add support for cap2 flags

### DIFF
--- a/sys/src/9/amd64/ahci.h
+++ b/sys/src/9/amd64/ahci.h
@@ -64,19 +64,25 @@ enum {
 	Hsalp	= 1<<26,	/* aggressive link pm */
 	Hsal	= 1<<25,	/* activity led */
 	Hsclo	= 1<<24,	/* command-list override */
-	Hiss	= 1<<20,	/* for interface speed */
-//	Hsnzo	= 1<<19,
 	Hsam	= 1<<18,	/* ahci-mode only */
 	Hspm	= 1<<17,	/* port multiplier */
-//	Hfbss	= 1<<16,
+	Hfbss	= 1<<16,	/* fis-based switching */
 	Hpmb	= 1<<15,	/* multiple-block pio */
 	Hssc	= 1<<14,	/* slumber state */
 	Hpsc	= 1<<13,	/* partial-slumber state */
-	Hncs	= 1<<8,		/* n command slots */
 	Hcccs	= 1<<7,		/* coal */
 	Hems	= 1<<6,		/* enclosure mgmt. */
 	Hsxs	= 1<<5,		/* external sata */
-	Hnp	= 1<<0,		/* n ports */
+};
+
+/* cap2 bits: supported features */
+enum {
+	Hdeso	= 1<<5,		/* devsleep entrance from slumber only */
+	Hsadm	= 1<<4,		/* supports aggressive device sleep mgmt */
+	Hsds	= 1<<3,		/* supports sleep device */
+	Hapst	= 1<<2,		/* automatic partial to slumber transitions */
+	Hnvmp	= 1<<1,		/* nvmhci/nvme present */
+	Hboh	= 1<<0,		/* bios/os handoff */
 };
 
 /* ghc bits */

--- a/sys/src/9/amd64/sdiahci.c
+++ b/sys/src/9/amd64/sdiahci.c
@@ -2348,6 +2348,7 @@ iartopctl(SDev *sdev, char *p, char *e)
 	ctlr = sdev->ctlr;
 	hba = ctlr->hba;
 	p = seprint(p, e, "sd%c ahci port %#p: ", sdev->idno, ctlr->physio);
+
 	cap = hba->cap;
 	has(Hs64a, "64a");
 	has(Hsalp, "alp");
@@ -2364,11 +2365,26 @@ iartopctl(SDev *sdev, char *p, char *e)
 	has(Hssc, "slum");
 	has(Hsss, "ss");
 	has(Hsxs, "sxs");
+	has(Hfbss, "fbss");
+	has(Hpmb, "pmb");
+
+	int iss = (cap>>20) & 0xf;
+	int ncs = (cap>>8) & 0x1f;
+	int np = 1 + (cap & 0x1f);
+
+	cap = hba->cap2;
+	has(Hdeso, "deso");
+	has(Hsadm, "sadm");
+	has(Hsds, "sds");
+	has(Hapst, "apst");
+	has(Hnvmp, "nvmp");
+	has(Hboh, "boh");
+
 	portr(pr, pr + sizeof pr, hba->pi);
+
 	return seprint(p, e,
 		"iss %ld ncs %ld np %ld; ghc %#lx isr %#lx pi %#lx %s ver %#lx\n",
-		(cap>>20) & 0xf, (cap>>8) & 0x1f, 1 + (cap & 0x1f),
-		hba->ghc, hba->isr, hba->pi, pr, hba->ver);
+		iss, ncs, np, hba->ghc, hba->isr, hba->pi, pr, hba->ver);
 #undef has
 }
 


### PR DESCRIPTION
also remove flags that aren't really flags - they're > 1 bit

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>