### PR TITLE
Allow building 6l on unix

### DIFF
--- a/sys/src/cmd/6l/BUILD
+++ b/sys/src/cmd/6l/BUILD
@@ -1,0 +1,16 @@
+#!/bin/sh
+mkdir -p ../../../../linux_amd64/bin
+9c -Wno-char-subscripts -g -I .  asm.c list.c obj.c optab.c pass.c span.c unixcompat.c ../6c/enam.c ../ld/elf.c
+
+9l -o 6l \
+asm.o \
+enam.o \
+elf.o \
+list.o \
+obj.o \
+optab.o \
+pass.o \
+span.o \
+unixcompat.o 
+
+cp 6l ../../../../linux_amd64/bin

--- a/sys/src/cmd/6l/unixcompat.c
+++ b/sys/src/cmd/6l/unixcompat.c
@@ -1,0 +1,67 @@
+#include	"l.h"
+
+/*
+ * fake malloc
+ */
+void*
+malloc(ulong n)
+{
+	void *p;
+
+	while(n & 7)
+		n++;
+	while(nhunk < n)
+		gethunk();
+	p = hunk;
+	nhunk -= n;
+	hunk += n;
+	return p;
+}
+
+void
+free(void *p)
+{
+	USED(p);
+}
+
+void*
+calloc(ulong m, ulong n)
+{
+	void *p;
+
+	n *= m;
+	p = malloc(n);
+	memset(p, 0, n);
+	return p;
+}
+
+void*
+realloc(void*_, ulong __)
+{
+	fprint(2, "realloc called\n");
+	abort();
+	return 0;
+}
+
+void*
+mysbrk(ulong size)
+{
+	return sbrk(size);
+}
+
+void
+setmalloctag(void *v, ulong pc)
+{
+	USED(v);
+	USED(pc);
+}
+
+int
+fileexists(char *s)
+{
+	uchar dirbuf[400];
+	int stat(const char *pathname, void *_/*struct stat *statbuf*/);
+
+	/* it's fine if stat result doesn't fit in dirbuf, since even then the file exists */
+	return stat(s, dirbuf) >= 0;
+}


### PR DESCRIPTION
This is the first in a series of scripts that will let us build the toolchain on linux.

Adapted from NxM, but better: it's just two files for 6l, and it's buildable right in the tree.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>