### PR TITLE
util/build-img.sh: use system syslinux binaries

### DIFF
--- a/.github/workflows/harvey.yml
+++ b/.github/workflows/harvey.yml
@@ -40,3 +40,5 @@ jobs:
       env:
         HARVEY: ${{github.workspace}}
       run: ./linux_amd64/bin/qtap
+    - name: build a image
+      run: ./util/build-img.sh

--- a/util/build-img.sh
+++ b/util/build-img.sh
@@ -2,18 +2,30 @@
 
 # Build a qcow2 image for loading in qemu
 
-SRC_IMG=$HARVEY/util/img/syslinux-bios
-SRC_SYSLINUX=$SRC_IMG/syslinux
-SRC_MBR=$SRC_IMG/mbr.bin
+# Syslinux should already be installed on the system since it's a
+# dependency of guestfish. We want to use the system syslinux binaries
+# which match the extlinux command below.
+SRC_SYSLINUX=/usr/lib/syslinux/bios
+SRC_MBR=/usr/lib/syslinux/bios/mbr.bin
+SRC_CFG=$HARVEY/util/img/syslinux-bios/syslinux/syslinux-usb.cfg
 SRC_KERNEL=$HARVEY/sys/src/9/amd64/harvey.32bit
 
-DEST=$HARVEY/harvey.qcow2
 
+FORMAT=qcow2
+if [ "$1" = "-f" ]; then
+	FORMAT=$2
+fi
+if [ "$FORMAT" = "" ]; then
+	echo "usage: $0 [-f format]" 1>&2
+	exit 2
+fi
+
+DEST=$HARVEY/harvey.$FORMAT
 echo "Creating harvey image $DEST"
 rm -f $DEST
 
 guestfish <<EOF
-disk-create $DEST qcow2 3G
+disk-create $DEST $FORMAT 3G
 add-drive $DEST
 
 launch
@@ -28,6 +40,9 @@ part-set-bootable /dev/sda 1 true
 mount /dev/sda1 /
 extlinux /
 copy-in $SRC_SYSLINUX /
+rename /bios /syslinux
+copy-in $SRC_CFG /syslinux
+rename /syslinux/syslinux-usb.cfg /syslinux/syslinux.cfg
 copy-in $SRC_KERNEL /
 rename /harvey.32bit /harvey
 

--- a/util/img/syslinux-bios/syslinux/syslinux-usb.cfg
+++ b/util/img/syslinux-bios/syslinux/syslinux-usb.cfg
@@ -1,0 +1,26 @@
+TIMEOUT 50
+DEFAULT vesamenu.c32
+MENU TITLE Harvey OS
+
+LABEL 0
+TEXT HELP
+Boot Harvey kernel as a terminal
+ENDTEXT
+MENU LABEL Harvey OS (Terminal)
+KERNEL mboot.c32
+APPEND ../harvey service=terminal maxcores=1024 nvram=/boot/nvram nvrlen=512 nvroff=0 acpiirq=1 mouseport=ps2 vgasize=1024x768x24 monitor=vesa
+
+LABEL 1
+TEXT HELP
+Boot Harvey kernel as a CPU node
+ENDTEXT
+MENU LABEL Harvey OS (CPU)
+KERNEL mboot.c32
+APPEND ../harvey service=cpu maxcores=1024 nvram=/boot/nvram nvrlen=512 nvroff=0 acpiirq=1 mouseport=ps2 vgasize=1024x768x24 monitor=vesa
+
+LABEL 2
+MENU LABEL Reboot
+TEXT HELP
+Restart the computer
+ENDTEXT
+COM32 reboot.c32


### PR DESCRIPTION
Guestfish uses the extlinux command installed on the system and the
version of syslinux install on the system may be different from the one
that comes with Harvey. If we mix syslinux versions, boot can fail. For
example, I was getting this when booting from an image created on an
ArchLinux system:
```
Undef symbol FAIL: x86_init_fpu
Failed to load libcom32.c32
Failed to load COM32 file vesamenu.c32
```

Help #1072

Signed-off-by: Fazlul Shahriar <fshahriar@gmail.com>