### PR TITLE
Add devname() and devdc() functions to all dev*.c in sys/src/9/port

### DIFF
--- a/sys/src/9/port/dev9p.c
+++ b/sys/src/9/port/dev9p.c
@@ -648,3 +648,16 @@ Dev v9pdevtab = {
 	.remove = v9premove,
 	.wstat = v9pwstat,
 };
+
+static char *
+devname(void)
+{
+        return 9pdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return 9pdevtab.dc;
+}
+

--- a/sys/src/9/port/devbridge.c
+++ b/sys/src/9/port/devbridge.c
@@ -1191,3 +1191,16 @@ Dev bridgedevtab = {
 	devremove,
 	devwstat,
 };
+
+static char *
+devname(void)
+{
+        return bridgedevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return bridgedevtab.dc;
+}
+

--- a/sys/src/9/port/devcap.c
+++ b/sys/src/9/port/devcap.c
@@ -288,3 +288,16 @@ Dev capdevtab = {
 	.bwrite = devbwrite,
 	.remove = capremove,
 	.wstat = devwstat};
+
+static char *
+devname(void)
+{
+        return capdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return capdevtab.dc;
+}
+

--- a/sys/src/9/port/devcec.c
+++ b/sys/src/9/port/devcec.c
@@ -926,3 +926,16 @@ Dev cecdevtab = {
 	.power = devpower,
 	.config = devconfig,
 };
+
+static char *
+devname(void)
+{
+        return cecdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return cecdevtab.dc;
+}
+

--- a/sys/src/9/port/devcons.c
+++ b/sys/src/9/port/devcons.c
@@ -1412,3 +1412,16 @@ writebintime(char *buf, int n)
 	}
 	return n;
 }
+
+static char *
+devname(void)
+{
+        return consdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return consdevtab.dc;
+}
+

--- a/sys/src/9/port/devcoreboot.c
+++ b/sys/src/9/port/devcoreboot.c
@@ -459,3 +459,16 @@ Dev corebootdevtab = {
 	.remove = devremove,
 	.wstat = devwstat,
 };
+
+static char *
+devname(void)
+{
+        return corebootdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return corebootdevtab.dc;
+}
+

--- a/sys/src/9/port/devdraw.c
+++ b/sys/src/9/port/devdraw.c
@@ -2219,3 +2219,16 @@ drawidletime(void)
 {
 	return TK2SEC(machp()->ticks - sdraw.blanktime) / 60;
 }
+
+static char *
+devname(void)
+{
+        return drawdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return drawdevtab.dc;
+}
+

--- a/sys/src/9/port/devdup.c
+++ b/sys/src/9/port/devdup.c
@@ -153,3 +153,16 @@ Dev dupdevtab = {
 	.remove = devremove,
 	.wstat = devwstat,
 };
+
+static char *
+devname(void)
+{
+        return dupdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return dupdevtab.dc;
+}
+

--- a/sys/src/9/port/devenv.c
+++ b/sys/src/9/port/devenv.c
@@ -448,3 +448,16 @@ getconfenv(void)
 	runlock(&eg->rwl);
 	return p;
 }
+
+static char *
+devname(void)
+{
+        return envdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return envdevtab.dc;
+}
+

--- a/sys/src/9/port/devether.c
+++ b/sys/src/9/port/devether.c
@@ -483,3 +483,16 @@ Dev etherdevtab = {
 	.remove = devremove,
 	.wstat = etherwstat,
 };
+
+static char *
+devname(void)
+{
+        return etherdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return etherdevtab.dc;
+}
+

--- a/sys/src/9/port/devfdmux.c
+++ b/sys/src/9/port/devfdmux.c
@@ -569,3 +569,16 @@ Dev fdmuxdevtab = {
 	.remove = devremove,
 	.wstat = devwstat,
 };
+
+static char *
+devname(void)
+{
+        return fdmuxdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return fdmuxdevtab.dc;
+}
+

--- a/sys/src/9/port/devkbin.c
+++ b/sys/src/9/port/devkbin.c
@@ -118,3 +118,16 @@ Dev kbindevtab = {
 	.remove = devremove,
 	.wstat = devwstat,
 };
+
+static char *
+devname(void)
+{
+        return kbindevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return kbindevtab.dc;
+}
+

