### PR TITLE
Import 9pqueue from 9front

### DIFF
--- a/sys/include/9p.h
+++ b/sys/include/9p.h
@@ -33,7 +33,23 @@ typedef struct Filelist	Filelist;
 typedef struct Tree	Tree;
 typedef struct Readdir	Readdir;
 typedef struct Srv 	Srv;
+typedef struct Reqqueue Reqqueue;
+typedef struct Queueelem Queueelem;
 
+struct Queueelem
+{
+	Queueelem *prev, *next;
+	void (*f)(Req *);
+};
+
+struct Reqqueue
+{
+	QLock;
+	Rendez;
+	Queueelem;
+	int pid, flush;
+	Req *cur;
+};
 
 struct Fid
 {
@@ -253,3 +269,8 @@ void	authdestroy(Fid*);
 int	authattach(Req*);
 
 extern void (*_forker)(void (*)(void*), void*, int);
+
+Reqqueue*	reqqueuecreate(void);
+void		reqqueuepush(Reqqueue*, Req*, void (*)(Req *));
+void		reqqueueflush(Reqqueue*, Req*);
+void		reqqueuefree(Reqqueue*);

--- a/sys/include/9p.h
+++ b/sys/include/9p.h
@@ -38,17 +38,17 @@ typedef struct Queueelem Queueelem;
 
 struct Queueelem
 {
-	Queueelem *prev, *next;
-	void (*f)(Req *);
+	Queueelem	*prev, *next;
+	void		(*f)(Req *);
 };
 
 struct Reqqueue
 {
-	QLock;
-	Rendez;
-	Queueelem;
-	int pid, flush;
-	Req *cur;
+	QLock		lock;
+	Rendez		rendez;
+	Queueelem	queue;
+	int		pid, flush;
+	Req		*cur;
 };
 
 struct Fid
@@ -70,7 +70,7 @@ struct Fid
 
 struct Req
 {
-	u32	tag;
+	u32		tag;
 	void*		aux;
 	Fcall		ifcall;
 	Fcall		ofcall;
@@ -81,11 +81,13 @@ struct Req
 	Fid*		newfid;
 	Srv*		srv;
 
+	Queueelem	qu;
+
 /* below is implementation-specific; don't use */
 	QLock		lk;
 	Ref		ref;
 	Reqpool*	pool;
-	u8 *	buf;
+	u8 *		buf;
 	u8		type;
 	u8		responded;
 	char*		error;

--- a/sys/src/lib9p/lib9p.json
+++ b/sys/src/lib9p/lib9p.json
@@ -14,6 +14,7 @@
 			"intmap.c",
 			"listen.c",
 			"mem.c",
+			"queue.c",
 			"req.c",
 			"parse.c",
 			"post.c",

--- a/sys/src/lib9p/queue.c
+++ b/sys/src/lib9p/queue.c
@@ -1,0 +1,104 @@
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include <fcall.h>
+#include <9p.h>
+
+static void
+_reqqueueproc(void *v)
+{
+	Reqqueue *q;
+	Req *r;
+	void (*f)(Req *);
+	int fd;
+	char *buf;
+
+	q = v;
+	rfork(RFNOTEG);
+
+	buf = smprint("/proc/%lud/ctl", (ulong)getpid());
+	fd = open(buf, OWRITE|OCEXEC);
+	free(buf);
+	
+	for(;;){
+		qlock(q);
+		q->flush = 0;
+		if(fd >= 0)
+			write(fd, "nointerrupt", 11);
+		q->cur = nil;
+		while(q->next == q)
+			rsleep(q);
+		r = (Req*)(((char*)q->next) - ((char*)&((Req*)0)->qu));
+		r->qu.next->prev = r->qu.prev;
+		r->qu.prev->next = r->qu.next;
+		f = r->qu.f;
+		memset(&r->qu, 0, sizeof(r->qu));
+		q->cur = r;
+		qunlock(q);
+		if(f == nil)
+			break;
+		f(r);
+	}
+
+	if(fd >= 0)
+		close(fd);
+	free(r);
+	free(q);
+	threadexits(nil);
+}
+
+Reqqueue *
+reqqueuecreate(void)
+{
+	Reqqueue *q;
+
+	q = emalloc9p(sizeof(*q));
+	memset(q, 0, sizeof(*q));
+	q->l = q;
+	q->next = q->prev = q;
+	q->pid = proccreate(_reqqueueproc, q, mainstacksize);
+	return q;
+}
+
+void
+reqqueuepush(Reqqueue *q, Req *r, void (*f)(Req *))
+{
+	qlock(q);
+	r->qu.f = f;
+	r->qu.next = q;
+	r->qu.prev = q->prev;
+	q->prev->next = &r->qu;
+	q->prev = &r->qu;
+	rwakeup(q);
+	qunlock(q);
+}
+
+void
+reqqueueflush(Reqqueue *q, Req *r)
+{
+	qlock(q);
+	if(q->cur == r){
+		threadint(q->pid);
+		q->flush++;
+		qunlock(q);
+	}else{
+		if(r->qu.next != nil){
+			r->qu.next->prev = r->qu.prev;
+			r->qu.prev->next = r->qu.next;
+		}
+		memset(&r->qu, 0, sizeof(r->qu));
+		qunlock(q);
+		respond(r, "interrupted");
+	}
+}
+
+void
+reqqueuefree(Reqqueue *q)
+{
+	Req *r;
+
+	if(q == nil)
+		return;
+	r = emalloc9p(sizeof(Req));
+	reqqueuepush(q, r, nil);
+}

--- a/sys/src/lib9p/queue.c
+++ b/sys/src/lib9p/queue.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright © 2021 Plan 9 Foundation
+ * Copyright © 2021 9front authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #include <u.h>
 #include <libc.h>
 #include <thread.h>
@@ -16,25 +39,25 @@ _reqqueueproc(void *v)
 	q = v;
 	rfork(RFNOTEG);
 
-	buf = smprint("/proc/%lud/ctl", (ulong)getpid());
+	buf = smprint("/proc/%lu/ctl", (u32)getpid());
 	fd = open(buf, OWRITE|OCEXEC);
 	free(buf);
 	
 	for(;;){
-		qlock(q);
+		qlock(&q->lock);
 		q->flush = 0;
 		if(fd >= 0)
 			write(fd, "nointerrupt", 11);
 		q->cur = nil;
-		while(q->next == q)
-			rsleep(q);
-		r = (Req*)(((char*)q->next) - ((char*)&((Req*)0)->qu));
+		while((Reqqueue*)q->queue.next == q)
+			rsleep(&q->rendez);
+		r = (Req*)(((char*)q->queue.next) - ((char*)&((Req*)0)->qu));
 		r->qu.next->prev = r->qu.prev;
 		r->qu.prev->next = r->qu.next;
 		f = r->qu.f;
 		memset(&r->qu, 0, sizeof(r->qu));
 		q->cur = r;
-		qunlock(q);
+		qunlock(&q->lock);
 		if(f == nil)
 			break;
 		f(r);
@@ -54,8 +77,8 @@ reqqueuecreate(void)
 
 	q = emalloc9p(sizeof(*q));
 	memset(q, 0, sizeof(*q));
-	q->l = q;
-	q->next = q->prev = q;
+	q->rendez.l = &q->lock;
+	q->queue.next = q->queue.prev = (Queueelem*)q;
 	q->pid = proccreate(_reqqueueproc, q, mainstacksize);
 	return q;
 }
@@ -63,31 +86,31 @@ reqqueuecreate(void)
 void
 reqqueuepush(Reqqueue *q, Req *r, void (*f)(Req *))
 {
-	qlock(q);
+	qlock(&q->lock);
 	r->qu.f = f;
-	r->qu.next = q;
-	r->qu.prev = q->prev;
-	q->prev->next = &r->qu;
-	q->prev = &r->qu;
-	rwakeup(q);
-	qunlock(q);
+	r->qu.next = (Queueelem*)q;
+	r->qu.prev = q->queue.prev;
+	q->queue.prev->next = &r->qu;
+	q->queue.prev = &r->qu;
+	rwakeup(&q->rendez);
+	qunlock(&q->lock);
 }
 
 void
 reqqueueflush(Reqqueue *q, Req *r)
 {
-	qlock(q);
+	qlock(&q->lock);
 	if(q->cur == r){
 		threadint(q->pid);
 		q->flush++;
-		qunlock(q);
+		qunlock(&q->lock);
 	}else{
 		if(r->qu.next != nil){
 			r->qu.next->prev = r->qu.prev;
 			r->qu.prev->next = r->qu.next;
 		}
 		memset(&r->qu, 0, sizeof(r->qu));
-		qunlock(q);
+		qunlock(&q->lock);
 		respond(r, "interrupted");
 	}
 }


### PR DESCRIPTION
9pqueue will be used by the 9front usb/serial code.

From the man page:
Reqqueue provides routines for deferred processing of 9p request in multithreaded 9p servers.

There are 2 commits - the first is the unadulterated 9front code, the second contains the changes to get it building in harvey.