### PR TITLE
rdmsr: minor tweaks.

### DIFF
--- a/sys/src/9/pc/l.s
+++ b/sys/src/9/pc/l.s
@@ -675,19 +675,17 @@ TEXT lcycles(SB),1,$0
 // TODO: change type signature of rdmsr
 TEXT rdmsr(SB), $0				/* model-specific register */
 	MOVL	index+0(FP), CX
-TEXT rdmsr_doit(SB), $0
+TEXT mayberdmsr(SB), $0
 	RDMSR
-TEXT rdmsr_ok(SB), $0
-	JMP 1f
-TEXT rdmsr_bad(SB), $0
-	MOVL    $0xffffffff, AX
-	MOVL	AX, DX
-
 1:
 	MOVL	vlong+4(FP), CX			/* &vlong */
 	MOVL	AX, 0(CX)			/* lo */
 	MOVL	DX, 4(CX)			/* hi */
 	RET
+TEXT rdmsrfail(SB), $0
+	MOVL    $0xffffffff, AX
+	MOVL	AX, DX
+	JMP	1b
 	
 TEXT wrmsr(SB), $0
 	MOVL	index+0(FP), CX

--- a/sys/src/9/pc/trap.c
+++ b/sys/src/9/pc/trap.c
@@ -193,7 +193,6 @@ trapinit0(void)
 	for(v = 0; v < 256; v++){
 		d1 = (vaddr & 0xFFFF0000)|SEGP;
 		switch(v){
-
 		case VectorBPT:
 			d1 |= SEGPL(3)|SEGIG;
 			break;
@@ -609,17 +608,19 @@ unexpected(Ureg* ureg, void*)
 
 extern void checkpages(void);
 extern void checkfault(ulong, ulong);
+extern void mayberdmsr(void);
+extern void rdmsrfail(void);
 
 static void
 faultgpf(Ureg* ureg, void*)
 {
-	switch (ureg->pc) {
-		case rdmsr_doit:
-			ureg->pc = rdmsr_bad;
-			break;
-		default:
-			panic("GPF with no handler at addr=0x%.8lux", ureg->pc);
-			break;
+	switch(ureg->pc){
+	case mayberdmsr:
+		ureg->pc = rdmsrfail;
+		break;
+	default:
+		panic("GPF with no handler at addr=0x%.8lux", ureg->pc);
+		break;
 	}
 }
 


### PR DESCRIPTION
0. Names.
1. Plan 9 formatting in the switch in trap.c
2. Add declarations for `mayberdmsr` and `rdmsrfail`
3. Assembly language tweaks

Signed-off-by: Dan Cross <cross@gajendra.net>