### PR TITLE
ramfs: use Pages for backing store, not malloc

### DIFF
--- a/sys/src/9/port/page.c
+++ b/sys/src/9/port/page.c
@@ -359,6 +359,7 @@ auxpage(usize size)
 	pa = &pga.pgsza[si];
 	p = pa->head;
 	if(pa->freecount < Nminfree){
+		print("freecount %d Nminfree %d return nil\n", pa->freecount, Nminfree);
 		unlock(&pga.l);
 		return nil;
 	}


### PR DESCRIPTION
New hardware has a LOT of pages. If we unpack uroot into

Clearly we need to be a lot smarter than this code is, but it
already lets us get much further than we have so far.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>