### PR TITLE
Introduce a slightly modified version of the 9legacy usb build script

### DIFF
--- a/build/build.bash
+++ b/build/build.bash
@@ -70,9 +70,9 @@ send "cd /n/harvey/build/scripts\n"
 expect -exact "term% "
 send "rc build && rc repl && rc usb\n"
 expect -exact "term% "
-send "ls -l /tmp/dist/\n"
-expect -exact "term% "
-send "time fcp /tmp/plan9-usb.img.bz2 /n/host/\n"
+send "ls -l /n/host/\n"
+#expect -exact "term% "
+#send "time fcp /tmp/plan9-usb.img.bz2 /n/host/\n"
 
 # build usb
 expect -exact "term% "

--- a/build/build.bash
+++ b/build/build.bash
@@ -66,15 +66,13 @@ send "srv -c tcp!10.0.2.2!5640 host /n/host\n"
 expect -exact "term% "
 send "cd /n/harvey/build/scripts\n"
 
-# build iso
+# build usb first
 expect -exact "term% "
 send "rc build && rc repl && rc usb\n"
 expect -exact "term% "
 send "ls -l /n/host/\n"
-#expect -exact "term% "
-#send "time fcp /tmp/plan9-usb.img.bz2 /n/host/\n"
 
-# build usb
+# build iso
 expect -exact "term% "
 send "rm -r /tmp/dist/plan9-usb.*\n"
 expect -exact "term% "

--- a/build/build.bash
+++ b/build/build.bash
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-rm -f /tmp/image
-
 if [ $HARVEY_GOLANG"" == "" ]; then
                echo Not including Go in the image
        else

--- a/build/build.bash
+++ b/build/build.bash
@@ -55,27 +55,36 @@ set timeout 2400
 expect -exact "term% "
 send "ramfs -u -m /n/harvey\n"
 expect -exact "term% "
+send "ramfs -u -m /tmp\n"
+expect -exact "term% "
 send "cd /n/harvey\n"
 expect -exact "term% "
 send "gunzip < /dev/sdC0/data | tar x\n"
 
+expect -exact "term% "
+send "srv -c tcp!10.0.2.2!5640 host /n/host\n"
+
 # Go to the build dir
 expect -exact "term% "
 send "cd /n/harvey/build/scripts\n"
-expect -exact "term% "
-send "rc build && rc repl && rc iso\n"
 
-# and shut down
+# build iso
+expect -exact "term% "
+send "rc build && rc repl && rc usb\n"
 expect -exact "term% "
 send "ls -l /tmp/dist/\n"
 expect -exact "term% "
-send "srv -c tcp!10.0.2.2!5640 host /n/host\n"
+send "time fcp /tmp/plan9-usb.img.bz2 /n/host/\n"
+
+# build usb
+expect -exact "term% "
+send "rm -r /tmp/dist/plan9-usb.*\n"
+expect -exact "term% "
+send "rc iso\n"
 expect -exact "term% "
 send "time fcp /tmp/dist/plan9-new.iso.bz2 /n/host/\n"
-expect -exact "term% "
-send "cd /n/host\n"
-expect -exact "term% "
-send "mkusbboot -r /n/harvey -p /sys/lib/sysconfig/proto/allproto -s 2048\n"
+
+# and shut down
 expect -exact "term% "
 send "fshalt\n"
 expect -exact "done halting"

