### PR TITLE
devtls: fix bwrite memory leak when channel stops being open

### DIFF
--- a/sys/src/9/port/devtls.c
+++ b/sys/src/9/port/devtls.c
@@ -1254,6 +1254,8 @@ tlsrecwrite(TlsRec *tr, int type, Block *b)
 if(tr->debug)pprint("send %ld\n", BLEN(b));
 if(tr->debug)pdump(BLEN(b), b->rp, "sent:");
 
+	if(type == RApplication)
+		checkstate(tr, 0, SOpen);
 
 	ok = SHandshake|SOpen|SRClose;
 	if(type == RAlert)
@@ -1371,7 +1373,6 @@ tlsbwrite(Chan *c, Block *b, ulong offset)
 		tr->handout += n;
 		break;
 	case Qdata:
-		checkstate(tr, 0, SOpen);
 		tlsrecwrite(tr, RApplication, b);
 		tr->dataout += n;
 		break;


### PR DESCRIPTION
tlsbwrite() would call checkstate() before calling tlsrecwrite()
to make sure the channel is open. however, because checkstate()
only raises the error, the Block* passed wont be freed and
would result in a memory leak.

move the checkstate() call inside tlsrecwrite() to reuse the
error handling that frees the block on error.

[Authored by Cinap for 9front; DCO ok for Harvey by cross@:
9front uses the MIT license for all changes unless otherwise
noted: http://fqa.9front.org/fqa0.html#0.2.4.4]

Signed-off-by: Dan Cross <cross@gajendra.net>