### PR TITLE
Set up Dockerfile to optionally build from local folder

### DIFF
--- a/build/BUILD_IN_DOCKER
+++ b/build/BUILD_IN_DOCKER
@@ -1,31 +1,50 @@
 #!/bin/bash
 
-export HARVEY=/usr/local/harvey
-export HARVEY_LINUX_BIN=/usr/local/harvey_linux/bin
+# We can build with docker, using the a local repo by binding the local
+# directory to $HARVEY_LOCAL.  This will then be copied to $HARVEY.
+# If $HARVEY_LOCAL doesn't exist, we'll clone the harvey repo to $HARVEY.
+HARVEY_LOCAL=/usr/local/harvey_local
+if [ -d $HARVEY_LOCAL ]
+then
+        echo "Copying $HARVEY_LOCAL -> $HARVEY"
+        mkdir -p $HARVEY
+        time cp -R $HARVEY_LOCAL/* $HARVEY/
+else
+        # Clone harvey (shallow for a little speed)
+        echo "Cloning https://github.com/$HARVEY_OWNER/$HARVEY_REPO.git branch $HARVEY_BRANCH -> $HARVEY"
+        HARVEY_OWNER=Harvey-OS
+        HARVEY_REPO=harvey
+        HARVEY_BRANCH=main
+        git clone --depth 1 --single-branch --branch $HARVEY_BRANCH https://github.com/$HARVEY_OWNER/$HARVEY_REPO.git $HARVEY
+fi
 
-mkdir -p $HARVEY_LINUX_BIN
+########################################################################
+# Copy/build toolchains for linux host
+# TODO true->size is a hack to make size not fail when building - best to remove this sometime
+# TODO need to make our bind script handle binds of single files
+cp /bin/true $HARVEY_LINUX_BIN/size
+cp $NINECC/src/cmd/iar/o.out $HARVEY_LINUX_BIN/ar
+cp $PLAN9/bin/{sed,yacc,lex,awk,date,dd,rm,basename,ls} $HARVEY_LINUX_BIN
+cp $HARVEY/build/bind /bin
 
-# Build toolchain
 # TODO Merge cmd/BUILD and BUILDTOOLCHAIN?
-bash $HARVEY/sys/src/BUILDTOOLCHAIN
-# cpp was build in the BUILDTOOLCHAIN script.
-# We need to copy cpp to /bin because pcc execs /bin/cpp.
+(cd $HARVEY/sys/src && bash BUILDTOOLCHAIN)
+# cpp was built by BUILDTOOLCHAIN - we need to copy to /bin because pcc execs /bin/cpp
 cp $HARVEY_LINUX_BIN/cpp /bin
 # build pcc
-bash $HARVEY/sys/src/cmd/BUILD
+(cd $HARVEY/sys/src/cmd && bash BUILD)
 
 # Modify some mkfiles to handle binaries in subfolders
 # TODO not sure if this is great, since it'll alter the mkfiles in the image - maybe undo after?
 sed -i 's/aux\/mklatinkbd/mklatinkbd/' $HARVEY/sys/src/9/port/portmkfile $HARVEY/sys/src/9k/mk/portmkfile
 sed -i 's/aux\/data2s/data2s/' $HARVEY/sys/src/9/port/{mkroot,mkrootall} $HARVEY/sys/src/9k/mk/{mkroot,mkrootall}
 
-# TODO need to make our bind script handle binds of single files
-cp $HARVEY/build/bind /bin
-
-# Is this correct?
 export USER=root
-export PATH="${PATH}:/rc/bin"
+export PATH="${HARVEY_LINUX_BIN}:${PATH}:/rc/bin:."
+export objtype=amd64
+export cputype=unix
+export FORCERCFORMK=1
+export CGO_ENABLED=0
 
-cd $HARVEY/sys/src
-#bash RUN_BUILD_IN_PRIVATE_NAMESPACE
-bash
+(cd $HARVEY/sys/src && bash RUN_BUILD_IN_PRIVATE_NAMESPACE)
+#(cd $HARVEY/sys/src && bash)

--- a/build/BUILD_IN_DOCKER
+++ b/build/BUILD_IN_DOCKER
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+export HARVEY=/usr/local/harvey
+export HARVEY_LINUX_BIN=/usr/local/harvey_linux/bin
+
+mkdir -p $HARVEY_LINUX_BIN
+
+# Build toolchain
+# TODO Merge cmd/BUILD and BUILDTOOLCHAIN?
+bash $HARVEY/sys/src/BUILDTOOLCHAIN
+# cpp was build in the BUILDTOOLCHAIN script.
+# We need to copy cpp to /bin because pcc execs /bin/cpp.
+cp $HARVEY_LINUX_BIN/cpp /bin
+# build pcc
+bash $HARVEY/sys/src/cmd/BUILD
+
+# Modify some mkfiles to handle binaries in subfolders
+# TODO not sure if this is great, since it'll alter the mkfiles in the image - maybe undo after?
+sed -i 's/aux\/mklatinkbd/mklatinkbd/' $HARVEY/sys/src/9/port/portmkfile $HARVEY/sys/src/9k/mk/portmkfile
+sed -i 's/aux\/data2s/data2s/' $HARVEY/sys/src/9/port/{mkroot,mkrootall} $HARVEY/sys/src/9k/mk/{mkroot,mkrootall}
+
+# TODO need to make our bind script handle binds of single files
+cp $HARVEY/build/bind /bin
+
+# Is this correct?
+export USER=root
+export PATH="${PATH}:/rc/bin"
+
+cd $HARVEY/sys/src
+#bash RUN_BUILD_IN_PRIVATE_NAMESPACE
+bash

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,10 +1,15 @@
+# First build the container:
 # docker build -t harvey:Dockerfile .
 # (or:
 #   docker build --progress=plain -t harvey:Dockerfile .
 #  if you want to see the output from commands (useful for debugging build))
-# docker run --rm -it --cap-add SYS_ADMIN --privileged harvey:Dockerfile
+#
+# Now run container to build.
+# If you want to build from the repo (i.e. for CI), run:
+#   docker run --rm -it --cap-add SYS_ADMIN --privileged harvey:Dockerfile
+# If you want to build from a local folder (e.g. the current directoy), run:
+#   docker run --rm -it --mount type=bind,source="$(pwd)"/..,target=/usr/local/harvey_local,readonly --cap-add SYS_ADMIN --privileged harvey:Dockerfile
 
-# TODO probably need to pass in aarch64 as an env var
 # TODO mahjonng doesn't build becuase of problems with cpp - fix cpp!
 
 FROM ubuntu:21.10
@@ -12,6 +17,10 @@ FROM ubuntu:21.10
 RUN apt-get -y update
 RUN apt-get -y upgrade
 RUN apt-get install -y build-essential git sudo
+
+ENV HARVEY=/usr/local/harvey
+ENV HARVEY_LINUX_BIN=/usr/local/harvey_linux/bin
+RUN mkdir -p $HARVEY_LINUX_BIN
 
 
 ########################################################################
@@ -69,74 +78,9 @@ RUN if [ `uname -p` = "aarch64" ]; then \
   fi
 
 RUN mk
-# We'll copy the ar binary into the harvey bin folder once it exists
+RUN cp ${NINECC}/src/cmd/iar/o.out $HARVEY_LINUX_BIN/ar
 
+#TEMP!
+COPY BUILD_IN_DOCKER /usr/local/
 
-########################################################################
-# Fetch latest harvey (using cache if possible)
-# TODO Populate these args from CI
-ARG HARVEY_OWNER=Harvey-OS
-ARG HARVEY_REPO=harvey
-ARG HARVEY_BRANCH=main
-ADD https://api.github.com/repos/$HARVEY_OWNER/$HARVEY_REPO/git/refs/heads/$HARVEY_BRANCH version.json
-RUN cd /usr/local \
-    && git clone -b $HARVEY_BRANCH https://github.com/$HARVEY_OWNER/$HARVEY_REPO.git
-
-
-########################################################################
-# Build toolchains for linux host
-# (true->size is a hack to make size not fail when building - best to remove this sometime)
-WORKDIR /usr/local/harvey/sys/src
-
-RUN pwd
-RUN ls /usr/local/harvey
-
-
-RUN if [ `uname -p` = "aarch64" ]; then \
-    sed -i 's/linux_amd64/linux_arm64/' \
-        BUILD cmd/BUILD cmd/6a/BUILD cmd/6c/BUILD cmd/6l/BUILD \
-        cmd/8a/BUILD cmd/8c/BUILD cmd/8l/BUILD cmd/cpp/BUILD cmd/aux/BUILD && \
-    mkdir -p /usr/local/harvey/linux_arm64/bin && \
-    cp /bin/true /usr/local/harvey/linux_arm64/bin/size && \
-    cp ${NINECC}/src/cmd/iar/o.out /usr/local/harvey/linux_arm64/bin/ar && \
-    cd ${PLAN9}/bin && \
-    cp sed yacc lex awk date dd rm basename ls /usr/local/harvey/linux_arm64/bin; \
-  else \
-    mkdir -p /usr/local/harvey/linux_amd64/bin && \
-    cp ${NINECC}/src/cmd/iar/o.out /usr/local/harvey/linux_amd64/bin/ar && \
-    cp /bin/true /usr/local/harvey/linux_amd64/bin/size && \
-    cd ${PLAN9}/bin && \
-    cp sed yacc lex awk date dd rm basename ls /usr/local/harvey/linux_amd64/bin; \
-  fi
-
-RUN bash BUILDTOOLCHAIN
-
-# cpp was build in the BUILDTOOLCHAIN script.
-# We need to copy cpp to /bin because pcc execs /bin/cpp.
-RUN if [ `uname -p` = "aarch64" ]; then \
-    cp /usr/local/harvey/linux_arm64/bin/cpp /bin; \
-  else \
-    cp /usr/local/harvey/linux_amd64/bin/cpp /bin; \
-  fi
-
-WORKDIR /usr/local/harvey/sys/src/cmd
-RUN bash BUILD
-
-# Modify some mkfiles to handle binaries in subfolders
-# TODO not sure if this is great, since it'll alter the mkfiles in the image
-WORKDIR /usr/local/harvey
-RUN sed -i 's/aux\/mklatinkbd/mklatinkbd/' sys/src/9/port/portmkfile sys/src/9k/mk/portmkfile
-RUN sed -i 's/aux\/data2s/data2s/' sys/src/9/port/mkroot sys/src/9/port/mkrootall sys/src/9k/mk/mkroot sys/src/9k/mk/mkrootall
-
-COPY bind /bin
-RUN chmod +x /bin/bind
-
-WORKDIR /usr/local/harvey/sys/src
-
-# Is this correct?
-ENV USER=root
-ENV HARVEY=/usr/local/harvey
-
-ENV PATH="${PATH}:/rc/bin"
-
-ENTRYPOINT ["bash", "RUN_BUILD_IN_PRIVATE_NAMESPACE"]
+ENTRYPOINT ["bash", "/usr/local/BUILD_IN_DOCKER"]

--- a/sys/src/BUILD
+++ b/sys/src/BUILD
@@ -5,22 +5,12 @@ set +x
 # plan9ports/bin is LAST in your path
 . buildnamespace
 which mk
-export FORCERCFORMK=1
-export CGO_ENABLED=0
-PATH=`pwd`/../../linux_amd64/bin:$PATH
-export objtype=amd64
-export cputype=unix
-HARVEY=`pwd`/../..
-# yes, plan 9 really needs this!
-PATH=$PATH:.
+
 # we clean things out b/c it really is no time penalty
 # and we want to be sure it all gets built.
 mk clean
 
-#time mk all
-#time mk install
-
-rc $HARVEY/build/scripts/linux-build
+time rc $HARVEY/build/scripts/linux-build
 
 # in case of emergency break glass
 /bin/bash

--- a/sys/src/BUILDTOOLCHAIN
+++ b/sys/src/BUILDTOOLCHAIN
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -x
 set -e
-(cd ./cmd/6a && sh BUILD)
-(cd ./cmd/6l && sh BUILD)
-(cd ./cmd/8a && sh BUILD)
-(cd ./cmd/8c && sh BUILD)
-(cd ./cmd/6c && sh BUILD)
-(cd ./cmd/8l && sh BUILD)
-(cd ./cmd/cpp && sh BUILD)
-(cd ./cmd/aux && sh BUILD)
+(cd $HARVEY/sys/src/cmd/6a && sh BUILD)
+(cd $HARVEY/sys/src/cmd/6c && sh BUILD)
+(cd $HARVEY/sys/src/cmd/6l && sh BUILD)
+(cd $HARVEY/sys/src/cmd/8a && sh BUILD)
+(cd $HARVEY/sys/src/cmd/8c && sh BUILD)
+(cd $HARVEY/sys/src/cmd/8l && sh BUILD)
+(cd $HARVEY/sys/src/cmd/cpp && sh BUILD)
+(cd $HARVEY/sys/src/cmd/aux && sh BUILD)

--- a/sys/src/RUN_BUILD_IN_PRIVATE_NAMESPACE
+++ b/sys/src/RUN_BUILD_IN_PRIVATE_NAMESPACE
@@ -3,4 +3,3 @@ export > exports.$$
 # what a mess.
 export > buildnamespace
 sudo unshare -m bash BUILD_SETUP_NAMESPACE $USER exports.$$
-

--- a/sys/src/cmd/6a/BUILD
+++ b/sys/src/cmd/6a/BUILD
@@ -1,5 +1,4 @@
-mkdir -p ../../../../linux_amd64/bin
 $PLAN9/bin/yacc -D1 -d a.y
 9c -O0 -Wno-maybe-uninitialized -g -I . *.c
 9l -o 6a *.o
-cp 6a ../../../../linux_amd64/bin
+cp 6a $HARVEY_LINUX_BIN

--- a/sys/src/cmd/6c/BUILD
+++ b/sys/src/cmd/6c/BUILD
@@ -1,4 +1,3 @@
-mkdir -p ../../../../linux_amd64/bin
 rm -f *.o
 
 (cd ../cc; $PLAN9/bin/yacc -D1 -d cc.y)
@@ -52,4 +51,4 @@ rm -f *.o
 	swt.c \
 	txt.c \
 && 9l -o 6c -static -g *.o
-cp 6c ../../../../linux_amd64/bin
+cp 6c $HARVEY_LINUX_BIN

--- a/sys/src/cmd/6l/BUILD
+++ b/sys/src/cmd/6l/BUILD
@@ -1,6 +1,5 @@
 #!/bin/sh
-mkdir -p ../../../../linux_amd64/bin
-9c -O0 -Wno-char-subscripts -g -I .  asm.c list.c obj.c optab.c pass.c span.c unixcompat.c ../6c/enam.c ../ld/elf.c
+9c -O0 -Wno-char-subscripts -g -I . asm.c list.c obj.c optab.c pass.c span.c unixcompat.c ../6c/enam.c ../ld/elf.c
 
 9l -o 6l \
 asm.o \
@@ -13,4 +12,4 @@ pass.o \
 span.o \
 unixcompat.o 
 
-cp 6l ../../../../linux_amd64/bin
+cp 6l $HARVEY_LINUX_BIN

--- a/sys/src/cmd/8a/BUILD
+++ b/sys/src/cmd/8a/BUILD
@@ -1,5 +1,4 @@
-mkdir -p ../../../../linux_amd64/bin
 $PLAN9/bin/yacc -D1 -d a.y
 9c -O0 -Wno-maybe-uninitialized -g -I . *.c
 9l -o 8a *.o
-cp 8a ../../../../linux_amd64/bin
+cp 8a $HARVEY_LINUX_BIN

--- a/sys/src/cmd/8c/BUILD
+++ b/sys/src/cmd/8c/BUILD
@@ -1,4 +1,3 @@
-mkdir -p ../../../../linux_amd64/bin
 rm -f *.o
 
 (cd ../cc; $PLAN9/bin/yacc -D1 -d cc.y)
@@ -52,4 +51,4 @@ rm -f *.o
 	swt.c \
 	txt.c \
 && 9l -o 8c -static *.o
-cp 8c ../../../../linux_amd64/bin
+cp 8c $HARVEY_LINUX_BIN

--- a/sys/src/cmd/8l/BUILD
+++ b/sys/src/cmd/8l/BUILD
@@ -1,6 +1,5 @@
 #!/bin/sh
-mkdir -p ../../../../linux_amd64/bin
-9c -O0 -Wno-char-subscripts -g -I .  asm.c list.c obj.c optab.c pass.c span.c ../6l/unixcompat.c ../8c/enam.c ../ld/elf.c
+9c -O0 -Wno-char-subscripts -g -I . asm.c list.c obj.c optab.c pass.c span.c ../6l/unixcompat.c ../8c/enam.c ../ld/elf.c
 
 9l -o 8l \
 asm.o \
@@ -13,4 +12,4 @@ pass.o \
 span.o \
 unixcompat.o 
 
-cp 8l ../../../../linux_amd64/bin
+cp 8l $HARVEY_LINUX_BIN

--- a/sys/src/cmd/BUILD
+++ b/sys/src/cmd/BUILD
@@ -1,4 +1,4 @@
 #!/bin/bash
 9c pcc.c
 9l -o pcc pcc.o
-cp pcc ../../../linux_amd64/bin
+cp pcc $HARVEY_LINUX_BIN

--- a/sys/src/cmd/aux/BUILD
+++ b/sys/src/cmd/aux/BUILD
@@ -1,8 +1,8 @@
 #!/bin/sh
 9c mklatinkbd.c
 9l -o mklatinkbd mklatinkbd.o
-cp mklatinkbd ../../../../linux_amd64/bin
+cp mklatinkbd $HARVEY_LINUX_BIN
 
 9c data2s.c
 9l -o data2s data2s.o
-cp data2s ../../../../linux_amd64/bin
+cp data2s $HARVEY_LINUX_BIN

--- a/sys/src/cmd/cpp/BUILD
+++ b/sys/src/cmd/cpp/BUILD
@@ -1,5 +1,4 @@
 #!/bin/sh
-mkdir -p ../../../../linux_amd64/bin
 9c -Wno-char-subscripts \
    -Wno-format \
    -Wno-unused-variable \
@@ -27,5 +26,4 @@ mkdir -p ../../../../linux_amd64/bin
 	include.o\
 	hideset.o\
 
-cp cpp ../../../../linux_amd64/bin
-
+cp cpp $HARVEY_LINUX_BIN


### PR DESCRIPTION
Build from a local folder if it's been mounted by docker

For CI, run `docker run --rm -it --cap-add SYS_ADMIN --privileged harvey:Dockerfile`

To build from the repo: `docker build -t harvey:Dockerfile . && docker run --rm -it --cap-add SYS_ADMIN --privileged harvey:Dockerfile`

To build from a local directory: `docker build -t harvey:Dockerfile . && docker run --rm -it --mount type=bind,source=$HARVEY,target=/usr/local/harvey_local,readonly --cap-add SYS_ADMIN --privileged harvey:Dockerfile`

It's not very sophisticated - it mounts the local repo, then copies it to another directory before building.  There's probably some cleverer way to do it, but it works.

It does simplify some things - the linux toolchain is placed in /usr/local/harvey_local - referred to throughout as `HARVEY_LOCAL`.  This gets rid of the arch-specific directory.

To test the PR, you'd need to change HARVEY_OWNER to gmacd and HARVEY_BRANCH to docker-local in the BUILD_IN_DOCKER script.