### PR TITLE
Double size of literal string in linkers

### DIFF
--- a/sys/src/cmd/4l/l.h
+++ b/sys/src/cmd/4l/l.h
@@ -226,7 +226,7 @@ EXTERN	char	inuxi4[4];
 EXTERN	char	inuxi8[8];
 EXTERN	Prog*	lastp;
 EXTERN	long	lcsize;
-EXTERN	char	literal[32];
+EXTERN	char	literal[64];
 EXTERN	int	nerrors;
 EXTERN	long	nhunk;
 EXTERN	vlong	instoffset;

--- a/sys/src/cmd/5l/l.h
+++ b/sys/src/cmd/5l/l.h
@@ -259,7 +259,7 @@ EXTERN	char	inuxi2[2];
 EXTERN	char	inuxi4[4];
 EXTERN	Prog*	lastp;
 EXTERN	long	lcsize;
-EXTERN	char	literal[32];
+EXTERN	char	literal[64];
 EXTERN	int	nerrors;
 EXTERN	long	nhunk;
 EXTERN	long	instoffset;

--- a/sys/src/cmd/6l/l.h
+++ b/sys/src/cmd/6l/l.h
@@ -293,7 +293,7 @@ EXTERN	Prog*	datap;
 EXTERN	Prog*	edatap;
 EXTERN	vlong	datsize;
 EXTERN	char	debug[128];
-EXTERN	char	literal[32];
+EXTERN	char	literal[64];
 EXTERN	Prog*	etextp;
 EXTERN	Prog*	firstp;
 EXTERN	uchar	fnuxi8[8];

--- a/sys/src/cmd/8l/l.h
+++ b/sys/src/cmd/8l/l.h
@@ -234,7 +234,7 @@ EXTERN	Prog*	datap;
 EXTERN	Prog*	edatap;
 EXTERN	long	datsize;
 EXTERN	char	debug[128];
-EXTERN	char	literal[32];
+EXTERN	char	literal[64];
 EXTERN	Prog*	etextp;
 EXTERN	Prog*	firstp;
 EXTERN	char	fnuxi8[8];

--- a/sys/src/cmd/9l/l.h
+++ b/sys/src/cmd/9l/l.h
@@ -227,7 +227,7 @@ EXTERN	uchar	inuxi4[4];
 EXTERN	uchar	inuxi8[8];
 EXTERN	Prog*	lastp;
 EXTERN	long	lcsize;
-EXTERN	char	literal[32];
+EXTERN	char	literal[64];
 EXTERN	int	nerrors;
 EXTERN	long	nhunk;
 EXTERN	char*	noname;

--- a/sys/src/cmd/il/l.h
+++ b/sys/src/cmd/il/l.h
@@ -236,7 +236,7 @@ EXTERN	char	inuxi4[4];
 EXTERN	char	inuxi8[8];
 EXTERN	Prog*	lastp;
 EXTERN	long	lcsize;
-EXTERN	char	literal[32];
+EXTERN	char	literal[64];
 EXTERN	int	nerrors;
 EXTERN	long	nhunk;
 EXTERN	Prog	nopalign;

--- a/sys/src/cmd/kl/l.h
+++ b/sys/src/cmd/kl/l.h
@@ -231,7 +231,7 @@ EXTERN	char	inuxi2[2];
 EXTERN	char	inuxi4[4];
 EXTERN	Prog*	lastp;
 EXTERN	long	lcsize;
-EXTERN	char	literal[32];
+EXTERN	char	literal[64];
 EXTERN	int	nerrors;
 EXTERN	long	nhunk;
 EXTERN	char*	noname;

--- a/sys/src/cmd/ql/l.h
+++ b/sys/src/cmd/ql/l.h
@@ -225,7 +225,7 @@ EXTERN	char	inuxi2[2];
 EXTERN	char	inuxi4[4];
 EXTERN	Prog*	lastp;
 EXTERN	long	lcsize;
-EXTERN	char	literal[32];
+EXTERN	char	literal[64];
 EXTERN	int	nerrors;
 EXTERN	long	nhunk;
 EXTERN	char*	noname;

--- a/sys/src/cmd/vl/l.h
+++ b/sys/src/cmd/vl/l.h
@@ -224,7 +224,7 @@ EXTERN	char	inuxi2[2];
 EXTERN	char	inuxi4[4];
 EXTERN	Prog*	lastp;
 EXTERN	long	lcsize;
-EXTERN	char	literal[32];
+EXTERN	char	literal[64];
 EXTERN	int	nerrors;
 EXTERN	long	nhunk;
 EXTERN	long	instoffset;


### PR DESCRIPTION
This fixes a problem seen when building clock.c with 8l.  Sometimes the literal would be 32 chars - not leaving enough space for the null.  So let's just increase to 64 and be consistent across all linkers

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>