### PR TITLE
WIP: change rdmsr to be safe

### DIFF
--- a/sys/src/9/pc/l.s
+++ b/sys/src/9/pc/l.s
@@ -671,9 +671,19 @@ TEXT lcycles(SB),1,$0
 	RDTSC
 	RET
 
+// WIP: if the rdmsr fails, then return all -1
+// TODO: change type signature of rdmsr
 TEXT rdmsr(SB), $0				/* model-specific register */
 	MOVL	index+0(FP), CX
+TEXT rdmsr_doit(SB), $0
 	RDMSR
+TEXT rdmsr_ok(SB), $0
+	JMP 1f
+TEXT rdmsr_bad(SB), $0
+	MOVL    $0xffffffff, AX
+	MOVL	AX, DX
+
+1:
 	MOVL	vlong+4(FP), CX			/* &vlong */
 	MOVL	AX, 0(CX)			/* lo */
 	MOVL	DX, 4(CX)			/* hi */

--- a/sys/src/9/pc/trap.c
+++ b/sys/src/9/pc/trap.c
@@ -221,6 +221,7 @@ trapinit(void)
 	 */
 	trapenable(VectorBPT, debugbpt, 0, "debugpt");
 	trapenable(VectorPF, fault386, 0, "fault386");
+	trapenable(VectorGPF, faultgpf, 0, "faultgpf");
 	trapenable(Vector2F, doublefault, 0, "doublefault");
 	trapenable(Vector15, unexpected, 0, "unexpected");
 	nmienable();
@@ -608,6 +609,21 @@ unexpected(Ureg* ureg, void*)
 
 extern void checkpages(void);
 extern void checkfault(ulong, ulong);
+
+static void
+faultgpf(Ureg* ureg, void*)
+{
+	switch (ureg->pc) {
+		case rdmsr_doit:
+			ureg->pc = rdmsr_bad;
+			break;
+		default:
+			panic("GPF with no handler at addr=0x%.8lux", ureg->pc);
+			break;
+	}
+}
+
+// This is a page fault handler for both kernel and user.
 static void
 fault386(Ureg* ureg, void*)
 {


### PR DESCRIPTION
Add labels in rdmsr to indicate which path to take on a failure.

Add GPF handler.

In GPF handler, switch on ureg->pc value, and if an address is handled,
fix uref->pc.

This is basically what is done in linux, minus all the fancy ELF and
linker set machinations. It will work just fine.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>