### PR TITLE
Add a walk entry to devregress to test VM mappings

### DIFF
--- a/sys/src/9/port/devregress.c
+++ b/sys/src/9/port/devregress.c
@@ -13,6 +13,7 @@ enum {
 	Qmalloc,
 	Qtsleep,
 	Qlock,
+	Qwalk,
 	Qmax,
 };
 
@@ -22,6 +23,7 @@ static Dirtab regressdir[Qmax] = {
 	{"malloc", {Qmalloc, 0}, 0, 0666},
 	{"tsleep", {Qtsleep, 0}, 0, 0666},
 	{"qlock", {Qlock, 0}, 0, 0666},
+	{"walk", {Qwalk, 0}, 0, 0666},
 };
 
 int verbose = 0;
@@ -30,7 +32,7 @@ static QLock testlock;
 static Chan *
 regressattach(char *spec)
 {
-	return devattach('Z', spec);
+	return devattach('R', spec);
 }
 
 Walkqid *
@@ -89,6 +91,7 @@ regresswrite(Chan *c, void *a, i32 n, i64 offset)
 	Proc *up = externup();
 	char *p;
 	unsigned long amt;
+	u64 addr;
 
 	switch((u32)c->qid.path){
 
@@ -126,6 +129,12 @@ regresswrite(Chan *c, void *a, i32 n, i64 offset)
 			error("Only v or V");
 		return n;
 
+	case Qwalk:
+		p = a;
+		addr = strtoull(p, 0, 0);
+		dumpmmuwalk(KADDR(cr3get()), addr);
+		return n;
+
 	default:
 		error(Eperm);
 		break;
@@ -134,7 +143,7 @@ regresswrite(Chan *c, void *a, i32 n, i64 offset)
 }
 
 Dev regressdevtab = {
-	.dc = L'ξ',
+	.dc = L'R',
 	.name = "regress",
 
 	.reset = devreset,


### PR DESCRIPTION
The walk entry lets us see how things are mapped, e.g.
192.168.0.7# echo -n 0xffff800000000000>'#R/walk'
cpu0: pml4 0xffff8000034c5000
cpu0: mmu l3 pte 0xffff8000034c5800 = 111023
cpu0: mmu l2 pte 0xffff800000111000 = 1602023
cpu0: mmu l1 pte 0xffff800001602000 = 1606023
cpu0: mmu l0 pte 0xffff800001606000 = 8000000000000003
192.168.0.7#

This whould help us debug some current problems, and also
understand how things end up being mapped.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>