### PR TITLE
frontusb: fix getcallerpc + spatch

### DIFF
--- a/sys/src/cmd/frontusb/lib/dump.c
+++ b/sys/src/cmd/frontusb/lib/dump.c
@@ -149,7 +149,7 @@ estrdup(char *s)
 	d = strdup(s);
 	if(d == nil)
 		sysfatal("strdup: %r");
-	setmalloctag(d, getcallerpc(&s));
+	setmalloctag(d, getcallerpc());
 	return d;
 }
 
@@ -163,7 +163,7 @@ emallocz(u32 size, int zero)
 		sysfatal("malloc: %r");
 	if(zero)
 		memset(x, 0, size);
-	setmalloctag(x, getcallerpc(&size));
+	setmalloctag(x, getcallerpc());
 	return x;
 }
 

--- a/sys/src/spatches/getcallerpc.cocci
+++ b/sys/src/spatches/getcallerpc.cocci
@@ -1,0 +1,5 @@
+@  @
+expression E;
+@@
+-getcallerpc(E)
++getcallerpc()


### PR DESCRIPTION
spatch --sp-file sys/src/spatches/getcallerpc.cocci sys/src/cmd/frontusb/**/*.c --in-place

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>