### PR TITLE
Add rc to boot options, and get rid of 9load usb boot dependency.

### DIFF
--- a/build/scripts/usb
+++ b/build/scripts/usb
@@ -63,7 +63,7 @@ cp $build/386/9loadusb /tmp/9load
 disk/mbr -m $build/386/mbr $data
 disk/fdisk -baw $data
 disk/prep -bw -a^(9fat nvram fscfg fossil) $plan9
-disk/format -b /386/pbslba -d -r 2 $9fat /tmp/9load $build/386/9pcf $build/386/9pccpuf /tmp/plan9.ini
+disk/format -b $build/386/pbslba -d -r 2 $9fat /tmp/9load $build/386/9pcf $build/386/9pccpuf /tmp/plan9.ini
 
 rm /tmp/9load
 rm /tmp/plan9.ini

--- a/sys/src/9/boot/boot.h
+++ b/sys/src/9/boot/boot.h
@@ -74,5 +74,8 @@ extern int	connectembed(void);
 
 extern void	configip(int, char**, int);
 
+extern void	configrc(Method*);
+extern int	connectrc(void);
+
 /* hack for passing authentication address */
 extern char	*authaddr;

--- a/sys/src/9/boot/bootmkfile
+++ b/sys/src/9/boot/bootmkfile
@@ -7,6 +7,7 @@ BOOTFILES=\
 	boot.$O\
 	bootcache.$O\
 	bootip.$O\
+	bootrc.$O\
 	local.$O\
 	embed.$O\
 	settime.$O\

--- a/sys/src/9/boot/bootrc.c
+++ b/sys/src/9/boot/bootrc.c
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the UCB release of Plan 9. It is subject to the license
+ * terms in the LICENSE file found in the top-level directory of this
+ * distribution and at http://akaros.cs.berkeley.edu/files/Plan9License. No
+ * part of the UCB release of Plan 9, including this file, may be copied,
+ * modified, propagated, or distributed except according to the terms contained
+ * in the LICENSE file.
+ */
+
+#include <u.h>
+#include <libc.h>
+#include <ip.h>
+
+#include "boot.h"
+
+void
+configrc(Method *m)
+{
+	void configloopback(void);
+	configloopback();
+	bind("#S", "/dev", MAFTER);
+	char *argv[] = {
+		"rc",
+		"-m",
+		"/boot/rcmain",
+		"-i",
+		0,
+	};
+	print("Step 1. Run an rc. Set things up.\n");
+	switch(fork()){
+	case -1:
+		print("configrc: fork failed: %r\n");
+	case 0:
+		exec("/boot/rc", argv);
+		fatal("can't exec rc");
+	default:
+		break;
+	}
+	while(waitpid() != -1)
+		;
+	print("Step 2. Run an rc. Verify that things are as you want them.\n");
+	switch(fork()){
+	case -1:
+		print("configrc: fork failed: %r\n");
+	case 0:
+		exec("/boot/rc", argv);
+		fatal("can't exec rc");
+	default:
+		break;
+	}
+	while(waitpid() != -1)
+		;
+	print("rc is done, continuing...\n");
+}
+
+int
+connectrc(void)
+{
+	int fd;
+	char buf[64];
+
+	// Later, make this anything.
+	snprint(buf, sizeof buf, "/srv/fossil");
+	fd = open("#s/fossil", 2);
+	if(fd < 0)
+		werrstr("dial %s: %r", buf);
+	return fd;
+}

--- a/sys/src/9/boot/usb.c
+++ b/sys/src/9/boot/usb.c
@@ -99,6 +99,15 @@ startpartfs(int post)
 }
 
 static int
+usbparts(void)
+{
+	dprint("usbpart... ");
+	run("/boot/rc", "-m", "/boot/rcmain", "-c", "/boot/fdisk -p /dev/sdXX/data > /dev/sdXX/ctl", nil);
+	run("/boot/rc", "-m", "/boot/rcmain", "-c", "/boot/prep -p /dev/sdXX/plan9 > /dev/sdXX/ctl", nil);
+	return 0;
+}
+
+static int
 mountusb(void)
 {
 	int fd;
@@ -119,7 +128,8 @@ int
 mountusbparts(void)
 {
 	mountusb();
-	return startpartfs(Post);
+	startpartfs(Post);
+	return usbparts();
 }
 
 /*

--- a/sys/src/9/pc/pcf
+++ b/sys/src/9/pc/pcf
@@ -137,6 +137,7 @@ port
 boot boot #S/sdC0/
 	tcp
 	local
+	rc
 
 bootdir
 	boot$CONF.out boot
@@ -147,3 +148,10 @@ bootdir
 	/386/bin/usb/usbd
 # needed to boot from a usb key and use its fossil
 	/386/bin/disk/partfs
+	/386/bin/rc
+	/rc/lib/rcmain
+	/386/bin/disk/prep
+	/386/bin/disk/fdisk
+	/386/bin/ls
+	/386/bin/bind
+	/386/bin/mount


### PR DESCRIPTION
You can now pick "rc" when asked "root is from". This gives you an rc
shell to set stuff up.

This change also invokes disk/fdisk and disk/prep when booting from
a USB disk. Previously, we had received partition offsets from 9load
and passed them in via the sdB0part environment variable. Since nload
doesn't do that, and we'd like to move to nload, we needed a different
way. Note that we had to add a few additional programs to /boot (namely
rc, fdisk, and prep) to make this work, but the kernel is still small.