### PR TITLE
Add nmount system call

### DIFF
--- a/sys/include/libc.h
+++ b/sys/include/libc.h
@@ -687,6 +687,7 @@ extern	int	fstat(int, uchar*, int);
 extern	int	fwstat(int, uchar*, int);
 extern	int	fversion(int, int, char*, int);
 extern	int	mount(int, int, char*, int, char*);
+extern	int	nmount(int, int, char*, int, char*, int);
 extern	int	unmount(char*, char*);
 extern	int	noted(int);
 extern	int	notify(void(*)(void*, char*));

--- a/sys/src/9/bcm/dat.h
+++ b/sys/src/9/bcm/dat.h
@@ -34,7 +34,7 @@ typedef uvlong		Tval;
 
 #pragma incomplete Ureg
 
-#define MAXSYSARG	5	/* for mount(fd, mpt, flag, arg, srv) */
+#define MAXSYSARG	6	/* for nmount(fd, mpt, flag, arg, srv, dc) */
 
 /*
  *  parameters for sysproc.c

--- a/sys/src/9/kw/dat.h
+++ b/sys/src/9/kw/dat.h
@@ -21,7 +21,7 @@ typedef uvlong		Tval;
 #pragma incomplete Pcidev
 #pragma incomplete Ureg
 
-#define MAXSYSARG	5	/* for mount(fd, mpt, flag, arg, srv) */
+#define MAXSYSARG	6	/* for nmount(fd, mpt, flag, arg, srv, dc) */
 
 /*
  *  parameters for sysproc.c

--- a/sys/src/9/loongson/dat.h
+++ b/sys/src/9/loongson/dat.h
@@ -18,7 +18,7 @@ typedef uvlong		Tval;
 
 #pragma incomplete Pcidev
 
-#define MAXSYSARG	5	/* for mount(fd, afd, mpt, flag, arg) */
+#define MAXSYSARG	6	/* for nmount(fd, afd, mpt, flag, arg, dc) */
 
 /*
  *  parameters for sysproc.c and rebootcmd.c

--- a/sys/src/9/loongson64/dat.h
+++ b/sys/src/9/loongson64/dat.h
@@ -18,7 +18,7 @@ typedef uvlong		Tval;
 
 #pragma incomplete Pcidev
 
-#define MAXSYSARG	5	/* for mount(fd, afd, mpt, flag, arg) */
+#define MAXSYSARG	6	/* for nmount(fd, afd, mpt, flag, arg, dc) */
 
 /*
  *  parameters for sysproc.c and rebootcmd.c

--- a/sys/src/9/mtx/dat.h
+++ b/sys/src/9/mtx/dat.h
@@ -17,7 +17,7 @@ typedef long		Tval;
 
 #pragma incomplete Ureg
 
-#define MAXSYSARG	5	/* for mount(fd, mpt, flag, arg, srv) */
+#define MAXSYSARG	6	/* for nmount(fd, mpt, flag, arg, srv, dc) */
 
 /*
  *  parameters for sysproc.c

--- a/sys/src/9/omap/dat.h
+++ b/sys/src/9/omap/dat.h
@@ -45,7 +45,7 @@ typedef uvlong		Tval;
 
 #pragma incomplete Ureg
 
-#define MAXSYSARG	5	/* for mount(fd, mpt, flag, arg, srv) */
+#define MAXSYSARG	6	/* for nmount(fd, mpt, flag, arg, srv, dc) */
 
 /*
  *  parameters for sysproc.c

--- a/sys/src/9/pc/dat.h
+++ b/sys/src/9/pc/dat.h
@@ -27,7 +27,7 @@ typedef struct Vctl	Vctl;
 #pragma incomplete Pcidev
 #pragma incomplete Ureg
 
-#define MAXSYSARG	5	/* for mount(fd, afd, mpt, flag, arg) */
+#define MAXSYSARG	6	/* for nmount(fd, afd, mpt, flag, arg, dc) */
 
 #define KMESGSIZE (256*1024)	/* lots, for acpi debugging */
 #define STAGESIZE 2048

