### PR TITLE
frontusb: ref spatch changes (incref, decref)

### DIFF
--- a/sys/src/cmd/frontusb/disk/disk.c
+++ b/sys/src/cmd/frontusb/disk/disk.c
@@ -984,7 +984,7 @@ findendpoints(Ums *ums)
 		return -1;
 	}
 	if(epout == epin){
-		incref(ums->epin);
+		incref(&ums->epin->ref);
 		ums->epout = ums->epin;
 	}else
 		ums->epout = openep(dev, epout);

--- a/sys/src/cmd/frontusb/joy/joy.c
+++ b/sys/src/cmd/frontusb/joy/joy.c
@@ -385,7 +385,7 @@ kbstart(Dev *d, Ep *ep, void (*f)(void*))
 	KDev *kd;
 
 	kd = emallocz(sizeof(KDev), 1);
-	incref(d);
+	incref(&d->ref);
 	kd->dev = d;
 	if(setproto(kd, ep->id) < 0){
 		fprint(2, "%s: %s: setproto: %r\n", argv0, d->dir);

--- a/sys/src/cmd/frontusb/kb/kb.c
+++ b/sys/src/cmd/frontusb/kb/kb.c
@@ -881,7 +881,7 @@ hdsetup(Dev *d, Ep *ep)
 	f = emallocz(sizeof(Hiddev), 1);
 	f->minfd = -1;
 	f->kinfd = -1;
-	incref(d);
+	incref(&d->ref);
 	f->dev = d;
 	if(setproto(f, ep->id) < 0){
 		fprint(2, "%s: %s: setproto: %r\n", argv0, d->dir);

--- a/sys/src/cmd/frontusb/lib/dev.c
+++ b/sys/src/cmd/frontusb/lib/dev.c
@@ -94,7 +94,7 @@ opendev(char *fn)
 	if(access("/dev/usb", AEXIST) < 0 && bind("#u", "/dev", MBEFORE) < 0)
 		return nil;
 	d = emallocz(sizeof(Dev), 1);
-	incref(d);
+	incref(&d->ref);
 
 	l = strlen(fn);
 	d->dfd = -1;
@@ -309,7 +309,7 @@ closedev(Dev *d)
 	int i;
 	Usbdev *ud;
 
-	if(d==nil || decref(d) != 0)
+	if(d==nil || decref(&d->ref) != 0)
 		return;
 	dprint(2, "%s: closedev %#p %s\n", argv0, d, d->dir);
 	if(d->cfd >= 0)

--- a/sys/src/cmd/frontusb/lib/usb.h
+++ b/sys/src/cmd/frontusb/lib/usb.h
@@ -173,7 +173,7 @@ enum {
  */
 struct Dev
 {
-	Ref;
+	Ref	ref;
 	char*	dir;		/* path for the endpoint dir */
 	int	id;		/* usb id for device or ep. number */
 	int	dfd;		/* descriptor for the data file */

--- a/sys/src/cmd/frontusb/serial/ch340.c
+++ b/sys/src/cmd/frontusb/serial/ch340.c
@@ -89,7 +89,7 @@ chinit(Serialport *p)
 	chops.setparam(p);
 
 	/* p gets freed by closedev, the process has a reference */
-	incref(ser->dev);
+	incref(&ser->dev->ref);
 	return 0;
 }
 

--- a/sys/src/cmd/frontusb/serial/ftdi.c
+++ b/sys/src/cmd/frontusb/serial/ftdi.c
@@ -1407,7 +1407,7 @@ statusreader(void *u)
 	a = emallocz(sizeof(Areader), 1);
 	a->p = p;
 	a->c = c;
-	incref(ser->dev);
+	incref(&ser->dev->ref);
 	proccreate(epreader, a, 16*1024);
 
 	while((pk = recvp(c)) != nil){
@@ -1474,7 +1474,7 @@ ftinit(Serialport *p)
 		/* 0xb is the mask for lines. plug dependant? */
 		ftdiwrite(p, BMMPSSE|0x0b, 0, FTSETBITMODE);
 	}
-	incref(ser->dev);
+	incref(&ser->dev->ref);
 	proccreate(statusreader, p, 8*1024);
 	return 0;
 }

--- a/sys/src/cmd/frontusb/serial/prolific.c
+++ b/sys/src/cmd/frontusb/serial/prolific.c
@@ -465,7 +465,7 @@ plinit(Serialport *p)
 		free(st);
 	}
 	/* p gets freed by closedev, the process has a reference */
-	incref(ser->dev);
+	incref(&ser->dev->ref);
 	proccreate(statusreader, p, 8*1024);
 	return 0;
 }

--- a/sys/src/cmd/frontusb/serial/serial.c
+++ b/sys/src/cmd/frontusb/serial/serial.c
@@ -575,7 +575,7 @@ openeps(Serialport *p, int epin, int epout, int epintr)
 		return -1;
 	}
 	if(epin == epout){
-		incref(p->epin);
+		incref(&p->epin->ref);
 		p->epout = p->epin;
 	} else
 		p->epout = openep(ser->dev, epout);

--- a/sys/src/cmd/frontusb/serial/silabs.c
+++ b/sys/src/cmd/frontusb/serial/silabs.c
@@ -84,7 +84,7 @@ slinit(Serialport *p)
 	slops.getparam(p);
 
 	/* p gets freed by closedev, the process has a reference */
-	incref(ser->dev);
+	incref(&ser->dev->ref);
 	return 0;
 }
 

--- a/sys/src/cmd/frontusb/usbd/hub.c
+++ b/sys/src/cmd/frontusb/usbd/hub.c
@@ -216,7 +216,7 @@ newhub(char *fn, Dev *d)
 	dprint(2, " ports %d pwrms %d max curr %d pwrm %d cmp %d leds %d\n",
 		h->nport, h->pwrms, h->maxcurrent,
 		h->pwrmode, h->compound, h->leds);
-	incref(h->dev);
+	incref(&h->dev->ref);
 	return h;
 Fail:
 	if(d != nil)

--- a/sys/src/cmd/frontusb/usbd/usbd.c
+++ b/sys/src/cmd/frontusb/usbd/usbd.c
@@ -128,7 +128,7 @@ pushevent(Dev *d, char *data)
 	qlock(&evlock);
 	e = evlast;
 	evlast = emallocz(sizeof(Event), 1);
-	incref(d);
+	incref(&d->ref);
 	e->dev = d;
 	e->data = data;
 	e->len = strlen(data);
@@ -247,7 +247,7 @@ enumerate(Event **l)
 			if(d == nil || d->usb == nil || p->hub != nil)
 				continue;
 			e = emallocz(sizeof(Event), 1);
-			incref(d);
+			incref(&d->ref);
 			e->dev = d;
 			e->data = formatdev(d, 0);
 			e->len = strlen(e->data);


### PR DESCRIPTION
run ref.cocci to update incref/decref uses
```spatch --sp-file sys/src/spatches/ref.cocci sys/src/cmd/frontusb/**/*.c --in-place```