### PR TITLE
Avoid page fault due to partially initialised memory sections

### DIFF
--- a/sys/src/9/amd64/memory.c
+++ b/sys/src/9/amd64/memory.c
@@ -96,7 +96,20 @@ umeminit(void)
 	extern void physallocdump(void);
 	setphysmembounds();
 
+	// If there are any modules, start user memory after the last module.
+	// This avoids any large PamMEMORY sections between the kernel and the
+	// modules.  This has the disadvantage that we don't use these memory
+	// sections, but at least it avoids a page fault if physinit is called.
+	// This should be fixed so that all large-enough PamMEMORY sections
+	// are used, regardless of their position.
+	PAMap *start = pamap;
 	for(PAMap *m = pamap; m != nil; m = m->next){
+		if (m->type == PamMODULE) {
+			start = m;
+		}
+	}
+
+	for(PAMap *m = start; m != nil; m = m->next){
 		if(m->type != PamMEMORY)
 			continue;
 		if(m->addr < 2 * MiB)


### PR DESCRIPTION
If module memory sections exist (e.g. when using initrd), and there's a usable memory larger than 2Mi between the end of the kernel memory and the start of the module, harvey would try to use it as user memory, despite it being found to be earlier than sys->pmstart (as set in setphysmembounds).  This would cause a page fault when physinit was later called for that memory section.

This commit will avoid using any PamMEMORY sections found earlier than any PamMODULE sections.  This has the downside that we lose useful memory, but probably not very much.  In my case the memory section was just under 6Mi.

Maybe this can be recovered with a more sophisticated change (probably involving physalloc.c)?

This change should have no effect if modules (initrd) are not used.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>