### PR TITLE
If there are no multiboot tables, have the courtesy of telling us

### DIFF
--- a/sys/src/9/amd64/multiboot.c
+++ b/sys/src/9/amd64/multiboot.c
@@ -115,8 +115,10 @@ multiboot(u32 magic, u32 pmbi, int vflag)
 
 	if(vflag)
 		print("magic %#x pmbi %#x\n", magic, pmbi);
-	if(magic != 0x2badb002)
+	if(magic != 0x2badb002) {
+		print("Multiboot magic is not set, no multiboot tables\n");
 		return -1;
+	}
 
 	mbi = KADDR(pmbi);
 	if(vflag)


### PR DESCRIPTION
This kernel is too silent when it needs to be informative.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>