### PR TITLE
rename uintmem to physaddr

### DIFF
--- a/sys/src/9/amd64/archamd64.c
+++ b/sys/src/9/amd64/archamd64.c
@@ -475,7 +475,7 @@ archfmtinstall(void)
 	 * Architecture-specific formatting. Not as neat as they
 	 * could be (e.g. there's no defined type for a 'register':
 	 *	L - Mpl, mach priority level
-	 *	P - uintmem, physical address
+	 *	P - physaddr, physical address
 	 *	R - register
 	 * With a little effort these routines could be written
 	 * in a fairly architecturally-independent manner, relying

--- a/sys/src/9/amd64/dat.h
+++ b/sys/src/9/amd64/dat.h
@@ -35,7 +35,7 @@ typedef u64 PTE;
 typedef struct Proc Proc;
 typedef struct Sys Sys;
 typedef struct Stackframe Stackframe;
-typedef u64 uintmem; /* Physical address (hideous) */
+typedef u64 physaddr; /* Physical address (hideous) */
 typedef struct Ureg Ureg;
 typedef struct Vctl Vctl;
 

--- a/sys/src/9/amd64/usbuhci.c
+++ b/sys/src/9/amd64/usbuhci.c
@@ -280,7 +280,7 @@ struct Td {
 #define OUTS(x, v) outs(ctlr->port + (x), (v))
 #define OUTL(x, v) outl(ctlr->port + (x), (v))
 #define TRUNC(x, sz) ((x) & ((sz)-1))
-#define PTR(q) ((void *)KADDR((uintmem)(q) & ~0xFULL))
+#define PTR(q) ((void *)KADDR((physaddr)(q) & ~0xFULL))
 #define QPTR(q) ((Qh *)PTR(q))
 #define TPTR(q) ((Td *)PTR(q))
 #define PORT(p) (Portsc0 + 2 * (p))

--- a/sys/src/9/riscv/archriscv.c
+++ b/sys/src/9/riscv/archriscv.c
@@ -118,7 +118,7 @@ archfmtinstall(void)
 	 * Architecture-specific formatting. Not as neat as they
 	 * could be (e.g. there's no defined type for a 'register':
 	 *	L - Mpl, mach priority level
-	 *	P - uintmem, physical address
+	 *	P - physaddr, physical address
 	 *	R - register
 	 * With a little effort these routines could be written
 	 * in a fairly architecturally-independent manner, relying

--- a/sys/src/9/riscv/dat.h
+++ b/sys/src/9/riscv/dat.h
@@ -32,7 +32,7 @@ typedef u64 PTE;
 typedef struct Proc Proc;
 typedef struct Sys Sys;
 typedef struct Stackframe Stackframe;
-typedef u64 uintmem; /* Physical address (hideous) */
+typedef u64 physaddr; /* Physical address (hideous) */
 typedef struct Ureg Ureg;
 typedef struct Vctl Vctl;
 


### PR DESCRIPTION
It was named uintmem because uint is 32-bits and we needed a
physical address type that was kind of uint but really for physical
addresses and hence 64 bits, while, at the same time, not being
tied to a bit length (so u64 would not do).

This all goes back to the days of the 32-bit transition for K10 IIRC.

This is all very confusing so give it a name related to its function.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>