### PR TITLE
Bind /sys/go/bin/plan9_$cputype into /bin

### DIFF
--- a/lib/namespace
+++ b/lib/namespace
@@ -25,6 +25,7 @@ mount -a /srv/factotum /mnt
 # standard bin
 bind /$cputype/bin /bin
 bind -a /rc/bin /bin
+bind -a /sys/go/bin/plan9_$cputype /bin
 
 # internal networks
 # mount -a /srv/ip /net


### PR DESCRIPTION
The system boots and this seems fine whether that
directory exists or not.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>