### PR TITLE
GO9P* scripts should use qemu q35 machine when using kvm

### DIFF
--- a/util/GO9PCPU
+++ b/util/GO9PCPU
@@ -9,7 +9,7 @@ centrepid=$!
 export machineflag=q35
 if [ "$(uname)" = "Linux" ] && [ -e /dev/kvm ]; then
 	export kvmflag='-enable-kvm'
-	export machineflag='pc,accel=kvm'
+	export machineflag='q35,accel=kvm'
 	if [ ! -w /dev/kvm ]; then
 		# we don't have access as a regular user
 		export kvmdo=sudo

--- a/util/GO9PCPUDOCKER
+++ b/util/GO9PCPUDOCKER
@@ -9,7 +9,7 @@ ufspid=$!
 export machineflag=q35
 if [ "$(uname)" = "Linux" ] && [ -e /dev/kvm ]; then
 	export kvmflag='-enable-kvm'
-	export machineflag='pc,accel=kvm'
+	export machineflag='q35,accel=kvm'
 	if [ ! -w /dev/kvm ]; then
 		# we don't have access as a regular user
 		export kvmdo=sudo

--- a/util/GO9PIMG
+++ b/util/GO9PIMG
@@ -20,7 +20,7 @@ ufspid=$!
 export machineflag=q35
 if [ "$(uname)" = "Linux" ] && [ -e /dev/kvm ]; then
 	export kvmflag='-enable-kvm'
-	export machineflag='pc,accel=kvm'
+	export machineflag='q35,accel=kvm'
 	if [ ! -w /dev/kvm ]; then
 		# we don't have access as a regular user
 		export kvmdo=sudo

--- a/util/GO9PIMGUSB
+++ b/util/GO9PIMGUSB
@@ -20,7 +20,7 @@ ufspid=$!
 export machineflag=q35
 if [ "$(uname)" = "Linux" ] && [ -e /dev/kvm ]; then
 	export kvmflag='-enable-kvm'
-	export machineflag='pc,accel=kvm'
+	export machineflag='q35,accel=kvm'
 	if [ ! -w /dev/kvm ]; then
 		# we don't have access as a regular user
 		export kvmdo=sudo

--- a/util/GO9PTERM
+++ b/util/GO9PTERM
@@ -9,7 +9,7 @@ centrepid=$!
 export machineflag=q35
 if [ "$(uname)" = "Linux" ] && [ -e /dev/kvm ]; then
 	export kvmflag='-enable-kvm'
-	export machineflag='pc,accel=kvm'
+	export machineflag='q35,accel=kvm'
 	if [ ! -w /dev/kvm ]; then
 		# we don't have access as a regular user
 		export kvmdo=sudo

--- a/util/GO9PUROOT
+++ b/util/GO9PUROOT
@@ -9,7 +9,7 @@ centrepid=$!
 export machineflag=q35
 if [ "$(uname)" = "Linux" ] && [ -e /dev/kvm ]; then
 	export kvmflag='-enable-kvm'
-	export machineflag='pc,accel=kvm'
+	export machineflag='q35,accel=kvm'
 	if [ ! -w /dev/kvm ]; then
 		# we don't have access as a regular user
 		export kvmdo=sudo


### PR DESCRIPTION
If kvm is enabled, the GO9P* scripts use the older 'pc' machine config, rather than the newer q35 config.
This means we don't have an ahci device amongst other things.
Switching to q35 to have a more modern config (and ahci).

A couple of consequences of the change:
- The default qemu config has a dvd drive.  This seems to cause a couple of i/o errors to show up in harvey.
- We can now attach images as drives by adding the following lines to the qemu line in GO9P*:
```
-drive id=disk,file=harveyhd.img,if=none \
-device ahci,id=ahci \
-device ide-,drive=disk,bus=ahci.0 \
```
These will now be picked up by devsd.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>