### PR TITLE
Alternative kernel build.json (allbuild.json) that adds uroot archive to ramdisk and extracts in cpurc

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,11 +10,11 @@ echo Building harvey-os.org commands into $HOSTBIN
 GO111MODULE=on go get harvey-os.org/cmd/...
 
 echo Building u-root into $HOSTBIN
-GO111MODULE=on go get github.com/u-root/u-root@c370a343c8b0b01faac358c1dafb409e5576ae1a
 # Download u-root sources into $GOPATH because that's what u-root expects.
 # See https://github.com/u-root/u-root/issues/805
 # and https://github.com/u-root/u-root/issues/583
 GO111MODULE=off go get -d github.com/u-root/u-root
+GO111MODULE=on go get github.com/u-root/u-root
 
 # this will make booting a VM easier
 mkdir -p tmp

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/u-root/u-root v6.0.1-0.20200728234108-3441aaa6cf0c+incompatible h1:vRAKYyEfhZV7SDTcaE3Cuop7tjDMOrapnBb59wVCcyE=
 github.com/u-root/u-root v6.0.1-0.20200728234108-3441aaa6cf0c+incompatible/go.mod h1:RYkpo8pTHrNjW08opNd/U6p/RJE7K0D8fXO0d47+3YY=
+github.com/u-root/u-root v7.0.0+incompatible h1:u+KSS04pSxJGI5E7WE4Bs9+Zd75QjFv+REkjy/aoAc8=
 github.com/u-root/u-root v7.0.1-0.20200915215200-c370a343c8b0+incompatible h1:72xpS/5zzWaJJSlPmvgUG4QCLFjCatyQMwKQ+xuyp+w=
 github.com/u-root/u-root v7.0.1-0.20200915215200-c370a343c8b0+incompatible/go.mod h1:RYkpo8pTHrNjW08opNd/U6p/RJE7K0D8fXO0d47+3YY=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=

--- a/rc/bin/cpurc
+++ b/rc/bin/cpurc
@@ -1,4 +1,15 @@
 #!/bin/rc
