### PR TITLE
termrc: set a default resolution 1024x768x32 not 1280x1024x32

### DIFF
--- a/rc/bin/termrc
+++ b/rc/bin/termrc
@@ -76,10 +76,10 @@ if(~ $mouseport ask){
 		mouseport=ps2
 }
 if(~ $vgasize ask){
-	echo -n 'vgasize [1280x1024x32]: '
+	echo -n 'vgasize [1024x768x32]: '
 	vgasize=`{read}
 	if(~ $#vgasize 0)
-		vgasize=1280x1024x32
+		vgasize=1024x768x32
 }
 if(~ $monitor ask){
 	echo -n 'monitor is [vesa]: '


### PR DESCRIPTION
The 1280x1024x32 is a wonderful aspirational setting
that fails a lot.

Use a default value: 1024x768x32 that is more likely to work.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>