--- a/sys/src/9/port/devkbmap.c
+++ b/sys/src/9/port/devkbmap.c
@@ -209,3 +209,16 @@ Dev kbmapdevtab = {
 	devremove,
 	devwstat,
 };
+
+static char *
+devname(void)
+{
+        return kbmapdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return kbmapdevtab.dc;
+}
+

--- a/sys/src/9/port/devkprof.c
+++ b/sys/src/9/port/devkprof.c
@@ -235,3 +235,16 @@ Dev kprofdevtab = {
 	.remove = devremove,
 	.wstat = devwstat,
 };
+
+static char *
+devname(void)
+{
+        return kprofdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return kprofdevtab.dc;
+}
+

--- a/sys/src/9/port/devmnt.c
+++ b/sys/src/9/port/devmnt.c
@@ -1274,3 +1274,16 @@ Dev mntdevtab = {
 	.remove = mntremove,
 	.wstat = mntwstat,
 };
+
+static char *
+devname(void)
+{
+        return mntdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return mntdevtab.dc;
+}
+

--- a/sys/src/9/port/devmntn.c
+++ b/sys/src/9/port/devmntn.c
@@ -691,3 +691,16 @@ Dev mntndevtab = {
 	.remove = mntremove,
 	.wstat = mntwstat,
 };
+
+static char *
+devname(void)
+{
+        return mntndevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return mntndevtab.dc;
+}
+

--- a/sys/src/9/port/devmouse.c
+++ b/sys/src/9/port/devmouse.c
@@ -773,3 +773,16 @@ mouseresize(void)
 	mouse.resize++;
 	wakeup(&mouse.rend);
 }
+
+static char *
+devname(void)
+{
+        return mousedevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return mousedevtab.dc;
+}
+

--- a/sys/src/9/port/devpci.c
+++ b/sys/src/9/port/devpci.c
@@ -305,3 +305,16 @@ Dev pcidevtab = {
 	.remove = devremove,
 	.wstat = devwstat,
 };
+
+static char *
+devname(void)
+{
+        return pcidevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return pcidevtab.dc;
+}
+

--- a/sys/src/9/port/devpipe.c
+++ b/sys/src/9/port/devpipe.c
@@ -399,3 +399,16 @@ Dev pipedevtab = {
 	.remove = devremove,
 	.wstat = devwstat,
 };
+
+static char *
+devname(void)
+{
+        return pipedevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return pipedevtab.dc;
+}
+

--- a/sys/src/9/port/devprobe.c
+++ b/sys/src/9/port/devprobe.c
@@ -406,3 +406,16 @@ Dev probedevtab = {
 	.remove = devremove,
 	.wstat = devwstat,
 };
+
+static char *
+devname(void)
+{
+        return probedevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return probedevtab.dc;
+}
+

--- a/sys/src/9/port/devproc.c
+++ b/sys/src/9/port/devproc.c
@@ -2017,3 +2017,16 @@ data2txt(Segment *s)
 
 	return ps;
 }
+
+static char *
+devname(void)
+{
+        return procdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return procdevtab.dc;
+}
+

--- a/sys/src/9/port/devregress.c
+++ b/sys/src/9/port/devregress.c
@@ -162,3 +162,16 @@ Dev regressdevtab = {
 	.remove = devremove,
 	.wstat = devwstat,
 };
+
+static char *
+devname(void)
+{
+        return regressdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return regressdevtab.dc;
+}
+

--- a/sys/src/9/port/devroot.c
+++ b/sys/src/9/port/devroot.c
@@ -260,3 +260,16 @@ Dev rootdevtab = {
 	.remove = devremove,
 	.wstat = devwstat,
 };
+
+static char *
+devname(void)
+{
+        return rootdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return rootdevtab.dc;
+}
+

--- a/sys/src/9/port/devsd.c
+++ b/sys/src/9/port/devsd.c
@@ -1674,3 +1674,16 @@ legacytopctl(Cmdbuf *cb)
 		error(Ebadarg);
 	sdconfig(cd.on, cd.spec, &cd.cf);
 }
+
+static char *
+devname(void)
+{
+        return sddevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return sddevtab.dc;
+}
+