--- a/sys/src/9/pcboot/dat.h
+++ b/sys/src/9/pcboot/dat.h
@@ -24,7 +24,7 @@ typedef struct Vctl	Vctl;
 #pragma incomplete Pcidev
 #pragma incomplete Ureg
 
-#define MAXSYSARG	5	/* for mount(fd, afd, mpt, flag, arg) */
+#define MAXSYSARG	6	/* for nmount(fd, afd, mpt, flag, arg, dc) */
 
 /*
  * Where configuration info is left for the loaded programme.

--- a/sys/src/9/port/syscallfmt.c
+++ b/sys/src/9/port/syscallfmt.c
@@ -274,6 +274,19 @@ syscallfmt(int syscallno, ulong pc, va_list list)
 		a = va_arg(list, char*);
 		fmtuserstring(&fmt, a, "");
 		break;
+	case NMOUNT:
+		i[0] = va_arg(list, int);
+		i[1] = va_arg(list, int);
+		fmtprint(&fmt, "%d %d ", i[0], i[1]);
+		a = va_arg(list, char*);
+		fmtuserstring(&fmt, a, " ");
+		i[0] = va_arg(list, int);
+		fmtprint(&fmt, "%#ux ", i[0]);
+		a = va_arg(list, char*);
+		fmtuserstring(&fmt, a, "");
+		i[0] = va_arg(list, int);
+		fmtprint(&fmt, "%d", i[0]);
+		break;
 	case _READ:					/* deprecated */
 	case PREAD:
 		i[0] = va_arg(list, int);

--- a/sys/src/9/port/sysfile.c
+++ b/sys/src/9/port/sysfile.c
@@ -986,7 +986,7 @@ syschdir(ulong *arg)
 }
 
 long
