### PR TITLE
Dev create signature changed to return Chan*

### DIFF
--- a/sys/src/9/ip/devip.c
+++ b/sys/src/9/ip/devip.c
@@ -513,10 +513,11 @@ ipopen(Chan *c, int omode)
 	return c;
 }
 
-static void
+static Chan*
 ipcreate(Chan *c, char *n, int i, int m)
 {
 	error(Eperm);
+	return nil;
 }
 
 static void

--- a/sys/src/9/port/dev.c
+++ b/sys/src/9/port/dev.c
@@ -487,7 +487,7 @@ Return:
 	return c;
 }
 
-void
+Chan*
 devcreate(Chan *c, char *d, int i, int n)
 {
 	if(0)
@@ -495,6 +495,7 @@ devcreate(Chan *c, char *d, int i, int n)
 	error(Eperm);
 	if(0)
 		print_func_exit();
+	return nil;
 }
 
 Block *

--- a/sys/src/9/port/dev9p.c
+++ b/sys/src/9/port/dev9p.c
@@ -499,10 +499,10 @@ v9pclose(Chan *c)
 	mdevtab->close(c);
 }
 
-static void
+static Chan*
 v9pcreate(Chan *c, char *name, int omode, int perm)
 {
-	mdevtab->create(c, name, omode, perm);
+	return mdevtab->create(c, name, omode, perm);
 }
 
 static void
@@ -568,10 +568,11 @@ phclose(Chan *c)
 	error(Edonotcall(__FUNCTION__));
 }
 
-static void
+static Chan*
 phcreate(Chan *c, char *name, int omode, int perm)
 {
 	error(Edonotcall(__FUNCTION__));
+	return nil;
 }
 
 static void

--- a/sys/src/9/port/devenv.c
+++ b/sys/src/9/port/devenv.c
@@ -145,7 +145,7 @@ envopen(Chan *c, int omode)
 	return c;
 }
 
-static void
+static Chan*
 envcreate(Chan *c, char *name, int omode, int i)
 {
 	Proc *up = externup();
@@ -192,6 +192,7 @@ envcreate(Chan *c, char *name, int omode, int i)
 	c->offset = 0;
 	c->mode = omode;
 	c->flag |= COPEN;
+	return c;
 }
 
 static void

--- a/sys/src/9/port/devether.c
+++ b/sys/src/9/port/devether.c
@@ -71,9 +71,11 @@ etheropen(Chan *chan, int omode)
 	return netifopen(&etherxx[chan->devno]->Netif, chan, omode);
 }
 
-static void
+static Chan*
 ethercreate(Chan *c, char *d, int i, int n)
 {
+	error(Eperm);
+	return nil;
 }
 
 static void

--- a/sys/src/9/port/devmnt.c
+++ b/sys/src/9/port/devmnt.c
@@ -551,10 +551,10 @@ mntopen(Chan *c, int omode)
 	return mntopencreate(Topen, c, nil, omode, 0);
 }
 
-static void
+static Chan*
 mntcreate(Chan *c, char *name, int omode, int perm)
 {
-	mntopencreate(Tcreate, c, name, omode, perm);
+	return mntopencreate(Tcreate, c, name, omode, perm);
 }
 
 static void

--- a/sys/src/9/port/devmntn.c
+++ b/sys/src/9/port/devmntn.c
@@ -394,10 +394,10 @@ mntopen(Chan *c, int omode)
 	return mntopencreate(Tlopen, c, nil, omode, 0);
 }
 
-static void
+static Chan*
 mntcreate(Chan *c, char *name, int omode, int perm)
 {
-	mntopencreate(Tlcreate, c, name, omode, perm);
+	return mntopencreate(Tlcreate, c, name, omode, perm);
 }
 
 static void

--- a/sys/src/9/port/devmouse.c
+++ b/sys/src/9/port/devmouse.c
@@ -215,10 +215,11 @@ mouseopen(Chan *c, int omode)
 	return c;
 }
 
