### PR TITLE
etherif.h: Extend MaxEther to 64.

### DIFF
--- a/sys/src/9/pc/etherif.h
+++ b/sys/src/9/pc/etherif.h
@@ -1,5 +1,5 @@
 enum {
-	MaxEther	= 48,
+	MaxEther	= 64,
 	Ntypes		= 8,
 };
 


### PR DESCRIPTION
This isn't the max number of ethernet cards supported
on a particular system, but how many can be linked into
the kernel.

The new 82563 driver expanded this number significantly.

Signed-off-by: Dan Cross <cross@gajendra.net>