### PR TITLE
Add a regression test for consuming memory

### DIFF
--- a/sys/src/regress/kernel/eatmem.c
+++ b/sys/src/regress/kernel/eatmem.c
@@ -1,0 +1,17 @@
+/* eatmem consumes memory until there is no more.
+ *
+ * It tests whether there are problems in the new vm.
+ */
+#include <u.h>
+#include <libc.h>
+
+void
+main(int argc, char *argv[])
+{
+	while (1) {
+		// If the kernel crashes, we won't print "PASS" :-)
+		mallocz(0x1048576*16, 1);
+	}
+	print("PASS\n");
+	exits(nil);
+}


### PR DESCRIPTION
On a T510 running with the new VM, it fails instantly with
a fault on 0xffff8001f8000000.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>