+
+if (test -e /boot/uroot) {
+	echo 'unpacking uroot'
+	olddir=`{pwd}
+	cd '#@'
+	decompress /boot/uroot > uroot.cpio
+	cpio i < uroot.cpio
+	bind -b '#@' /
+	cd $olddir
+}
+
 # cpu server start up
 date > /env/boottime
 

--- a/sys/src/9/amd64/allbuild.json
+++ b/sys/src/9/amd64/allbuild.json
@@ -12,6 +12,7 @@
 		],
 		"Projects": [
 			"gocmds.json",
+			"gocmdswithmods.json",
 			"u-root.json"
 		],
 		"Kernel": {
@@ -120,7 +121,6 @@
 				"sed": "/$ARCH/bin/sed",
 				"srv": "/$ARCH/bin/srv",
 				"startdisk": "startdisk",
-				"tmpfs": "/plan9_$ARCH/bin/tmpfs",
 				"usbd": "/$ARCH/bin/usb/usbd",
 				"venti": "/$ARCH/bin/venti/venti",
 				"vga": "/$ARCH/bin/aux/vga",

--- a/sys/src/9/amd64/allbuild.json
+++ b/sys/src/9/amd64/allbuild.json
@@ -10,6 +10,10 @@
 			"../ip/ip.json",
 			"../port/port.json"
 		],
+		"Projects": [
+			"gocmds.json",
+			"u-root.json"
+		],
 		"Kernel": {
 			"Config": {
 				"Code": [
@@ -91,8 +95,10 @@
 				"bind": "/$ARCH/bin/bind",
 				"boot": "/sys/src/9/boot/bootcpu.elf.out",
 				"cat": "/$ARCH/bin/cat",
+				"cpio": "/plan9_$ARCH/bin/cpio",
 				"crs": "/$ARCH/bin/acpi/crs",
 				"date": "/$ARCH/bin/date",
+				"decompress": "/plan9_$ARCH/bin/decompress",
 				"echo": "/$ARCH/bin/echo",
 				"ed": "/$ARCH/bin/ed",
 				"factotum": "/$ARCH/bin/auth/factotum",
@@ -114,9 +120,11 @@
 				"sed": "/$ARCH/bin/sed",
 				"srv": "/$ARCH/bin/srv",
 				"startdisk": "startdisk",
+				"tmpfs": "/plan9_$ARCH/bin/tmpfs",
 				"usbd": "/$ARCH/bin/usb/usbd",
 				"venti": "/$ARCH/bin/venti/venti",
-				"vga": "/$ARCH/bin/aux/vga"
+				"vga": "/$ARCH/bin/aux/vga",
+				"uroot": "uroot.cpio.lzma"
 			},
 			"Systab": "/sys/src/libc/9syscall/sys.h"
 		},

--- a/sys/src/9/amd64/gocmds.json
+++ b/sys/src/9/amd64/gocmds.json
@@ -2,12 +2,11 @@
 	{
 		"Name": "gocmds",
 		"Env": [
-			"GO111MODULE=on",
+			"GO111MODULE=off",
 			"GOOS=plan9",
 			"GOARCH=amd64"
 		],
 		"Pre": [
-			"go build -o /plan9_amd64/bin/decompress harvey-os.org/cmd/decompress",
 			"go build -o /plan9_amd64/bin/cpio github.com/u-root/u-root/cmds/core/cpio"
 		]
 	}

--- a/sys/src/9/amd64/gocmds.json
+++ b/sys/src/9/amd64/gocmds.json
@@ -7,7 +7,8 @@
 			"GOARCH=amd64"
 		],
 		"Pre": [
-			"go build -o /plan9_amd64/bin/tmpfs harvey-os.org/cmd/tmpfs"
+			"go build -o /plan9_amd64/bin/decompress harvey-os.org/cmd/decompress",
+			"go build -o /plan9_amd64/bin/cpio github.com/u-root/u-root/cmds/core/cpio"
 		]
 	}
 ]

--- a/sys/src/9/amd64/gocmdswithmods.json
+++ b/sys/src/9/amd64/gocmdswithmods.json
@@ -1,0 +1,13 @@
+[
+	{
+		"Name": "gocmds",
+		"Env": [
+			"GO111MODULE=on",
+			"GOOS=plan9",
+			"GOARCH=amd64"
+		],
+		"Pre": [
+			"go build -o /plan9_amd64/bin/decompress harvey-os.org/cmd/decompress"
+		]
+	}
+]

--- a/sys/src/9/amd64/u-root.json
+++ b/sys/src/9/amd64/u-root.json
@@ -6,13 +6,9 @@
 			"GOOS=plan9",
 			"GOARCH=amd64"
 		],
-		"#Pre only do this when KZERO is 0xffffffff_80000000": [
-			"u-root -o uroot.cpio -files /amd64/bin:amd64/bin -files /rc/bin:rc/bin -files /lib/ndb:lib/ndb $UROOTEXTRARGS plan9 $UROOTEXTRAPACKAGES",
-			"lzma -f -k uroot.cpio"
-		],
 		"Pre": [
-			"u-root -o uroot.cpio plan9",
-			"lzma -f -k uroot.cpio"
+			"u-root -shellbang -initcmd= -o uroot.cpio -files /amd64/bin:amd64/bin -files /rc/bin:rc/bin -files /lib/ndb:lib/ndb $UROOTEXTRARGS plan9 $UROOTEXTRAPACKAGES",
+			"lzma -f -k -3 uroot.cpio"
 		]
 	}
 ]

--- a/sys/src/9/amd64/u-root.json
+++ b/sys/src/9/amd64/u-root.json
@@ -7,7 +7,7 @@
 			"GOARCH=amd64"
 		],
 		"Pre": [
-			"u-root -shellbang -initcmd= -o uroot.cpio -files /amd64/bin:amd64/bin -files /rc/bin:rc/bin -files /lib/ndb:lib/ndb $UROOTEXTRARGS plan9 $UROOTEXTRAPACKAGES",
+			"u-root -shellbang -initcmd= -o uroot.cpio plan9",
 			"lzma -f -k -3 uroot.cpio"
 		]
 	}

--- a/sys/src/9/port/devroot.c
+++ b/sys/src/9/port/devroot.c
@@ -19,7 +19,7 @@ enum {
 	Qboot = 0x1000,
 
 	Nrootfiles = 32,
-	Nbootfiles = 32,
+	Nbootfiles = 64,
 };
 
 typedef struct Dirlist Dirlist;


### PR DESCRIPTION
If you build `sys/src/9/amd64/allbuild.json`, then run cpu, cpurc will extract the uroot archive to the ramdisk and bind it to root.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>