### PR TITLE
uroot.cpio.lzma is now the initrd rather than embedded in the kernel ramdisk

### DIFF
--- a/rc/bin/urootrc
+++ b/rc/bin/urootrc
@@ -1,9 +1,9 @@
 #!/bin/rc
 # terminal startup
 
-if(test -e '/boot/uroot') {
+if(test -e '#P/uroot.cpio.lzma') {
 	# Unpack uroot cpio into the ramdisk and bind to root
-	@{cd '#@' && /boot/decompress /boot/uroot | /boot/cpio i}
+	@{cd '#@' && /boot/decompress '#P/uroot.cpio.lzma' | /boot/cpio i}
 	bind -b '#@' /
 	bind -b /bbin /bin
 }

--- a/sys/src/9/amd64/allbuild.json
+++ b/sys/src/9/amd64/allbuild.json
@@ -123,8 +123,7 @@
 				"urootrc": "/rc/bin/urootrc",
 				"usbd": "/$ARCH/bin/usb/usbd",
 				"venti": "/$ARCH/bin/venti/venti",
-				"vga": "/$ARCH/bin/aux/vga",
-				"uroot": "uroot.cpio.lzma"
+				"vga": "/$ARCH/bin/aux/vga"
 			},
 			"Systab": "/sys/src/libc/9syscall/sys.h"
 		},

--- a/util/GO9PUROOT
+++ b/util/GO9PUROOT
@@ -21,6 +21,7 @@ fi
 
 read -r cmd <<EOF
 $kvmdo qemu-system-x86_64 -s -cpu max,vmware-cpuid-freq=on,+invtsc -smp 4 -m 2048 $kvmflag \
+-initrd sys/src/9/amd64/uroot.cpio.lzma \
 -usb \
 -serial stdio \
 --machine $machineflag \


### PR DESCRIPTION
Load uroot cpio as initrd, and try to unify the build a bit more.  We no longer need allbuild.json, there are just 3 extra files in the kernel ramdisk (decompress, cpio and urootrc).

To build and run with uroot:
- bootstrap
- build
- build sys/src/u-root.json
- run util/GO9PUROOT