### PR TITLE
nboot: add nboot and its efi booters to the build process

### DIFF
--- a/sys/man/8/nboot
+++ b/sys/man/8/nboot
@@ -1,4 +1,4 @@
-.TH 9BOOT 8
+.TH NBOOT 8
 .SH NAME
 9bootfat, 9bootiso, 9bootpxe, bootia32.efi, bootx64.efi, efiboot.fat \- PC bootloader for FAT, ISO and PXE network booting
 .SH SYNOPSIS

--- a/sys/src/mkfile
+++ b/sys/src/mkfile
@@ -41,6 +41,7 @@ LIBS=\
 
 
 CMDS=cmd\
+	nboot\
 	games\
 
 SUBSYS=ape\

--- a/sys/src/nboot/mkfile
+++ b/sys/src/nboot/mkfile
@@ -1,4 +1,5 @@
 ARCH=\
+	efi\
 	pc\
 
 all:V:
@@ -18,3 +19,5 @@ clean:V:
 		cd $i
 		mk clean
 	}
+
+nuke:V:clean


### PR DESCRIPTION
Next is getting it on the 9fat.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>