### PR TITLE
remove mistaken include from 9 kernel

### DIFF
--- a/sys/src/9/port/page.c
+++ b/sys/src/9/port/page.c
@@ -1,7 +1,6 @@
 #include	"u.h"
 #include	"../port/lib.h"
 #include	"mem.h"
-#include	"../port/portdat.h"
 #include	"dat.h"
 #include	"fns.h"
 #include	"../port/error.h"


### PR DESCRIPTION
Signed-off-by: John Floren <john@jfloren.net>