### PR TITLE
Add support for using u-root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 /go
+/bbin
 
 *.6
 *.8
 386/9*
-386/bin
+386/*bin
 386/init
 386/lib
 386/mbr
@@ -11,11 +12,11 @@
 9load
 acme/bin
 amd64/9*
-amd64/bin
+amd64/*bin
 amd64/init
 amd64/lib
 arm/9*
-arm/bin
+arm/*bin
 arm/init
 arm/lib
 arm/s9*

--- a/386/bbin/build.bash
+++ b/386/bbin/build.bash
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+echo "go version 1.17, makebb from github.com/u-root/gobusybox/src/cmds/makebb, latest u-root"
+GOOS=plan9 GOARCH=386 makebb -o bb \
+~/go/src/github.com/u-root/u-root/cmds/*/basename \
+~/go/src/github.com/u-root/u-root/cmds/*/cat \
+~/go/src/github.com/u-root/u-root/cmds/*/chmod \
+~/go/src/github.com/u-root/u-root/cmds/*/cmp \
+~/go/src/github.com/u-root/u-root/cmds/*/console \
+~/go/src/github.com/u-root/u-root/cmds/*/cp \
+~/go/src/github.com/u-root/u-root/cmds/*/cpio \
+~/go/src/github.com/u-root/u-root/cmds/*/date \
+~/go/src/github.com/u-root/u-root/cmds/*/dd \
+~/go/src/github.com/u-root/u-root/cmds/*/dirname \
+~/go/src/github.com/u-root/u-root/cmds/*/echo \
+~/go/src/github.com/u-root/u-root/cmds/*/false \
+~/go/src/github.com/u-root/u-root/cmds/*/find \
+~/go/src/github.com/u-root/u-root/cmds/*/gpgv \
+~/go/src/github.com/u-root/u-root/cmds/*/gpt \
+~/go/src/github.com/u-root/u-root/cmds/*/grep \
+~/go/src/github.com/u-root/u-root/cmds/*/gzip \
+~/go/src/github.com/u-root/u-root/cmds/*/hexdump \
+~/go/src/github.com/u-root/u-root/cmds/*/hostname \
+~/go/src/github.com/u-root/u-root/cmds/*/init \
+~/go/src/github.com/u-root/u-root/cmds/*/io \
+~/go/src/github.com/u-root/u-root/cmds/*/ls \
+~/go/src/github.com/u-root/u-root/cmds/*/mkdir \
+~/go/src/github.com/u-root/u-root/cmds/*/mv \
+~/go/src/github.com/u-root/u-root/cmds/*/ping \
+~/go/src/github.com/u-root/u-root/cmds/*/printenv \
+~/go/src/github.com/u-root/u-root/cmds/*/pwd \
+~/go/src/github.com/u-root/u-root/cmds/*/rm \
+~/go/src/github.com/u-root/u-root/cmds/*/rush \
+~/go/src/github.com/u-root/u-root/cmds/*/seq \
+~/go/src/github.com/u-root/u-root/cmds/*/sleep \
+~/go/src/github.com/u-root/u-root/cmds/*/sshd \
+~/go/src/github.com/u-root/u-root/cmds/*/tail \
+~/go/src/github.com/u-root/u-root/cmds/*/tee \
+~/go/src/github.com/u-root/u-root/cmds/*/truncate \
+~/go/src/github.com/u-root/u-root/cmds/*/wc \
+~/go/src/github.com/u-root/u-root/cmds/*/wget \
+~/go/src/github.com/u-root/u-root/cmds/*/which \
+~/go/src/github.com/rjkroege/edwood 

--- a/build/build.bash
+++ b/build/build.bash
@@ -4,26 +4,27 @@ set -e
 rm -f /tmp/image
 
 if [ $HARVEY_GOLANG"" == "" ]; then
-               echo Not including Go in the image
-       else
-	      mkdir -p ../sys/go
-              echo sudo mount --bind $HARVEY_GOLANG ../sys/go
-              sudo mount --bind $HARVEY_GOLANG ../sys/go
-              ls -l ../sys/go
-              function cleanup {
-                       echo unmounting sys/go
-                       sudo umount ../sys/go
-               }
-               trap cleanup EXIT
+    echo Not including Go in the image
+else
+    mkdir -p ../sys/go
+    echo sudo mount --bind $HARVEY_GOLANG ../sys/go
+    sudo mount --bind $HARVEY_GOLANG ../sys/go
+    ls -l ../sys/go
+    function cleanup {
+        echo unmounting sys/go
+        sudo umount ../sys/go
+    }
+    trap cleanup EXIT
 fi
 
 
 # Download Plan 9
 if [ ! -e 9legacy.iso ] && [ ! -e 9legacy.iso.bz2 ]; then
-  curl -L --fail -O https://github.com/Harvey-OS/harvey/releases/download/9legacy/9legacy.iso.bz2
+    curl -L --fail -O https://github.com/Harvey-OS/harvey/releases/download/9legacy/9legacy.iso.bz2
 fi
+
 if [ ! -e 9legacy.iso ]; then
-  bunzip2 -k 9legacy.iso.bz2
+    bunzip2 -k 9legacy.iso.bz2
 fi
 
 $(cd ..; bash ./build/mkdirs)

--- a/build/mkdirs
+++ b/build/mkdirs
@@ -258,6 +258,13 @@ lst=( \
 	./usr/glenda/bin/amd64 \
 	./usr/glenda/bin/mips \
 	./usr/glenda/tmp \
+	./bbin \
+	./amd64/bbin \
+	./386/bbin \
+	./arm64/bbin \
+	./arm/bbin \
+	./mips64/bbin \
+	./mips/bbin \
 )
 
 for i in "${lst[@]}"; do

--- a/lib/namespace
+++ b/lib/namespace
@@ -25,7 +25,15 @@ mount -a /srv/factotum /mnt
 # standard bin
 bind /$cputype/bin /bin
 bind -a /rc/bin /bin
+
+# golang
 bind -a /sys/go/bin/plan9_$cputype /bin
+
+# u-root
+# u-root assumes its binaries are in /bbin and uses
+# #! scripts for that purpose.
+bind /$cputype/bbin /bbin
+bind -a /$cputype/bbin /bin
 
 # internal networks
 # mount -a /srv/ip /net


### PR DESCRIPTION
u-root builds its busybox'ed binaries into one binary,
rewriting all commands into packages and compiling
them all at once. This process takes about 30s, end to end.

The construction is performed by the u-root command itself.
The commands need not be all u-root commands, e.g.
GO111MODULE=off GOOS=plan9 GOOS=386 u-root plan9 github.com/nsf/godit
will add the godit editor, for 386, using the plan9
template for u-root (which only adds commands
known to work on Plan 9).

In fact, u-root is happy to build images with zero u-root commands.
It's not picky.

On Plan 9, for each command, u-root creates a #! file, e.g.
for date:

This will run /bbin/bb with one argument, #!date.
The form of the second argument is carefully chosen
not to break the various shells and kernels in use.

This style of #! is tested and works across all Unix and
Plan 9 versions. For now, we continue to use the /bbin/bb
path. This requires two binds, which is less than ideal,
but I'd rather not change u-root itself just yet.

To incorporate a u-root image into harvey, for, e.g., 386:
GO111MODULE=off GOOS=plan9 GOARCH=386 u-root plan9
cd 386
cpio -iv < /tmp/initramfs.plan9_386.cpio

Will unpack the u-root commands into the harvey image, in bbin/

This change includes a small tweak to .gitignore to ignore
bbin directories and hence u-root binaries.

This is tested and working on my x230.

For some comparison on size:
There are, today, 40 u-root commands that run on Plan 9.
Some of them are not available on Plan9, e.g. sshd and gpt.
If we just consider the commands that are common, Plan 9
binaries are 1.134M, u-root combine into 5M.

So u-root is bigger, but at the same time, it will be bringing
in commands Plan 9 does not have. Further, there is a steep initial
size to u-root, but it grows slowly even as the number of commands doubles.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>