### PR TITLE
Ensure IPI is assigned to the correct bus

### DIFF
--- a/sys/src/9/amd64/trap.c
+++ b/sys/src/9/amd64/trap.c
@@ -274,7 +274,7 @@ trapinit(void)
 	trapenable(VectorBPT, debugbpt, 0, "#BP");
 	trapenable(VectorPF, faultamd64, 0, "#PF");
 	trapenable(Vector2F, doublefault, 0, "#DF");
-	intrenable(IdtIPI, expected, 0, BUSUNKNOWN, "#IPI");
+	intrenable(IdtIPI, expected, 0, MKBUS(BusIPI, 0xff, 0xff, 0xff), "#IPI");
 	trapenable(Vector15, unexpected, 0, "#15");
 	nmienable();
 


### PR DESCRIPTION
When we set up the IPI, it was given a tbdf of BUSUNKNOWN.  This sets a bus type of BusISA.  This then leads to the interrupt being misconfigured, and doesn't show up in #P/irqalloc.  It also shows unhappy looking logging at boot.

Instead, we assign it to the 'fake' BusIPI.  It now shows up in #P/irqalloc and doesn't produce unhappy logging at boot.

In another PR, we should probably change the BUSUNKNOWN macro to use some sort of BusUNKNOWN type rather than BusISA.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>