### PR TITLE
Fix git9 build in the distribution.

### DIFF
--- a/build/mkdirs
+++ b/build/mkdirs
@@ -242,6 +242,7 @@ lst=( \
 	./sys/lib/dist/pc/glenda/bin/386 \
 	./sys/lib/dist/pc/glenda/tmp \
 	./sys/lib/dist/pc/multi \
+	./sys/lib/git \
 	./sys/lib/lp/log \
 	./sys/lib/lp/perm \
 	./sys/lib/lp/tmp \

--- a/dist/replica/plan9.proto
+++ b/dist/replica/plan9.proto
@@ -111,6 +111,8 @@ sys	d775 sys sys
 			+	d775 sys sys
 		ghostscript	d775 sys sys
 			+	d775 sys sys
+		git	d775 sys sys
+			+	d775 sys sys
 		kbmap	d775 sys sys
 			+	d775 sys sys
 		lex	d775 sys sys


### PR DESCRIPTION
Git was being compiled, but its script library was not included in the
distribution.

Add /sys/lib/git to mkdirs
Add /sys/lib/git to dist/replica/plan9.proto

[really just pipecleaning my git process here...]

Signed-off-by: Paul Lalonde <plalonde@acm.org>