### PR TITLE
Fix mapping error

### DIFF
--- a/sys/src/9/amd64/mmu.c
+++ b/sys/src/9/amd64/mmu.c
@@ -547,7 +547,7 @@ mmukphysmap(PTE *pml4, u64 pa, PTE attr, usize size)
 		panic("mapping nonexistent physical address");
 
 	pl = splhi();
-	for(usize pae = pa + size; pa < pae; pa += pgsz){
+	for(u64 pae = pa + size; pa < pae; size -= pgsz, pa += pgsz){
 		uintptr va = (uintptr)KADDR(pa);
 		invlpg(va);
 


### PR DESCRIPTION
As we map each page of the address space, the amount
of address space we need to map decreases by the page
size we just mapped.

Signed-off-by: Dan Cross <cross@gajendra.net>