### PR TITLE
git: change time-related log code to use our libc rather than 9front (fix git build)

### DIFF
--- a/sys/src/cmd/git/log.c
+++ b/sys/src/cmd/git/log.c
@@ -135,7 +135,7 @@ nextline(char *p, char *e)
 static void
 show(Object *o)
 {
-	Tm tm;
+	Tm *tm;
 	char *p, *q, *e;
 
 	assert(o->type == GCommit);
@@ -150,10 +150,10 @@ show(Object *o)
 		Bwrite(out, p, q - p);
 		Bputc(out, '\n');
 	}else{
-		tmtime(&tm, o->commit->mtime, tzload("local"));
+		tm = localtime(o->commit->mtime);
 		Bprint(out, "Hash:\t%H\n", o->hash);
 		Bprint(out, "Author:\t%s\n", o->commit->author);
-		Bprint(out, "Date:\t%τ\n", tmfmt(&tm, "WW MMM D hh:mm:ss z YYYY"));
+		Bprint(out, "Date:\t%s\n", asctime(tm));
 		Bprint(out, "\n");
 		p = o->commit->msg;
 		e = p + o->commit->nmsg;
@@ -325,7 +325,6 @@ main(int argc, char **argv)
 		sysfatal("chdir: %r");
 
 	gitinit();
-	tmfmtinstall();
 	out = Bfdopen(1, OWRITE);
 	if(queryexpr != nil)
 		showquery(queryexpr);


### PR DESCRIPTION
Changes formatting of long dates in git log.  Shouldn't make a difference.  Sufficient to get git to build and run.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>