### PR TITLE
Copy uroot to tftp folder when built

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ tools/share
 cfg/pxe/tftpboot/harvey.32bit
 cfg/pxe/tftpboot/pxelinux.cfg
 cfg/pxe/tftpboot/ipxe
+cfg/pxe/tftpboot/uroot.cpio.lzma
 usr/harvey/tmp
 
 build_out

--- a/clean.json
+++ b/clean.json
@@ -2,10 +2,11 @@
 	{
 		"Name": "clean",
 		"Pre": [
-			"rm -rf $ARCH/lib/*.a $ARCH/bin/*",
-			"rm -f cfg/pxe/tftpboot/harvey.32bit",
-			"rm -rf plan9_$ARCH/bin/*",
-			"rm -rf linux_$ARCH/bin/*"
+			"rm -rf /$ARCH/lib/*.a /$ARCH/bin/*",
+			"rm -f /cfg/pxe/tftpboot/harvey.32bit",
+			"rm -f /cfg/pxe/tftpboot/uroot.cpio.lzma",
+			"rm -rf /plan9_$ARCH/bin/*",
+			"rm -rf /linux_$ARCH/bin/*"
 		],
 		"Projects": [
 			"/sys/src/9/$ARCH/clean.json",

--- a/sys/src/u-root.json
+++ b/sys/src/u-root.json
@@ -9,6 +9,9 @@
 		"Pre": [
 			"u-root -shellbang -initcmd= -o /plan9_$ARCH/uroot.cpio plan9",
 			"lzma -f -k -3 /plan9_$ARCH/uroot.cpio"
+		],
+		"Post": [
+			"cp /plan9_$ARCH/uroot.cpio.lzma /cfg/pxe/tftpboot"
 		]
 	}
 ]


### PR DESCRIPTION
To use, add `--- uroot.cpio.lzma` to the pxelinux file as described [here](https://github.com/Harvey-OS/harvey/wiki/Booting-Harvey-on-real-hardware-I-(TFTP)#preparing-the-host).

Note that at least on my machine, I get a page fault.  Fixing that would be the next step.  (Maybe it doesn't happen on other machines?)

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>