### PR TITLE
nboot: don't change uart settings for choice 'A'..'D'

### DIFF
--- a/sys/src/nboot/pc/sub.c
+++ b/sys/src/nboot/pc/sub.c
@@ -424,6 +424,8 @@ uartconf(char *s)
 	if(*s >= '0' && *s <= '3'){
 		uart = *s - '0';
 		uartinit(uart, (7<<5) | 3);	/* b9660 l8 s1 */
+	} else if(*s >= 'A' && *s <= 'D'){
+		uart = *s - 'A';
 	} else
 		uart = -1;
 }


### PR DESCRIPTION
If a user chooses consoles in the range 0 to 3, nboot calls the
bios to set uart paramaters, usually badly.

Change nboot so that if the user selects 'A'..'D', it is like
setting '0'..'3' but no uart bios calls are done.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>