### PR TITLE
Make ip/ipconfig give up quicker on DHCP

### DIFF
--- a/sys/src/cmd/ip/ipconfig/main.c
+++ b/sys/src/cmd/ip/ipconfig/main.c
@@ -626,7 +626,7 @@ doadd(int retry)
 	/* run dhcp if we need something */
 	if(dodhcp){
 		mkclientid();
-		for(tries = 0; tries < 30; tries++){
+		for(tries = 0; tries < 2; tries++){
 			dhcpquery(!noconfig, Sselecting);
 			if(conf.state == Sbound)
 				break;


### PR DESCRIPTION
Despite what the man pages say, ip/ipconfig can actually take 300 seconds to time out on acquiring a DHCP lease. That's because it runs up to 30 iterations of a function which itself retries DHCP requests 10 times, once per second. This will instead give up after 20 seconds, which should be more than enough and is much more in-line with what the man page claims.

Signed-off-by: John Floren <john.floren@gravwell.io>