-bindmount(int ismount, int fd, int afd, char* arg0, char* arg1, ulong flag, char* spec)
+bindmount(int ismount, int fd, int afd, char* arg0, char* arg1, ulong flag, char* spec, int dc)
 {
 	int ret;
 	Chan *c0, *c1, *ac, *bc;
@@ -1027,7 +1027,10 @@ bindmount(int ismount, int fd, int afd, char* arg0, char* arg1, ulong flag, char
 		bogus.chan = bc;
 		bogus.authchan = ac;
 		bogus.spec = spec;
-		ret = devno('M', 0);
+		ret = devno(dc, 1);
+		if (ret < 0) {
+			error("bindmount: bad devno");
+		}
 		c0 = devtab[ret]->attach((char*)&bogus);
 		poperror();	/* ac bc */
 		if(ac)
@@ -1068,19 +1071,25 @@ bindmount(int ismount, int fd, int afd, char* arg0, char* arg1, ulong flag, char
 long
 sysbind(ulong *arg)
 {
-	return bindmount(0, -1, -1, (char*)arg[0], (char*)arg[1], arg[2], nil);
+	return bindmount(0, -1, -1, (char*)arg[0], (char*)arg[1], arg[2], nil, 'M');
 }
 
 long
 sysmount(ulong *arg)
 {
-	return bindmount(1, arg[0], arg[1], nil, (char*)arg[2], arg[3], (char*)arg[4]);
+	return bindmount(1, arg[0], arg[1], nil, (char*)arg[2], arg[3], (char*)arg[4], 'M');
+}
+
+long
+sysnmount(ulong *arg)
+{
+	return bindmount(1, arg[0], arg[1], nil, (char*)arg[2], arg[3], (char*)arg[4], (int)arg[5]);
 }
 
 long
 sys_mount(ulong *arg)
 {
-	return bindmount(1, arg[0], -1, nil, (char*)arg[1], arg[2], (char*)arg[3]);
+	return bindmount(1, arg[0], -1, nil, (char*)arg[1], arg[2], (char*)arg[3], 'M');
 }
 
 long

--- a/sys/src/9/port/systab.h
+++ b/sys/src/9/port/systab.h
@@ -159,6 +159,7 @@ char *sysctab[]={
 	[WSTAT]		"Wstat",
 	[FWSTAT]	"Fwstat",
 	[MOUNT]		"Mount",
+	[NMOUNT]	"Nmount",
 	[AWAIT]		"Await",
 	[PREAD]		"Pread",
 	[PWRITE]	"Pwrite",

--- a/sys/src/9/ppc/dat.h
+++ b/sys/src/9/ppc/dat.h
@@ -20,7 +20,7 @@ typedef struct Vctl	Vctl;
 #pragma incomplete Imap
 #pragma incomplete Mach
 
-#define MAXSYSARG	5	/* for mount(fd, mpt, flag, arg, srv) */
+#define MAXSYSARG	6	/* for nmount(fd, mpt, flag, arg, srv, dc) */
 
 /*
  *  parameters for sysproc.c

--- a/sys/src/9/rb/dat.h
+++ b/sys/src/9/rb/dat.h
@@ -18,7 +18,7 @@ typedef uvlong		Tval;
 
 #pragma incomplete Pcidev
 
-#define MAXSYSARG	5	/* for mount(fd, afd, mpt, flag, arg) */
+#define MAXSYSARG	6	/* for nmount(fd, afd, mpt, flag, arg, dc) */
 
 /*
  *  parameters for sysproc.c and rebootcmd.c

--- a/sys/src/9/teg2/dat.h
+++ b/sys/src/9/teg2/dat.h
@@ -48,7 +48,7 @@ typedef uvlong		Tval;
 #pragma incomplete Pcidev
 #pragma incomplete Ureg
 
-#define MAXSYSARG	5	/* for mount(fd, mpt, flag, arg, srv) */
+#define MAXSYSARG	6	/* for nmount(fd, mpt, flag, arg, srv, dc) */
 
 /*
  *  parameters for sysproc.c

--- a/sys/src/9/vt4/dat.h
+++ b/sys/src/9/vt4/dat.h
@@ -16,7 +16,7 @@ typedef struct Ureg	Ureg;
 
 #pragma incomplete Ureg
 
-#define MAXSYSARG	5	/* for mount(fd, mpt, flag, arg, srv) */
+#define MAXSYSARG	6	/* for nmount(fd, mpt, flag, arg, srv, dc) */
 
 /*
  *  parameters for sysproc.c

--- a/sys/src/9/vt5/dat.h
+++ b/sys/src/9/vt5/dat.h
@@ -16,7 +16,7 @@ typedef struct Ureg	Ureg;
 
 #pragma incomplete Ureg
 
-#define MAXSYSARG	5	/* for mount(fd, mpt, flag, arg, srv) */
+#define MAXSYSARG	6	/* for nmount(fd, mpt, flag, arg, srv, dc) */
 
 /*
  *  parameters for sysproc.c

--- a/sys/src/9k/k10/dat.h
+++ b/sys/src/9k/k10/dat.h
@@ -24,7 +24,7 @@ typedef struct Vctl Vctl;
 
 #pragma incomplete Ureg
 
-#define MAXSYSARG	5	/* for mount(fd, afd, mpt, flag, arg) */
+#define MAXSYSARG	6	/* for nmount(fd, afd, mpt, flag, arg, dc) */
 
 /*
  *  parameters for sysproc.c

--- a/sys/src/9k/port/syscallfmt.c
+++ b/sys/src/9k/port/syscallfmt.c
@@ -273,6 +273,19 @@ syscallfmt(int syscallno, va_list list)
 		a = va_arg(list, char*);
 		fmtuserstring(&fmt, a, "");
 		break;
+	case NMOUNT:
+		i[0] = va_arg(list, int);
+		i[1] = va_arg(list, int);
+		fmtprint(&fmt, "%d %d ", i[0], i[1]);
+		a = va_arg(list, char*);
+		fmtuserstring(&fmt, a, " ");
+		i[0] = va_arg(list, int);
+		fmtprint(&fmt, "%#ux ", i[0]);
+		a = va_arg(list, char*);
+		fmtuserstring(&fmt, a, "");
+		i[0] = va_arg(list, int);
+		fmtprint(&fmt, "%d", i[0]);
+		break;
 	case _READ:					/* deprecated */
 	case PREAD:
 		i[0] = va_arg(list, int);

--- a/sys/src/9k/port/sysfile.c
+++ b/sys/src/9k/port/sysfile.c
@@ -1077,7 +1077,7 @@ syschdir(Ar0* ar0, va_list list)
 }
 
 static int
-bindmount(int ismount, int fd, int afd, char* arg0, char* arg1, int flag, char* spec)
+bindmount(int ismount, int fd, int afd, char* arg0, char* arg1, int flag, char* spec, int devno)
 {
 	int i;
 	Dev *dev;
@@ -1124,7 +1124,10 @@ bindmount(int ismount, int fd, int afd, char* arg0, char* arg1, int flag, char* 
 			nexterror();
 		}
 
-		dev = devtabget('M', 0);		//XDYNX
+		dev = devtabget(devno, 1);		//XDYNX
+		if (dev == nil) {
+			error("bindmount: bad devno");
+		}
 		if(waserror()){
 			//devtabdecr(dev);
 			nexterror();
@@ -1182,7 +1185,7 @@ sysbind(Ar0* ar0, va_list list)
 	old = va_arg(list, char*);
 	flag = va_arg(list, int);
 
-	ar0->i = bindmount(0, -1, -1, name, old, flag, nil);
+	ar0->i = bindmount(0, -1, -1, name, old, flag, nil, 'M');
 }
 
 void
@@ -1202,7 +1205,29 @@ sysmount(Ar0* ar0, va_list list)
 	flag = va_arg(list, int);
 	aname = va_arg(list, char*);
 
-	ar0->i = bindmount(1, fd, afd, nil, old, flag, aname);
+	ar0->i = bindmount(1, fd, afd, nil, old, flag, aname, 'M');
+}
+
+void
+sysnmount(Ar0* ar0, va_list list)
+{
+	int afd, fd, flag;
+	char *aname, *old;
+	int dev;
+
+	/*
+	 * int nmount(int fd, int afd, char* old, int flag, char* aname, int dev);
+	 * should be
+	 * long nmount(int fd, int afd, char* old, int flag, char* aname, int dev);
+	 */
+	fd = va_arg(list, int);
+	afd = va_arg(list, int);
+	old = va_arg(list, char*);
+	flag = va_arg(list, int);
+	aname = va_arg(list, char*);
+	dev = va_arg(list, int);
+
+	ar0->i = bindmount(1, fd, afd, nil, old, flag, aname, dev);
 }
 
 void
@@ -1223,7 +1248,7 @@ sys_mount(Ar0* ar0, va_list list)
 	flag = va_arg(list, int);
 	aname = va_arg(list, char*);
 
-	ar0->i = bindmount(1, fd, -1, nil, old, flag, aname);
+	ar0->i = bindmount(1, fd, -1, nil, old, flag, aname, 'M');
 }
 
 void

--- a/sys/src/cmd/5i/syscall.c
+++ b/sys/src/cmd/5i/syscall.c
@@ -30,6 +30,7 @@ char*	sysctab[] =
 	[_FSTAT]		"_fstat",
 	[SEGBRK]		"Segbrk",
 	[MOUNT]		"Mount",
+	[NMOUNT]	"Nmount",
 	[OPEN]		"Open",
 	[_READ]		"_Read",
 	[OSEEK]		"Oseek",

--- a/sys/src/cmd/ki/syscall.c
+++ b/sys/src/cmd/ki/syscall.c
@@ -32,6 +32,7 @@ char *sysctab[]={
 	[_FSTAT]		"_fstat",
 	[SEGBRK]		"Segbrk",
 	[MOUNT]		"Mount",
+	[NMOUNT]	"Nmount",
 	[OPEN]		"Open",
 	[_READ]		"_Read",
 	[OSEEK]		"Oseek",

--- a/sys/src/cmd/nmount.c
+++ b/sys/src/cmd/nmount.c
@@ -1,0 +1,119 @@
+#include <u.h>
+#include <libc.h>
+#include <auth.h>
+
+void	usage(void);
+void	catch(void*, char*);
+
+char *keyspec = "";
+
+int
+amount0(int fd, char *mntpt, int flags, char *aname, char *keyspec, int dev)
+{
+	int rv, afd;
+	AuthInfo *ai;
+
+	afd = fauth(fd, aname);
+	if(afd >= 0){
+		ai = auth_proxy(afd, amount_getkey, "proto=p9any role=client %s", keyspec);
+		if(ai != nil)
+			auth_freeAI(ai);
+		else
+			fprint(2, "%s: auth_proxy: %r\n", argv0);
+	}
+	rv = nmount(fd, afd, mntpt, flags, aname, dev);
+	if(afd >= 0)
+		close(afd);
+	return rv;
+}
+
+void
+main(int argc, char *argv[])
+{
+	char *spec;
+	ulong flag = 0;
+	int qflag = 0;
+	int noauth = 0;
+	char *mountname = "M";
+	int fd, rv;
+
+	ARGBEGIN{
+	case 'a':
+		flag |= MAFTER;
+		break;
+	case 'b':
+		flag |= MBEFORE;
+		break;
+	case 'c':
+		flag |= MCREATE;
+		break;
+	case 'C':
+		flag |= MCACHE;
+		break;
+	case 'k':
+		keyspec = EARGF(usage());
+		break;
+	case 'M':
+		mountname = EARGF(usage());
+		break;
+	case 'n':
+		noauth = 1;
+		break;
+	case 'q':
+		qflag = 1;
+		break;
+	default:
+		usage();
+	}ARGEND
+
+	if (strlen(mountname) != 1) {
+		exits("mountname (-M) must be 1 char");
+	}
+
+	spec = 0;
+	if(argc == 2)
+		spec = "";
+	else if(argc == 3)
+		spec = argv[2];
+	else
+		usage();
+
+	if((flag&MAFTER)&&(flag&MBEFORE))
+		usage();
+
+	fd = open(argv[0], ORDWR);
+	if(fd < 0){
+		if(qflag)
+			exits(0);
+		fprint(2, "%s: can't open %s: %r\n", argv0, argv[0]);
+		exits("open");
+	}
+
+	notify(catch);
+	if(noauth)
+		rv = nmount(fd, -1, argv[1], flag, spec, (int)mountname[0]);
+	else
+		rv = amount0(fd, argv[1], flag, spec, keyspec, (int)mountname[0]);
+	if(rv < 0){
+		if(qflag)
+			exits(0);
+		fprint(2, "%s: nmount %s: %r\n", argv0, argv[1]);
+		exits("nmount");
+	}
+	exits(0);
+}
+
+void
+catch(void *x, char *m)
+{
+	USED(x);
+	fprint(2, "nmount: %s\n", m);
+	exits(m);
+}
+
+void
+usage(void)
+{
+	fprint(2, "usage: nmount [-a|-b] [-cnq] [-k keypattern] [-M dc-specifier (one UTF-8 character)] /srv/service dir [spec]\n");
+	exits("usage");
+}

--- a/sys/src/cmd/qi/syscall.c
+++ b/sys/src/cmd/qi/syscall.c
@@ -64,6 +64,7 @@ char *sysctab[]={
 	[WSTAT]		"Wstat",
 	[FWSTAT]	"Fwstat",
 	[MOUNT]		"Mount",
+	[NMOUNT]	"Nmount",
 	[AWAIT]		"Await",
 	[PREAD]		"Pread",
 	[PWRITE]	"Pwrite",

--- a/sys/src/cmd/vi/syscall.c
+++ b/sys/src/cmd/vi/syscall.c
@@ -62,6 +62,7 @@ char *sysctab[]={
 	[WSTAT]		"Wstat",
 	[FWSTAT]	"Fwstat",
 	[MOUNT]		"Mount",
+	[NMOUNT]	"Nmount",
 	[AWAIT]		"Await",
 	[PREAD]		"Pread",
 	[PWRITE]	"Pwrite",

--- a/sys/src/libc/9syscall/sys.h
+++ b/sys/src/libc/9syscall/sys.h
@@ -50,3 +50,4 @@
 #define	PWRITE		51
 #define	TSEMACQUIRE	52
 #define NSEC		53
+#define NMOUNT		54


### PR DESCRIPTION
nmount allows use of different 9p clients in the kernel.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>