### PR TITLE
devshr: add postsharesrv and threadpostsharesrv functions

### DIFF
--- a/sys/include/9p.h
+++ b/sys/include/9p.h
@@ -219,6 +219,8 @@ struct Srv {
 void		srv(Srv*);
 void		postmountsrv(Srv*, char*, char*, int);
 void		_postmountsrv(Srv*, char*, char*, int);
+void		postsharesrv(Srv*, char*, char*, char*);
+void		_postsharesrv(Srv*, char*, char*, char*);
 void		listensrv(Srv*, char*);
 void		_listensrv(Srv*, char*);
 int 		postfd(char*, int);
@@ -226,6 +228,7 @@ int		chatty9p;
 void		respond(Req*, char*);
 void		responderror(Req*);
 void		threadpostmountsrv(Srv*, char*, char*, int);
+void		threadpostsharesrv(Srv*, char*, char*, char*);
 void		threadlistensrv(Srv *s, char *addr);
 
 /*

--- a/sys/src/lib9p/rfork.c
+++ b/sys/src/lib9p/rfork.c
@@ -40,3 +40,10 @@ postmountsrv(Srv *s, char *name, char *mtpt, int flag)
 	_forker = rforker;
 	_postmountsrv(s, name, mtpt, flag);
 }
+
+void
+postsharesrv(Srv *s, char *name, char *mtpt, char *desc)
+{
+	_forker = rforker;
+	_postsharesrv(s, name, mtpt, desc);
+}

--- a/sys/src/lib9p/thread.c
+++ b/sys/src/lib9p/thread.c
@@ -32,3 +32,10 @@ threadpostmountsrv(Srv *s, char *name, char *mtpt, int flag)
 	_forker = tforker;
 	_postmountsrv(s, name, mtpt, flag);
 }
+
+void
+threadpostsharesrv(Srv *s, char *name, char *mtpt, char *desc)
+{
+	_forker = tforker;
+	_postsharesrv(s, name, mtpt, desc);
+}


### PR DESCRIPTION
These are used by the 9front usb stack, but were missed in the previous devshr PRs.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>