--- a/sys/src/9/port/devsegment.c
+++ b/sys/src/9/port/devsegment.c
@@ -779,3 +779,16 @@ Dev segmentdevtab = {
 	.remove = segmentremove,
 	.wstat = segmentwstat,
 };
+
+static char *
+devname(void)
+{
+        return segmentdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return segmentdevtab.dc;
+}
+

--- a/sys/src/9/port/devsrv.c
+++ b/sys/src/9/port/devsrv.c
@@ -382,3 +382,16 @@ Dev srvdevtab = {
 	.remove = srvremove,
 	.wstat = srvwstat,
 };
+
+static char *
+devname(void)
+{
+        return srvdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return srvdevtab.dc;
+}
+

--- a/sys/src/9/port/devssl.c
+++ b/sys/src/9/port/devssl.c
@@ -1596,3 +1596,16 @@ dsnew(Chan *ch, Dstate **pp)
 	ch->qid.path = QID(pp - dstate, t);
 	ch->qid.vers = 0;
 }
+
+static char *
+devname(void)
+{
+        return ssldevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return ssldevtab.dc;
+}
+

--- a/sys/src/9/port/devtls.c
+++ b/sys/src/9/port/devtls.c
@@ -2235,3 +2235,16 @@ pdump(int len, void *a, char *tag)
 			pprint("%s\n", buf);
 	}
 }
+
+static char *
+devname(void)
+{
+        return tlsdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return tlsdevtab.dc;
+}
+

--- a/sys/src/9/port/devtrace.c
+++ b/sys/src/9/port/devtrace.c
@@ -901,3 +901,16 @@ Dev tracedevtab = {
 	.remove = devremove,
 	.wstat = devwstat,
 };
+
+static char *
+devname(void)
+{
+        return tracedevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return tracedevtab.dc;
+}
+

--- a/sys/src/9/port/devuart.c
+++ b/sys/src/9/port/devuart.c
@@ -725,3 +725,16 @@ uartclock(void)
 	}
 	unlock(&uartalloc.Lock);
 }
+
+static char *
+devname(void)
+{
+        return uartdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return uartdevtab.dc;
+}
+

--- a/sys/src/9/port/devufs.c
+++ b/sys/src/9/port/devufs.c
@@ -527,3 +527,16 @@ Dev ufsdevtab = {
 	.remove = devremove,
 	.wstat = devwstat,
 };
+
+static char *
+devname(void)
+{
+        return ufsdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return ufsdevtab.dc;
+}
+

--- a/sys/src/9/port/devvcon.c
+++ b/sys/src/9/port/devvcon.c
@@ -243,3 +243,16 @@ Dev vcondevtab = {
 	.remove = devremove,
 	.wstat = devwstat,
 };
+
+static char *
+devname(void)
+{
+        return vcondevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return vcondevtab.dc;
+}
+

--- a/sys/src/9/port/devwd.c
+++ b/sys/src/9/port/devwd.c
@@ -150,3 +150,16 @@ Dev wddevtab = {
 	.wstat = devwstat,
 	.power = devpower,
 };
+
+static char *
+devname(void)
+{
+        return wddevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return wddevtab.dc;
+}
+

--- a/sys/src/9/port/devws.c
+++ b/sys/src/9/port/devws.c
@@ -178,3 +178,16 @@ Dev wsdevtab = {
 	.remove = devremove,
 	.wstat = devwstat,
 };
+
+static char *
+devname(void)
+{
+        return wsdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return wsdevtab.dc;
+}
+

--- a/sys/src/9/port/devzp.c
+++ b/sys/src/9/port/devzp.c
@@ -597,3 +597,16 @@ Dev zpdevtab = {
 	.zread = zpzread,
 	.zwrite = zpzwrite,
 };
+
+static char *
+devname(void)
+{
+        return zpdevtab.name;
+}
+
+static int
+devdc(void)
+{
+        return zpdevtab.dc;
+}
+


### PR DESCRIPTION
As per Issue #1058, I tried to add the two devname() and devdc() functions to all dev*.c (in sys/src/9/port and not in 9/arch). I don't know if the issue meant literally "devtab.name" as no variable devtab exists in such files; I added the functions using the dev-name, as in: 

static char *
devname(void)
{
        return tlsdevtab.name;
}

Sorry if I'm wrong, first PR and first approach to Harvey. 