### PR TITLE
Fixed rdmsr.

### DIFF
--- a/sys/src/9/pc/fns.h
+++ b/sys/src/9/pc/fns.h
@@ -158,7 +158,7 @@ void	putcr0(ulong);
 void	putcr3(ulong);
 void	putcr4(ulong);
 void*	rampage(void);
-void	rdmsr(int, vlong*);
+int	rdmsr(int, vlong*);
 void	realmode(Ureg*);
 void	screeninit(void);
 void	(*screenputs)(char*, int);

--- a/sys/src/9/pc/io.h
+++ b/sys/src/9/pc/io.h
@@ -10,6 +10,7 @@ enum {
 	VectorCNA	= 7,		/* coprocessor not available */
 	Vector2F	= 8,		/* double fault */
 	VectorCSO	= 9,		/* coprocessor segment overrun */
+	VectorGPF	= 13,		/* General protection fault */
 	VectorPF	= 14,		/* page fault */
 	Vector15	= 15,		/* reserved */
 	VectorCERR	= 16,		/* coprocessor error */

--- a/sys/src/9/pc/l.s
+++ b/sys/src/9/pc/l.s
@@ -671,21 +671,19 @@ TEXT lcycles(SB),1,$0
 	RDTSC
 	RET
 
-// WIP: if the rdmsr fails, then return all -1
-// TODO: change type signature of rdmsr
 TEXT rdmsr(SB), $0				/* model-specific register */
 	MOVL	index+0(FP), CX
 TEXT mayberdmsr(SB), $0
 	RDMSR
-1:
+_rdmsrret:
 	MOVL	vlong+4(FP), CX			/* &vlong */
 	MOVL	AX, 0(CX)			/* lo */
 	MOVL	DX, 4(CX)			/* hi */
 	RET
 TEXT rdmsrfail(SB), $0
-	MOVL    $0xffffffff, AX
+	MOVL	$0xffffffff, AX
 	MOVL	AX, DX
-	JMP	1b
+	JMP		_rdmsrret
 	
 TEXT wrmsr(SB), $0
 	MOVL	index+0(FP), CX

--- a/sys/src/9k/k10/l64v.s
+++ b/sys/src/9k/k10/l64v.s
@@ -175,11 +175,17 @@ TEXT rdtsc(SB), 1, $-4				/* Time Stamp Counter */
 
 TEXT rdmsr(SB), 1, $-4				/* Model-Specific Register */
 	MOVL	RARG, CX
+TEXT mayberdmsr(SB), 0, $-4
 	RDMSR
+_rdmsrret:
 	XCHGL	DX, AX				/* swap lo/hi, zero-extend */
 	SHLQ	$32, AX				/* hi<<32 */
 	ORQ	DX, AX				/* (hi<<32)|lo */
 	RET
+TEXT rdmsrfail(SB), 0, $-4
+	MOVL	$0xffffffff, AX
+	MOVL	AX, DX
+	JMP		_rdmsrret
 
 TEXT wrmsr(SB), 1, $-4
 	MOVL	RARG, CX


### PR DESCRIPTION
Our assembler doesn't understand number labels
and the 'f' and 'b' syntax.  Case labels in a
switch must refer to compile-time constants.

Signed-off-by: Dan Cross <cross@gajendra.net>