--- a/build/scripts/funcs
+++ b/build/scripts/funcs
@@ -50,6 +50,8 @@ fn buildinit {
 		dir=/n/harvey/build
 		path=(/bin $dir .)
 
+		outputdir=/n/host
+
 		rdev=/dev/sdD0
 
 		buildinitdone=yes

--- a/build/scripts/usb
+++ b/build/scripts/usb
@@ -1,0 +1,106 @@
+#!/bin/rc
+
+rfork en
+
+. funcs
+
+if (test -e /srv/fossil -o -e /srv/fossil.open) {
+	echo $0: /srv/fossil* exists, not safe to start a new one >[1=2]
+	exit fossil-already-running
+}
+
+sd=sdXX
+dev=/dev/$sd
+target=plan9-usb
+disk=/tmp/$target.img
+#gb=1024*1024*1024
+#size=$gb^*1
+size=131072
+
+data=$dev/data
+plan9=$dev/plan9
+9fat=$dev/9fat
+fossil=$dev/fossil
+
+{
+	echo [menu]
+	echo menuitem'='cpu, Plan 9 CPU Kernel
+	echo menuitem'='terminal, Plan 9 Terminal Kernel
+	echo menuitem'='manual, Manual
+	echo menudefault'='terminal, 10
+	echo
+	echo [cpu]
+	echo bootfile'='sdB0!9fat!9pccpuf
+	echo
+	echo [terminal]
+	echo bootfile'='sdB0!9fat!9pcf
+	echo
+	echo [manual]
+	echo
+	echo [common]
+	echo nobootprompt'='local!$dev/fossil
+	echo
+	echo nvram'='$dev/nvram
+	echo debugboot'='1
+	echo *nodumpstack'='1
+	echo *noe820print'='1
+	echo *nomp'='1
+	echo
+	echo mouseport'='ask
+	echo monitor'='ask
+	echo vgasize'='ask
+	echo user'='glenda
+} > /tmp/plan9.ini
+
+#dd -if /dev/zero -of $disk -bs 1 -seek $size -count 1
+dd -if /dev/zero -of $disk -bs 8192 -count $size
+chmod +t $disk
+disk/partfs $disk
+
+cp $build/386/9loadusb /tmp/9load
+
+disk/mbr -m $build/386/mbr $data
+disk/fdisk -baw $data
+disk/prep -bw -a^(9fat nvram fscfg fossil) $plan9
+disk/format -b /386/pbslba -d -r 2 $9fat /tmp/9load $build/386/9pcf $build/386/9pccpuf /tmp/plan9.ini
+
+rm /tmp/9load
+rm /tmp/plan9.ini
+
+fossil/flfmt -y $fossil
+
+{
+	echo fsys main config
+	echo fsys main open -Va -c 32768
+	echo srv fossil
+	echo srv -APW fossil.open
+	echo srv -Ap fscons.open
+	echo fsys main
+} | fossil/conf -w $fossil
+
+fossil/fossil -f $fossil
+
+bind /n/harvey /n/dist
+mount -c /srv/fossil.open /n/newfs
+
+echo fsys main create /active/adm adm sys d775 >>/srv/fscons.open
+echo fsys main create /active/adm/users adm sys 664 >>/srv/fscons.open
+echo uname upas :upas >>/srv/fscons.open
+echo users -w >>/srv/fscons.open
+for(i in dist dist/replica dist/replica/client)
+	echo fsys main create /active/$i sys sys d775 >>/srv/fscons.open
+echo fsys main create /active/dist/replica/client/plan9.db sys sys 664 >>/srv/fscons.open
+echo fsys main create /active/dist/replica/client/plan9.log sys sys a664 >>/srv/fscons.open
+replica/pull /sys/lib/dist/pc/inst/replcfg
+
+unmount /n/newfs
+sleep 8
+echo fsys all sync >>/srv/fscons.open
+sleep 8
+echo fsys all halt >>/srv/fscons.open
+sleep 8
+rm -f /srv/^(fossil fossil.open fscons fscons.open)
+sleep 8
+kill fossil2 | rc
+
+bzip2 -c9 $disk > $disk.bz2 && rm $disk

--- a/build/scripts/usb
+++ b/build/scripts/usb
@@ -12,7 +12,7 @@ if (test -e /srv/fossil -o -e /srv/fossil.open) {
 sd=sdXX
 dev=/dev/$sd
 target=plan9-usb
-disk=/tmp/$target.img
+disk=$outputdir^/$target.img
 #gb=1024*1024*1024
 #size=$gb^*1
 size=131072
@@ -103,4 +103,4 @@ rm -f /srv/^(fossil fossil.open fscons fscons.open)
 sleep 8
 kill fossil2 | rc
 
-bzip2 -c9 $disk > $disk.bz2 && rm $disk
+#bzip2 -c9 $disk > $disk.bz2 && rm $disk


### PR DESCRIPTION
instead of using mkusbboot.

I'd appreciate if a few people tested this. Running build.bash should now generate both the ISO and the USB image.