### PR TITLE
Put a lock around putstrn so output is readable

### DIFF
--- a/sys/src/9/port/devcons.c
+++ b/sys/src/9/port/devcons.c
@@ -279,7 +279,10 @@ putstrn0(char *str, int n, int usewrite)
 void
 putstrn(char *str, int n)
 {
+	static Lock lock;
+	ilock(&lock);
 	putstrn0(str, n, 0);
+	iunlock(&lock);
 }
 
 int


### PR DESCRIPTION
putstrn is called by print. When multiple cpus call it
we get output like this:
54cupc3up 2uc 1oc locolorol ro- r1-  1-r 1or lorelo elT eCT  CTt Cst cst cs3 c93 993899789078107910491449544
5
s
2 lhcsehcdehidenidinitin:ti :tn :onb o s ocsnhco htof c ofosrorc rehc  :pc fupao3ulr
 c

This is hard to read.

With this simple lock we get this:
unknown color for cpu1
ioapicintrinit: success
virtio-9p initializing
unknown color for cpu2
schedinit: no sch for cpu3
CPU Freq. 1400MHz
unknown color for cpu3
schedinit...
virtio-serial-pci initializing
acpiintr: gpe 1 on
read fault fail, no segment, pid 1 addr 0x89c04320e pc 0xffff80000030dc28
acpiintr: calling gpe 1
panic: cpu1: fault: 0x89c04320e

die:wait forever

This is easier to read, altough it is hard to understand :-)

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>