### PR TITLE
Add uroot service as a clone of terminal

### DIFF
--- a/rc/bin/urootrc
+++ b/rc/bin/urootrc
@@ -1,7 +1,7 @@
 #!/bin/rc
 # terminal startup
 
-if(test -e '#@/uroot') {
+if(test -e '/boot/uroot') {
 	# Unpack uroot cpio into the ramdisk and bind to root
 	cd '#@'
 	/boot/decompress /boot/uroot > uroot.cpio
@@ -113,3 +113,25 @@ if(test -f /dev/mousectl){
 }
 
 dontkill '^(ipconfig|factotum|mntgen|fossil|cs|dns|listen|reboot)$'
+
+# If we're running uroot, we're assuming everything's come from the ramdisk
+# at this point.  There may be no usr profile, so let's put sensible defaults here.
+# Can then run something in the $home/lib/profile if it exists
+home=/usr/$user
+cd
+
+# This is what would traditionally be in lib/profile by default
+bind -a $home/bin/rc /bin
+bind -a $home/bin/$cputype /bin
+bind -c tmp /tmp
+
+font=/lib/font/bit/go/Go-Mono/Go-Mono.14.font
+fn cd { builtin cd $* && awd }  # for acme
+fn acme { /bin/acme -f $font $* }
+
+plumber
+echo -n accelerated > '#m/mousectl'
+echo -n 'res 3' > '#m/mousectl'
+prompt=('term% ' '	')
+fn term%{ $* }
+exec rio -s -i riostart

--- a/rc/bin/urootrc
+++ b/rc/bin/urootrc
@@ -1,0 +1,103 @@
+#!/bin/rc
+# terminal startup
+TIMESYNCARGS=(-rLa1000000)
+NDBFILE=/lib/ndb/local
+
+# Hack
+terminal = "ninep"
+
+mntgen -s slashn && chmod 666 /srv/slashn
+
+# bind all likely devices (#S was bound in boot)
+for(i in t m v C)
+	/bin/bind -a '#'^$i /dev >/dev/null >[2=1]
+
+# set up any partitions
+diskparts
+
+rm -f /env/disk
+
+# we do this before we have a name.  we may need to do network
+# setup so that we can get a name.
+if(test -e /rc/bin/termrc.local)
+	. /rc/bin/termrc.local
+
+# cs sets sysname (termrc.local may already have started it so check)
+if(! test -e /srv/cs && ! test -e /net/cs)
+	ndb/cs -f $NDBFILE
+sysname=`{cat /dev/sysname}
+if (~ $#sysname 0 || ~ $sysname '') {
+	sysname = harvey			# default
+	echo -n $sysname >/dev/sysname
+}
+
+# machine specific startup (e.g., for devices not probed)
+if(test -e /cfg/$sysname/termrc)
+	. /cfg/$sysname/termrc
+
+# start IP on the LAN, if not already configured.  diskless terminals
+# are already configured by now.  It's commented out to avoid a long timeout
+# on startup waiting for DHCP.
+#
+# If your site provides DHCP service,
+#
+#if(! test -e /net/ipifc/0/ctl)
+#	ip/ipconfig
+#
+# Otherwise, see /cfg/$sysname/termrc (/cfg/example/termrc is an example).
+
+# start dns if we have an internet
+if(test -e /net/ipifc/0/ctl && ! test -e /srv/dns)
+	ndb/dns -r
+
+if(! ~ $terminal *vx32* && ! ~ $terminal *ninep*){
+	# start timesync if it isn't running and we weren't told not to
+	if(! ps|grep -s timesync)
+		if(! ~ $TIMESYNCARGS '')
+			aux/timesync $TIMESYNCARGS
+
+	# add the loop-back medium
+	if(! grep -s 127.0.0.1 /net/ipselftab)
+		ip/ipconfig loopback /dev/null 127.1
+
+	# set things up for vmware
+	if(! ~ `{cat /dev/user} none)
+		if(test -e /bin/aux/vmware)
+			aux/vmware
+}
+
+# query user if terminal isn't adequately configured yet
+if(~ $mouseport ask){
+	echo -n 'mouseport is (ps2, ps2intellimouse, 0, 1, 2)[ps2]: '
+	mouseport=`{read}
+	if(~ $#mouseport 0)
+		mouseport=ps2
+}
+if(~ $vgasize ask){
+	echo -n 'vgasize [640x480x8]: '
+	vgasize=`{read}
+	if(~ $#vgasize 0)
+		vgasize=640x480x8
+}
+if(~ $monitor ask){
+	echo -n 'monitor is [xga]: '
+	monitor=`{read}
+	if(~ $#monitor 0)
+		monitor=xga
+}
+if(test -f /dev/mousectl){
+	switch($mouseport){
+	case ps2 ps2intellimouse 0 1 2
+		aux/mouse $mouseport
+		ms& #soft mouse
+		# parse vgasize into fields
+		vgasize=`{echo $vgasize}
+		if(! ~ $"monitor '' && ! ~ `{cat /dev/user} none)
+			aux/realemu
+			aux/vga -m $monitor -l $vgasize
+		if(~ $accupoint 1)
+			pipefile -dr /bin/aux/accupoint /dev/mouse
+	}
+}
+
+dontkill '^(ipconfig|factotum|mntgen|fossil|cs|dns|listen|reboot)$'

--- a/rc/bin/urootrc
+++ b/rc/bin/urootrc
@@ -1,5 +1,17 @@
 #!/bin/rc
 # terminal startup
+
+if(test -e '#@/uroot') {
+	# Unpack uroot cpio into the ramdisk and bind to root
+	cd '#@'
+	/boot/decompress /boot/uroot > uroot.cpio
+	/boot/cpio i < uroot.cpio
+	rm uroot.cpio
+	cd
+	bind -b '#@' /
+	bind -b /bbin /bin
+}
+
 TIMESYNCARGS=(-rLa1000000)
 NDBFILE=/lib/ndb/local
 

--- a/sys/src/9/amd64/allbuild.json
+++ b/sys/src/9/amd64/allbuild.json
@@ -120,6 +120,7 @@
 				"sed": "/$ARCH/bin/sed",
 				"srv": "/$ARCH/bin/srv",
 				"startdisk": "startdisk",
+				"urootrc": "/rc/bin/urootrc",
 				"usbd": "/$ARCH/bin/usb/usbd",
 				"venti": "/$ARCH/bin/venti/venti",
 				"vga": "/$ARCH/bin/aux/vga",

--- a/sys/src/9/boot/boot.c
+++ b/sys/src/9/boot/boot.c
@@ -70,7 +70,7 @@ acpiirq(void)
 void
 boot(int argc, char *argv[])
 {
-	int fd, afd, srvt;
+	int fd, afd;
 	Method *mp;
 	char *cmd, cmdbuf[64], *iargv[16];
 	char rootbuf[64];
@@ -224,17 +224,9 @@ boot(int argc, char *argv[])
 		close(afd);
 
 	cmd = getenv("init");
-	srvt = strcmp(service, "terminal");
-	if(cmd == nil){
-		if(!srvt){
-			sprint(cmdbuf, "/%s/bin/init -%s%s", cputype,
-			       "t", mflag ? "m" : "");
-			cmd = cmdbuf;
-		} else {
-			sprint(cmdbuf, "/%s/bin/init -%s%s", cputype,
-			       "c", mflag ? "m" : "");
-			cmd = cmdbuf;
-		}
+	if(cmd == nil && service != nil) {
+		sprint(cmdbuf, "/%s/bin/init -s %s %s", cputype, service, mflag ? "m" : "");
+		cmd = cmdbuf;
 	}
 	iargc = tokenize(cmd, iargv, nelem(iargv) - 1);
 	cmd = iargv[0];

--- a/sys/src/9/boot/boot.c
+++ b/sys/src/9/boot/boot.c
@@ -224,7 +224,7 @@ boot(int argc, char *argv[])
 		close(afd);
 
 	cmd = getenv("init");
-	if(cmd == nil && service != nil) {
+	if(cmd == nil && service[0] != 0) {
 		sprint(cmdbuf, "/%s/bin/init -s %s %s", cputype, service, mflag ? "m" : "");
 		cmd = cmdbuf;
 	}

--- a/sys/src/9/port/error.h
+++ b/sys/src/9/port/error.h
@@ -52,3 +52,4 @@ extern char Etoobig[]; /* read or write too large */
 extern char Etoosmall[]; /* read or write too small */
 extern char Eunion[]; /* not in union */
 extern char Eunmount[]; /* not mounted */
+

--- a/sys/src/cmd/init.c
+++ b/sys/src/cmd/init.c
@@ -188,6 +188,9 @@ rcexec(void)
 	}else if(strcmp(service, "terminal") == 0){
 	        print ("init: starting termrc\n");
 		execl("/bin/rc", "rc", "-c", ". /rc/bin/termrc; home=/usr/$user; cd; . lib/profile", nil);
+	}else if(strcmp(service, "uroot") == 0){
+	        print ("init: starting urootrc\n");
+		execl("/bin/rc", "rc", "-c", ". /rc/bin/urootrc; home=/usr/$user; cd; . lib/profile", nil);
 	}
 	else
 		execl("/bin/rc", "rc", nil);

--- a/sys/src/cmd/init.c
+++ b/sys/src/cmd/init.c
@@ -41,14 +41,14 @@ main(int argc, char *argv[])
 	service = "cpu";
 	manual = 0;
 	ARGBEGIN{
-	case 'c':
-		service = "cpu";
-		break;
 	case 'm':
 		manual = 1;
 		break;
-	case 't':
-		service = "terminal";
+	case 's':
+		service = ARGF();
+		if (service == nil) {
+			print("init: warning: expected service\n");
+		}
 		break;
 	}ARGEND
 	cmd = *argv;

--- a/sys/src/cmd/init.c
+++ b/sys/src/cmd/init.c
@@ -190,7 +190,7 @@ rcexec(void)
 		execl("/bin/rc", "rc", "-c", ". /rc/bin/termrc; home=/usr/$user; cd; . lib/profile", nil);
 	}else if(strcmp(service, "uroot") == 0){
 	        print ("init: starting urootrc\n");
-		execl("/bin/rc", "rc", "-c", ". /rc/bin/urootrc; home=/usr/$user; cd; . lib/profile", nil);
+		execl("/boot/rc", "rc", "-c", ". /boot/urootrc", nil);
 	}
 	else
 		execl("/bin/rc", "rc", nil);

--- a/usr/harvey/lib/profile
+++ b/usr/harvey/lib/profile
@@ -23,6 +23,13 @@ case terminal
 	prompt=('term% ' '	')
 	fn term%{ $* }
 	exec rio -s -i riostart
+case uroot
+	plumber
+	echo -n accelerated > '#m/mousectl'
+	echo -n 'res 3' > '#m/mousectl'
+	prompt=('term% ' '	')
+	fn term%{ $* }
+	exec rio -s -i riostart
 case cpu
 	if (test -e /mnt/term/mnt/wsys) { # rio already running
 		bind -a /mnt/term/mnt/wsys /dev

--- a/util/GO9PUROOT
+++ b/util/GO9PUROOT
@@ -3,8 +3,8 @@ set -e
 
 trap : 2
 
-#$HARVEY/linux_amd64/bin/centre -i "" -ninep-dir=$HARVEY &
-#centrepid=$!
+$HARVEY/linux_amd64/bin/centre -i "" -ninep-dir=$HARVEY &
+centrepid=$!
 
 export machineflag=q35
 if [ "$(uname)" = "Linux" ] && [ -e /dev/kvm ]; then
@@ -33,12 +33,12 @@ hostfwd=tcp::1666-:1666,\
 hostfwd=tcp::5356-:5356,\
 hostfwd=tcp::17013-:17013 \
 -object filter-dump,id=f1,netdev=user.0,file=/tmp/vm0.pcap \
--append "service=uroot nobootprompt=tcp maxcores=1024 nvram=/boot/nvram nvrlen=512 nvroff=0 acpiirq=1" \
+-append "service=uroot nobootprompt=tcp maxcores=1024 fs=10.0.2.2 auth=10.0.2.2 nvram=/boot/nvram nvrlen=512 nvroff=0 acpiirq=1 mouseport=ps2 vgasize=1024x768x24 monitor=vesa" \
 -kernel $HARVEY/sys/src/9/amd64/harvey.32bit $*
 EOF
 
 echo $cmd
 eval $cmd
 
-#kill $centrepid
+kill $centrepid
 wait

--- a/util/GO9PUROOT
+++ b/util/GO9PUROOT
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+trap : 2
+
+#$HARVEY/linux_amd64/bin/centre -i "" -ninep-dir=$HARVEY &
+#centrepid=$!
+
+export machineflag=q35
+if [ "$(uname)" = "Linux" ] && [ -e /dev/kvm ]; then
+	export kvmflag='-enable-kvm'
+	export machineflag='pc,accel=kvm'
+	if [ ! -w /dev/kvm ]; then
+		# we don't have access as a regular user
+		export kvmdo=sudo
+	fi
+fi
+
+# vmware-cpuid-freq=on,+invtsc exposes the 0x40000000 hypervisor cpuid values to
+# the guest, which we can use to identify the TSC frequency
+
+read -r cmd <<EOF
+$kvmdo qemu-system-x86_64 -s -cpu max,vmware-cpuid-freq=on,+invtsc -smp 4 -m 2048 $kvmflag \
+-usb \
+-serial stdio \
+--machine $machineflag \
+-net nic,model=rtl8139 \
+-net user,id=user.0,\
+hostfwd=tcp::5555-:1522,\
+hostfwd=tcp::9999-:9,\
+hostfwd=tcp::17010-:17010,\
+hostfwd=tcp::1666-:1666,\
+hostfwd=tcp::5356-:5356,\
+hostfwd=tcp::17013-:17013 \
+-object filter-dump,id=f1,netdev=user.0,file=/tmp/vm0.pcap \
+-append "service=uroot nobootprompt=tcp maxcores=1024 nvram=/boot/nvram nvrlen=512 nvroff=0 acpiirq=1" \
+-kernel $HARVEY/sys/src/9/amd64/harvey.32bit $*
+EOF
+
+echo $cmd
+eval $cmd
+
+#kill $centrepid
+wait


### PR DESCRIPTION
The uroot service is a clone of terminal.  This can be the starting point to remove and tidy what we don't want.

If sys/src/9/amd64/allbuild.json is built (adding the uroot archive to the kernel ramdisk) it will unpack that to devramfs, bind it to root and bind /bbin to /bin, before other binaries.

To test:
- build everything
- build sys/src/9/amd64/allbuild.json
- run util/GO9PUROOT