### PR TITLE
Add prepare-commit-msg script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,11 @@ Harvey uses Github Pull Requests to accept contributions.
 	[commit message](https://github.com/keedon/harvey/commit/09fe3a21fa8b42088bc8ad83287928e9e7cc96ef)
 	for issue #70 mentioned above. You can also use graphical git
     tools such as `git gui` if you like.
+
+    To sign off automatically, copy the script for a git hook:
+    ```sh
+    cp util/prepare-commit-msg .git/hooks/
+    ```
 5.  Fork the repo (only once).
     ![harvey-os_harvey__a_fresh_take_on_plan_9](https://cloud.githubusercontent.com/assets/429977/13457174/099fb5cc-e067-11e5-83ce-f65aa966a4a9.png)
 6.  Add the repo as a remote (every time you clone the repository)

--- a/util/prepare-commit-msg
+++ b/util/prepare-commit-msg
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# see https://stackoverflow.com/questions/15015894/git-add-signed-off-by-line-using-format-signoff-not-working/46536244#46536244
+
+NAME=$(git config user.name)
+EMAIL=$(git config user.email)
+
+if [ -z "$NAME" ]; then
+    echo "empty git config user.name"
+    exit 1
+fi
+
+if [ -z "$EMAIL" ]; then
+    echo "empty git config user.email"
+    exit 1
+fi
+
+git interpret-trailers --if-exists doNothing --trailer \
+    "Signed-off-by: $NAME <$EMAIL>" \
+    --in-place "$1"


### PR DESCRIPTION
This will automatically sign off commits. See also:
https://stackoverflow.com/questions/15015894/git-add-signed-off-by-line-using-format-signoff-not-working/46536244#46536244

Signed-off-by: Daniel Maslowski <info@orangecms.org>
