### PR TITLE
Allow for more Go commands

### DIFF
--- a/sys/src/cmd/go/commands
+++ b/sys/src/cmd/go/commands
@@ -1,1 +1,3 @@
-git://github.com/Harvey-OS/edwood.git edwood
+edwood git://github.com/Harvey-OS/edwood.git edwood
+tools/gopls git://github.com/golang/tools.git tools
+tools/cmd/goimports ... 

--- a/sys/src/cmd/go/fetchrepos.rc
+++ b/sys/src/cmd/go/fetchrepos.rc
@@ -1,5 +1,6 @@
 #!/bin/rc
-cat commands | while (line=`{read}) {
+# TODO: fix this to match fetch.sh
+grep git: commands | while (line=`{read}) {
 	echo git/clone $line
 	git/clone $line
 }

--- a/sys/src/cmd/go/fetchrepos.sh
+++ b/sys/src/cmd/go/fetchrepos.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
-while read line
+grep git: commands | while read line
 do
-	dest=`echo $line | awk '{print $2}'`
+	dest=`echo $line | awk '{print $3}'`
+	cmd=`echo $line | awk '{print $2 " " $3}'`
 	if [ ! -e $dest ]
 	then
-		echo git clone --depth 1 $line
-		git clone --depth 1 $line
+		echo git clone --depth 1 $cmd
+		git clone --depth 1 $cmd
 	fi
-done < commands
+done

--- a/sys/src/cmd/go/mkfile
+++ b/sys/src/cmd/go/mkfile
@@ -2,7 +2,7 @@
 #
 #		programs
 #
-DIRS=`{cat commands | awk '{print $2}'}
+DIRS=`{cat commands | awk '{print $1}'}
 
 #</sys/src/cmd/mkmany
 
@@ -29,8 +29,7 @@ installdirs:V:
 			echo INSTALL $i
 			ls $i
 			cd $i
-			GOARCH=$objtype go build
-			cp $i /$objtype/bin/	
+			GOARCH=$objtype go build -o /$objtype/bin/ .
 		}
 	}
 	if not {


### PR DESCRIPTION
The format of the command file changes slightly.
The first field is the directory to cd into to build the command.
The rest are the git URL and directory name as before.

Some URLs comtain many commants.
Only commands with a URL are used in the fetch.
Lines like this:
name ...
are not used in a fetch, only a build.

To simplify the build step, use build -o /$objtype/bin/
instead of go install, so even names of the form a/b/c
will work easily.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>