-static void
+static Chan*
 mousecreate(Chan *c, char *j, int i, int u)
 {
 	error(Eperm);
+	return nil;
 }
 
 static void

--- a/sys/src/9/port/devramfs.c
+++ b/sys/src/9/port/devramfs.c
@@ -429,7 +429,7 @@ ramwrite(Chan *c, void *v, i32 n, i64 off)
 	return total;
 }
 
-void
+static Chan*
 ramcreate(Chan *c, char *name, int omode, int perm)
 {
 	Proc *up = externup();
@@ -471,6 +471,8 @@ ramcreate(Chan *c, char *name, int omode, int perm)
 	qunlock(&ramlock);
 
 	poperror();
+
+	return c;
 }
 
 void

--- a/sys/src/9/port/devsegment.c
+++ b/sys/src/9/port/devsegment.c
@@ -294,7 +294,7 @@ segmentclose(Chan *c)
 		putgseg(c->aux);
 }
 
-static void
+static Chan*
 segmentcreate(Chan *c, char *name, int omode, int perm)
 {
 	Proc *up = externup();
@@ -359,6 +359,8 @@ segmentcreate(Chan *c, char *name, int omode, int perm)
 	c->mode = OWRITE;
 
 	DBG("segmentcreate(%s, %#o %#x)\n", name, omode, perm);
+
+	return c;
 }
 
 enum { PTRSIZE = 19 }; /* "0x1234567812345678 " */

--- a/sys/src/9/port/devsrv.c
+++ b/sys/src/9/port/devsrv.c
@@ -152,7 +152,7 @@ srvopen(Chan *c, int omode)
 	return sp->chan;
 }
 
-static void
+static Chan*
 srvcreate(Chan *c, char *name, int omode, int perm)
 {
 	Proc *up = externup();
@@ -195,6 +195,7 @@ srvcreate(Chan *c, char *name, int omode, int perm)
 
 	c->flag |= COPEN;
 	c->mode = OWRITE;
+	return c;
 }
 
 static void

--- a/sys/src/9/port/portdat.h
+++ b/sys/src/9/port/portdat.h
@@ -251,7 +251,7 @@ struct Dev {
 	Walkqid *(*walk)(Chan *, Chan *, char **, int);
 	i32 (*stat)(Chan *, unsigned char *, i32);
 	Chan *(*open)(Chan *, int);
-	void (*create)(Chan *, char *, int, int);
+	Chan *(*create)(Chan *, char *, int, int);
 	void (*close)(Chan *);
 	i32 (*read)(Chan *, void *, i32, i64);
 	Block *(*bread)(Chan *, i32, i64);

--- a/sys/src/9/port/portfns.h
+++ b/sys/src/9/port/portfns.h
@@ -71,7 +71,7 @@ Block *devbread(Chan *, i32, i64);
 i32 devbwrite(Chan *, Block *, i64);
 Chan *devclone(Chan *);
 int devconfig(int, char *, DevConf *);
-void devcreate(Chan *, char *, int, int);
+Chan *devcreate(Chan *, char *, int, int);
 void devdir(Chan *, Qid, char *, i64, char *, i32, Dir *);
 i32 devdirread(Chan *, char *, i32, Dirtab *, int, Devgen *);
 Devgen devgen;


### PR DESCRIPTION
Device create functions changed to return Chan* created, similar to open.
Required for integration of devshr.

Looks to have been added because shrcreate has a path where a new Chan is created, in which case it wants to sent the new chan rather than the one passed in.

As mentioned in slack, the 9front commit this change is based on is: https://code.9front.org/hg/plan9front/rev/2e0310025a75
```
changeset:   771:2e0310025a75
user:        cinap_lenrek@centraldogma
date:        Wed Aug 17 23:27:31 2011 +0200
summary:     change definition of Chan.create to return a chan like open
```

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>