### PR TITLE
nboot: get the EFI bootloaders into the right place, add them to usb …

### DIFF
--- a/build/scripts/usb
+++ b/build/scripts/usb
@@ -65,6 +65,15 @@ disk/fdisk -baw $data
 disk/prep -bw -a^(9fat nvram fscfg fossil) $plan9
 disk/format -b $build/386/pbslba -d -r 2 $9fat /tmp/9load $build/386/9pcf $build/386/9pccpuf /tmp/plan9.ini
 
+# this is the guts of a:, but placed here to insulate us from changes that might be made to it.
+if(! test -f /srv/dos)
+	dossrv >/dev/null </dev/null >[2]/dev/null
+unmount /n/a >[2]/dev/null
+mount -c /srv/dos /n/a $9fat
+mkdir -p /n/a/efi/boot
+cp $build/386/*.efi /n/a/efi/boot
+unmount /n/a
+
 rm /tmp/9load
 rm /tmp/plan9.ini
 

--- a/sys/src/nboot/efi/mkfile
+++ b/sys/src/nboot/efi/mkfile
@@ -11,6 +11,8 @@ install:V: $TARG
 
 bootia32.efi:	pe32.8 efi.8 fs.8 pxe.8 iso.8 sub.8
 	8l -l -H3 -T$IMAGEBASE -o $target $prereq
+	cp $target /386
+	cp $target /amd64
 
 pe32.8:	pe32.s
 	8a $PEFLAGS pe32.s
@@ -36,6 +38,8 @@ sub.8:	sub.c
 bootx64.efi:	pe64.6 efi.6 fs.6 pxe.6 iso.6 sub.6
 	6l -l -s -R1 -T$IMAGEBASE -o bootx64.out $prereq
 	dd -if bootx64.out -bs 1 -iseek 40 >$target
+	cp $target /386
+	cp $target /amd64
 
 pe64.6:	pe64.s
 	6a $PEFLAGS pe64.s


### PR DESCRIPTION
…stick

With this change, on an UP Xtreme i11, we get to the efi bootloader dialog.

From there, type
bootfile=9pccpuf
boot

and watch it reset. We can't handle the UEFI truth yet.

(the UEFI truth is simple: UEFI is really bad, really really bad,
which is why Intel made it our life).

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>