### PR TITLE
Don't discard debug sections when linking the kernel

### DIFF
--- a/sys/src/9/amd64/kernel.ld
+++ b/sys/src/9/amd64/kernel.ld
@@ -54,6 +54,5 @@ SECTIONS {
 
 	/DISCARD/ : {
 		*(.eh_frame .note.GNU-stack)
-		*(.debug*)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>